### PR TITLE
Koodiülevaate madala riskiga parandused (Leid 4, 5, 8, 9)

### DIFF
--- a/docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md
+++ b/docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md
@@ -1,0 +1,335 @@
+# Koodi ülevaade: reaalsed leiud ja soovitused
+
+Kuupäev: 2026-06-24  
+Allikas: Gemini/Jules soovituste järelkontroll koodibaasi põhjal  
+Eesmärk: jätta alles ainult reaalsed probleemid/küsimused, mida implementatsioonil arvesse võtta.
+
+---
+
+## Kokkuvõte
+
+| # | Teema | Hinnang | Prioriteet | Viide |
+|---|-------|---------|------------|-------|
+| 1 | `sync_work_to_meilisearch` on liiga suur | reaalne hooldatavuse risk | keskmine | `server/meilisearch_ops.py:315-642` |
+| 2 | `save_and_transfer_to_ocr` on keeruline | reaalne hooldatavuse risk | madal/keskmine | `server/upload_ops.py:426-665` |
+| 3 | `_find_works_with_collection` skaneerib failisüsteemi | ebaefektiivne, admin-only | madal | `server/main.py:1815-1830` |
+| 4 | Blocking file I/O async endpointides | tehniliselt reaalne | madal | `server/main.py:1156-1161`, `1853-1856` |
+| 5 | OCR cleanup kasutab shellkäsku `rm -rf` | mitte ekspluateeritav, aga halb muster | madal | `server/upload_ops.py:1201,1458,1503` |
+| 6 | Tootmise secretite seadistus vajab kinnitamist | konfiguratsiooniküsimus | kontroll | `server/config.py:183,234-267` |
+| 7 | `crossLangTypeMap` / `crossLangGenreMap` eemaldamise eeltingimus | andmekontroll enne kustutamist | keskmine | `src/components/AdvancedFilters.tsx:185-210` |
+| 8 | Testilüngad | reaalne, mitte kriitiline | madal | vt allpool |
+| 9 | Kommenteeritud vana OCR prompt | cleanup | triviaalne | `loss/kataloogi-jalgimine-ja-ocr.py:94-119` |
+
+---
+
+## 1. `sync_work_to_meilisearch` on liiga suur
+
+**Viide:** `server/meilisearch_ops.py:315-642` — umbes 328 rida ühes funktsioonis.
+
+Funktsioonis on koos mitu vastutust:
+- metadata lugemine ja normaliseerimine;
+- lehekülgede `.txt`/`.json` lugemine;
+- otsinguteksti puhastus (`lehekylje_tekst`) vs raw editoritekst (`text_content`);
+- autorite/aliaste/labelite väljade koostamine;
+- Meilisearchi upsert/delete loogika.
+
+See pole otsene bug, aga muudatuste regressioonirisk on kõrge.
+
+**Soovitus:** enne refaktooringut lisa fixture/snapshot-test, mis fikseerib ühe väikese teose Meilisearchi dokumendi väljad:
+- `lehekylje_tekst` vs `text_content`;
+- `type_ids` / `genre_ids`;
+- `authors_text` aliastega;
+- collection fields;
+- aasta vahemik (`parse_year_range`).
+
+Seejärel refaktoori väiksemateks abifunktsioonideks, nt:
+- `_build_page_document(...)`;
+- `_clean_search_text(...)`;
+- `_load_work_index_context(...)`;
+- `_upsert_work_documents(...)`.
+
+**Prioriteet:** keskmine. Planeerida eraldi PR/issue-na.
+
+---
+
+## 2. `save_and_transfer_to_ocr` on keeruline
+
+**Viide:** `server/upload_ops.py:426-665` — umbes 239 rida.
+
+Funktsioon haldab korraga:
+- faili tüübi tuvastust;
+- PDF-i `pdfinfo` loogikat;
+- pildi/PDF SFTP uploadi;
+- PNG/TIFF → JPEG konverteerimist;
+- state.json staatuseid;
+- taustalõime ja progressi.
+
+Kood on kommenteeritud ja funktsionaalselt arusaadav, aga muutmine on riskantne.
+
+**Soovitus:** refaktoori järk-järgult, mitte koos käitumismuudatustega:
+- `_prepare_pdf_upload(...)`;
+- `_prepare_image_upload(...)`;
+- `_sftp_transfer_pdf(...)`;
+- `_sftp_transfer_image(...)`;
+- ühine state/progress helper.
+
+**Prioriteet:** madal/keskmine. Mitte esimese kiire PR-i osa.
+
+---
+
+## 3. `_find_works_with_collection` on ebaefektiivne
+
+**Viide:** `server/main.py:1815-1830`.
+
+Funktsioon käib iga kõne ajal läbi kõik `BASE_DIR` kaustad ja loeb iga `_metadata.json` faili. Seda kasutavad:
+- `admin_collection_works_count` — `server/main.py:1853-1856`;
+- `admin_delete_collection` — `server/main.py:1874`.
+
+Mõju on piiratud, sest tegu on admin-only vooga, aga teoste arvu kasvades muutub see aeglaseks.
+
+**Soovitus:**
+- lühiajaliselt piisab blocking-I/O parandusest (vt punkt 4);
+- pikemalt kaaluda cached indeksit `collection_id → works` või Meilisearchi filtrit;
+- kui kasutada cache’i, tuleb see invalideerida metadata salvestamisel ja kollektsioonide muutmisel.
+
+**Prioriteet:** madal.
+
+---
+
+## 4. Blocking file I/O async endpointides
+
+### 4.1 `admin_collection_works_count`
+
+**Viide:** `server/main.py:1853-1856`.
+
+Endpoint ei kasuta `await`, aga on `async def`. Kuna ta teeb `_find_works_with_collection` kaudu sync faililugemist, blokeerib ta event loopi.
+
+**Soovitus:** muuta endpoint tavaliseks `def`-iks. FastAPI jooksutab sync endpointid threadpoolis.
+
+```python
+@app.get("/admin/collections/{collection_id}/works-count")
+def admin_collection_works_count(collection_id: str, user=Depends(require_role("admin"))):
+    count = len(_find_works_with_collection(collection_id))
+    return {"status": "success", "count": count}
+```
+
+### 4.2 `get_work_meta_direct`
+
+**Viide:** `server/main.py:1156-1161`.
+
+Seda ei tohi pimesi `def`-iks muuta, sest endpoint kutsub `await get_json_data(request)`.
+
+**Soovitus:** endpoint jääb `async`, aga faililugemine tõsta threadpooli:
+
+```python
+from starlette.concurrency import run_in_threadpool
+
+
+def _read_work_meta_direct_sync(work_id: str, original_path: str):
+    path = find_directory_by_id(work_id) or os.path.join(
+        BASE_DIR,
+        os.path.basename(original_path or ''),
+    )
+    meta_path = os.path.join(path, '_metadata.json')
+    if os.path.exists(meta_path):
+        with open(meta_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+
+@app.post("/get-work-metadata")
+async def get_work_meta_direct(request: Request, user=Depends(require_role("editor"))):
+    data = await get_json_data(request)
+    metadata = await run_in_threadpool(
+        _read_work_meta_direct_sync,
+        data.get('work_id'),
+        data.get('original_path', ''),
+    )
+    return {"status": "success", "metadata": metadata}
+```
+
+**Testisoovitus:** kontrollida vähemalt:
+- olemasolev metadata tagastatakse;
+- puuduva `_metadata.json` korral vastus on `metadata: {}`.
+
+**Prioriteet:** madal, aga kiire ja puhas parandus.
+
+---
+
+## 5. `upload_ops.py` OCR cleanup kasutab shellkäsku
+
+**Viide:** `server/upload_ops.py:1201,1458,1503`.
+
+Kolmes kohas kasutatakse:
+
+```python
+chan.exec_command(f'rm -rf "{remote_staging}"')
+```
+
+See ei paista praegu ekspluateeritav, sest:
+- `upload_id` on piiratud vorminguga;
+- `ocr_model` on ainult `hand` või `print`;
+- `remote_staging_path` koostatakse serveris;
+- `OCR_SERVER_PATH` tuleb serveri env-ist, mitte kasutajalt.
+
+Aga muster on siiski halb: shellkäsk + string interpolation. Tulevikumuudatus võib selle ohtlikuks muuta.
+
+**Soovitus:** tee üks helper ja kasuta `shlex.quote` + `--`:
+
+```python
+import shlex
+
+
+def _ssh_rm_rf(upload_id: str, remote_path: str):
+    """Kustutab OCR serveris staging-kausta. remote_path peab olema serveri koostatud tee."""
+    transport = get_or_create_ssh(upload_id)
+    chan = transport.open_session()
+    try:
+        chan.set_combine_stderr(True)
+        chan.exec_command(f"rm -rf -- {shlex.quote(remote_path)}")
+        status = chan.recv_exit_status()
+        if status != 0:
+            raise RuntimeError(f"rm -rf ebaõnnestus (exit={status}): {remote_path}")
+    finally:
+        chan.close()
+```
+
+Seejärel asendada kolm kordust:
+
+```python
+_ssh_rm_rf(upload_id, remote_staging)
+```
+
+**Testisoovitus:** mockida `get_or_create_ssh` / channel ja kontrollida, et käsk sisaldab `rm -rf --` ja `shlex.quote`-itud path’i.
+
+**Prioriteet:** madal, aga soovitatav kiire parandus.
+
+---
+
+## 6. Tootmise secretite seadistus vajab kinnitamist
+
+**Viited:**
+- `server/config.py:183` — `IMAGE_TOKEN_SECRET` dev fallback;
+- `server/config.py:234-267` — `check_production_secrets()`;
+- `docker-compose.yml` — `VUTT_ENV=${VUTT_ENV:-dev}` ja secretite fallbackid.
+
+Koodis on juba kaitse: kui `VUTT_ENV=production`, siis `check_production_secrets()` keeldub käivitumast dev-secretitega. Kontroll käivitatakse mooduli importimisel (`server/config.py:267`).
+
+**Reaalne küsimus:** kas tootmise `.env`-is on `VUTT_ENV=production` päriselt seatud?
+
+**Kontroll serveris:**
+
+```bash
+ssh vutt
+grep -E 'VUTT_ENV|IMAGE_TOKEN_SECRET|MEILI_MASTER_KEY' ~/VUTT/.env
+```
+
+Oodatav:
+
+```bash
+VUTT_ENV=production
+IMAGE_TOKEN_SECRET=<päris juhuslik väärtus>
+MEILI_MASTER_KEY=<päris juhuslik väärtus>
+```
+
+Kui `VUTT_ENV` puudub või on `dev`, siis startup-kontroll ei rakendu. See on konfiguratsiooniprobleem, mitte uus koodiviga.
+
+**Prioriteet:** kontrollida kohe. Koodimuudatust pole vaja, kui `.env` on korras.
+
+---
+
+## 7. `crossLangTypeMap` / `crossLangGenreMap` eemaldamise eeltingimus
+
+**Viide:** `src/components/AdvancedFilters.tsx:185-210`.
+
+Koodis on juba TODO: mapid võib eemaldada, kui kõigil teostel on `type_ids` ja `genre_ids` indekseeritud.
+
+**Oluline:** seda ei saa kindlalt kontrollida lokaalses koopias, sest lokaalne masin ei peegelda serveri `data/` ega Meilisearchi sisu.
+
+**Soovituslik protsess:**
+1. kontrollida serveri Meilisearchis, kui palju dokumente on ilma `type_ids`/`genre_ids` väljadeta;
+2. kui leidub, käivitada serveris reindekseerimine (`./scripts/server_seed_data.sh`);
+3. kontrollida uuesti;
+4. alles siis eemaldada fallback-mapid frontendist.
+
+**Prioriteet:** keskmine, aga ainult pärast andmekontrolli.
+
+---
+
+## 8. Testilüngad
+
+Reaalselt puuduvad või vajavad täiendust:
+
+| Teema | Viide | Soovitus |
+|-------|-------|----------|
+| `check_rate_limit` | `server/rate_limit.py:101` | lisada testid olemasolevasse `tests/test_login_throttle.py` |
+| `trash_ops.py` | `server/trash_ops.py` | lisada baas-testid prügikasti operatsioonidele |
+| `poll_reocr_job` | `server/reocr_ops.py:466` | lisada test mockitud OCR/SFTP olekutega |
+| `fetchWithTimeout` | `src/utils/fetchWithTimeout.ts` | testida timeout/abort/error handling |
+| `entityLabelsService.ts` | `src/services/entityLabelsService.ts` | fetch-mock testid |
+| `collectionService.ts` | `src/services/collectionService.ts` | fetch-mock testid + värvide helperid kui katmata |
+| `workService.ts` | `src/services/workService.ts` | fetch-mock testid |
+| username derivation | `server/registration.py:117,122,149` | testida `_base_username_from_email`, `_next_available_username`, `suggest_username_for_email` |
+| `parse_year_range` edge case’id | `server/utils.py:121`, `tests/test_year_range.py` | lisada puuduvad piirjuhtumid, kui neid tuvastatakse |
+
+**`check_rate_limit` soovitatud testid:**
+- tundmatu endpoint → `(True, 0)`;
+- limiidi all lubab;
+- limiit täis → `(False, retry_after > 0)`;
+- akna aegumine lubab uuesti;
+- eri IP-d ja endpointid on isoleeritud.
+
+**Prioriteet:** madal. Testid võib jagada eraldi PR-i.
+
+---
+
+## 9. Kommenteeritud vana OCR prompt
+
+**Viide:** `loss/kataloogi-jalgimine-ja-ocr.py:94-119`.
+
+Seal on vana `INSTRUCTION_OLD` prompt plokk-kommentaarina. Kui seda ei kasutata dokumentatsioonina, kustutada. Kui soovitakse säilitada ajaloo tõttu, tõsta pigem `docs/` alla.
+
+**Prioriteet:** triviaalne cleanup.
+
+---
+
+## Soovitatav implementatsioonijärjekord
+
+### Kiire madala riskiga PR
+
+1. Kustutada vana OCR prompt plokk või tõsta dokumentatsiooni.
+2. Lisada `_ssh_rm_rf` helper + asendada 3 `exec_command` kohta.
+3. Parandada blocking-I/O endpointid:
+   - `admin_collection_works_count` → `def`;
+   - `get_work_meta_direct` faililugemine `run_in_threadpool` kaudu.
+4. Lisada `check_rate_limit` testid.
+
+### Eraldi PR-id
+
+1. `trash_ops.py` ja `poll_reocr_job` testid.
+2. `sync_work_to_meilisearch` fixture/snapshot-test + refaktooring.
+3. `save_and_transfer_to_ocr` järkjärguline refaktooring.
+4. `crossLang*Map` eemaldamine pärast serveri Meilisearchi andmekontrolli.
+
+---
+
+## Kontrollkäsud
+
+```bash
+# Suured funktsioonid
+awk '/^def sync_work_to_meilisearch\(dir_name\)/{s=NR} s&&/^def /&&NR>s{print NR-s" rida"; exit}' server/meilisearch_ops.py
+awk '/^def save_and_transfer_to_ocr\(/{s=NR} s&&/^def /&&NR>s{print NR-s" rida"; exit}' server/upload_ops.py
+
+# OCR cleanup shellkäsud
+grep -n "exec_command" server/upload_ops.py
+
+# Blocking-I/O endpointid
+grep -n "def get_work_meta_direct\|def admin_collection_works_count" server/main.py
+
+# Testilüngad
+grep -R "check_account_lockout" -n tests/
+grep -R "check_rate_limit" -n tests/ || true
+
+# Tootmisseadistus serveris
+ssh vutt 'grep -E "VUTT_ENV|IMAGE_TOKEN_SECRET|MEILI_MASTER_KEY" ~/VUTT/.env'
+```

--- a/loss/kataloogi-jalgimine-ja-ocr.py
+++ b/loss/kataloogi-jalgimine-ja-ocr.py
@@ -89,34 +89,9 @@ PDF_DPI = 300
 
 EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff"}
 
-# Instruktsioon – identne treenimisega (train.py / train_stage2.py)
-# Vana instruktsioon (markdown formaat, enne VUTT XML-ile \u00FCleminekut):
-# INSTRUCTION_OLD = """You are an expert OCR assistant for historical documents.
-#
-# Instructions:
-# 1. Transcribe the entire page from the provided image.
-# 2. Preserve original line breaks and hyphenation:
-#    - Antiqua hyphenation: - (regular hyphen), e.g. coa-cervare
-#    - Fraktur/Gothic hyphenation: \u2E17 (double hyphen), e.g. Ge\u2E17witter
-# 3. Do not translate; keep the original language (Latin, Greek, German, Estonian, etc.).
-# 4. Ligatures:
-#    - \u00E6, \u00C6, \u0153, \u0152 \u2013 transcribe exactly as they are
-#    - st, ff, fi, fl and other typographic ligatures \u2013 write out as separate letters
-# 5. Umlauts and diacritics:
-#    - \u00F6, \u00E4, \u00FC, \u00F5 \u2013 always use modern form
-#    - u\u0364, o\u0364, a\u0364 (letter + superscript e) \u2013 transcribe as \u00FC, \u00F6, \u00E4
-#    - \u00E5, \u00C5 (Swedish) \u2013 keep as is
-#    - \u0169, \u00F1, \u00F5 \u2013 keep as is (tilde preserved)
-# 6. Special characters:
-#    - \u017F (long s) \u2013 transcribe as \u017F
-#    - \u00DF (double s) \u2013 transcribe as \u00DF
-# 7. Abbreviations:
-#    - que abbreviation (\uA757 etc.) \u2013 write as q;
-#    - -us abbreviation (\uA770) \u2013 may be expanded
-# 8. Signature marks (quire numbers): place at the very end, e.g. A 3
-# 9. Page breaks: if the image contains a double-page spread, mark the page break between pages with --lk--.
-#
-# Return only the exact transcription as plain text."""
+# Instruktsioon – identne treenimisega (train.py / train_stage2.py).
+# Vana markdown-formaadis instruktsioon (enne VUTT XML-ile üleminekut) on eemaldatud;
+# ajaloolise viite jaoks vaata docs/ või git-ajalugu (2026-06, INSTRUCTION_OLD).
 
 # --- 2. MUDELI LAADIMINE ---
 

--- a/server/main.py
+++ b/server/main.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, Request, HTTPException, Depends, status, Background
 from fastapi.datastructures import FormData
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, HTMLResponse, FileResponse, StreamingResponse, Response
+from starlette.concurrency import run_in_threadpool
 
 from .config import PORT, ALLOWED_ORIGINS, BASE_DIR, UPLOAD_ENABLED, UPLOADS_DIR, COLLECTIONS_FILE, USER_SETTINGS_DIR, NOTIFICATIONS_DIR, get_logger, ARCHIVES_FILE
 from .utils import build_work_id_cache, find_directory_by_id, metadata_lock, generate_nanoid, atomic_write_json
@@ -135,6 +136,23 @@ def _load_work_metadata(work_id: str):
             return json.load(f)
     except Exception:
         return None
+
+
+def _read_work_meta_direct_sync(work_id: str, original_path: str):
+    """Loeb teose _metadata.json blokeeriva I/O-na (kutsutud threadpoolist).
+
+    Lahutatud /get-work-metadata endpointist, et sync faililugemine ei blokeeriks
+    event loopi (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 4).
+    """
+    path = find_directory_by_id(work_id) or os.path.join(BASE_DIR, os.path.basename(original_path or ''))
+    meta_path = os.path.join(path, '_metadata.json')
+    if os.path.exists(meta_path):
+        try:
+            with open(meta_path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
 
 
 def _get_optional_user(request: Request):
@@ -1155,11 +1173,10 @@ async def update_work_metadata(request: Request, background_tasks: BackgroundTas
 @app.post("/get-work-metadata")
 async def get_work_meta_direct(request: Request, user=Depends(require_role("editor"))):
     data = await get_json_data(request)
-    path = find_directory_by_id(data.get('work_id')) or os.path.join(BASE_DIR, os.path.basename(data.get('original_path', '')))
-    meta_path = os.path.join(path, '_metadata.json')
-    if os.path.exists(meta_path):
-        with open(meta_path, 'r', encoding='utf-8') as f: return {"status": "success", "metadata": json.load(f)}
-    return {"status": "success", "metadata": {}}
+    # Faililugemine threadpoolis, et mitte blokeerida event loopi
+    # (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 4).
+    metadata = await run_in_threadpool(_read_work_meta_direct_sync, data.get('work_id'), data.get('original_path', ''))
+    return {"status": "success", "metadata": metadata}
 
 @app.post("/get-metadata-suggestions")
 async def metadata_suggestions(request: Request, user=Depends(require_role("editor"))):
@@ -1850,8 +1867,13 @@ def _find_works_with_archive(archive_id: str):
     return results
 
 @app.get("/admin/collections/{collection_id}/works-count")
-async def admin_collection_works_count(collection_id: str, user=Depends(require_role("admin"))):
-    """Tagastab mitu teost on antud kollektsioonis."""
+def admin_collection_works_count(collection_id: str, user=Depends(require_role("admin"))):
+    """Tagastab mitu teost on antud kollektsioonis.
+
+    Tavaline (mitte-async) endpoint: FastAPI jooksutab selle threadpoolis, nii et
+    _find_works_with_collection sync faililugemine ei blokeeri event loopi
+    (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 4).
+    """
     count = len(_find_works_with_collection(collection_id))
     return {"status": "success", "count": count}
 

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -8,6 +8,7 @@ Etapp 4 lisab: import_as_work, cleanup_upload.
 import json
 import os
 import re
+import shlex
 import shutil
 import socket
 import subprocess
@@ -177,6 +178,25 @@ def close_ssh(upload_id: str):
             transport.close()
         except Exception:
             pass
+
+
+def _ssh_rm_rf(upload_id: str, remote_path: str):
+    """Kustutab OCR serveris kausta rekursiivselt (`rm -rf`) SSH kanali kaudu.
+
+    remote_path peab olema serveri koostatud absoluutne tee (mitte kasutaja sisend).
+    Kasutab shlex.quote + `--`, et vältida tulevikus shell-injection lõhna/kirra
+    (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 5).
+    """
+    transport = get_or_create_ssh(upload_id)
+    chan = transport.open_session()
+    try:
+        chan.set_combine_stderr(True)
+        chan.exec_command(f"rm -rf -- {shlex.quote(remote_path)}")
+        status = chan.recv_exit_status()
+        if status != 0:
+            raise RuntimeError(f"rm -rf ebaõnnestus (exit={status}): {remote_path}")
+    finally:
+        chan.close()
 
 
 def _sftp_open(upload_id: str):
@@ -1195,12 +1215,7 @@ def import_as_work(upload_id: str, username: str = None) -> dict:
     # Koristame OCR serveri (mitte kriitiline)
     remote_staging = f"{OCR_SERVER_PATH}/{state['remote_staging_path']}"
     try:
-        transport = get_or_create_ssh(upload_id)
-        chan = transport.open_session()
-        chan.set_combine_stderr(True)
-        chan.exec_command(f'rm -rf "{remote_staging}"')
-        chan.recv_exit_status()
-        chan.close()
+        _ssh_rm_rf(upload_id, remote_staging)
         close_ssh(upload_id)
         logger.info(f"import {upload_id}: OCR serveri kaust koristatud: {remote_staging}")
     except Exception as e:
@@ -1452,12 +1467,7 @@ async def replace_work_content(upload_id: str, target_work_id: str, metadata_upd
     # 11. Koristame OCR serveri (mitte kriitiline)
     remote_staging = f"{OCR_SERVER_PATH}/{state['remote_staging_path']}"
     try:
-        transport = get_or_create_ssh(upload_id)
-        chan = transport.open_session()
-        chan.set_combine_stderr(True)
-        chan.exec_command(f'rm -rf "{remote_staging}"')
-        chan.recv_exit_status()
-        chan.close()
+        _ssh_rm_rf(upload_id, remote_staging)
         close_ssh(upload_id)
         logger.info(f"replace {upload_id}: OCR serveri kaust koristatud: {remote_staging}")
     except Exception as e:
@@ -1497,12 +1507,7 @@ def cancel_upload(upload_id: str) -> bool:
     if state and state.get('status') not in ('pending', 'error'):
         remote_staging = f"{OCR_SERVER_PATH}/{state['remote_staging_path']}"
         try:
-            transport = get_or_create_ssh(upload_id)
-            chan = transport.open_session()
-            chan.set_combine_stderr(True)
-            chan.exec_command(f'rm -rf "{remote_staging}"')
-            chan.recv_exit_status()
-            chan.close()
+            _ssh_rm_rf(upload_id, remote_staging)
             logger.info(f"OCR serveri kaust koristatud: {remote_staging}")
         except Exception as e:
             logger.warning(f"cancel_upload SSH koristus ebaõnnestus {upload_id}: {e}")

--- a/tests/test_login_throttle.py
+++ b/tests/test_login_throttle.py
@@ -13,12 +13,16 @@ import server.rate_limit as rl
 
 @pytest.fixture(autouse=True)
 def _clean_store():
-    """Tühjenda konto-throttle hoidla iga testi eel ja järel."""
+    """Tühjenda konto- ja IP-throttle hoidlad iga testi eel ja järel."""
     with rl._account_lock:
         rl._account_failures.clear()
+    with rl._rate_limit_lock:
+        rl._rate_limit_store.clear()
     yield
     with rl._account_lock:
         rl._account_failures.clear()
+    with rl._rate_limit_lock:
+        rl._rate_limit_store.clear()
 
 
 def test_below_threshold_not_locked():
@@ -68,3 +72,59 @@ def test_unknown_username_also_throttled():
     for _ in range(rl.ACCOUNT_LOCKOUT_THRESHOLD):
         rl.record_login_failure("olematu_kasutaja_xyz")
     assert rl.check_account_lockout("olematu_kasutaja_xyz")[0] is True
+
+
+# ------------------------------------------------------------------
+# IP-põhine rate-limit (check_rate_limit)
+# ------------------------------------------------------------------
+# RATE_LIMITS['/login'] = (5, 60) — kasutame seda testides fikseeritud konfiguna.
+_LOGIN_MAX, _LOGIN_WINDOW = rl.RATE_LIMITS['/login']
+
+
+def test_rate_limit_unknown_endpoint_always_allowed():
+    """Tundmatu endpoint (pole RATE_LIMITS-is) ei piirrita."""
+    allowed, retry = rl.check_rate_limit("1.2.3.4", "/tundmatu-endpoint")
+    assert allowed is True
+    assert retry == 0
+
+
+def test_rate_limit_below_limit_allows():
+    """Limiidi all olevad päringud lubatakse ja loendur täitub."""
+    for _ in range(_LOGIN_MAX - 1):
+        allowed, retry = rl.check_rate_limit("1.2.3.4", "/login")
+        assert allowed is True
+        assert retry == 0
+
+
+def test_rate_limit_at_limit_blocks():
+    """Pärast limiidi täitumist järgmist päringut ei lubata ja retry > 0."""
+    for _ in range(_LOGIN_MAX):
+        assert rl.check_rate_limit("1.2.3.4", "/login")[0] is True
+    allowed, retry = rl.check_rate_limit("1.2.3.4", "/login")
+    assert allowed is False
+    assert retry > 0
+
+
+def test_rate_limit_window_expiry_allows_again(monkeypatch):
+    """Pärast akna möödumist aeguvad päringud ja limiit lähtestub."""
+    for _ in range(_LOGIN_MAX):
+        rl.check_rate_limit("1.2.3.4", "/login")
+    assert rl.check_rate_limit("1.2.3.4", "/login")[0] is False
+
+    # Liiguta aega aknast kaugemale
+    base = time.time()
+    monkeypatch.setattr(rl.time, "time", lambda: base + _LOGIN_WINDOW + 1)
+    allowed, retry = rl.check_rate_limit("1.2.3.4", "/login")
+    assert allowed is True
+    assert retry == 0
+
+
+def test_rate_limit_isolated_per_ip_and_endpoint():
+    """Ühe IP/endpointi limiit ei mõjuta teist IP-d ega teist endpointi."""
+    for _ in range(_LOGIN_MAX):
+        rl.check_rate_limit("1.1.1.1", "/login")
+    assert rl.check_rate_limit("1.1.1.1", "/login")[0] is False
+    # Teine IP — endiselt lubatud
+    assert rl.check_rate_limit("2.2.2.2", "/login")[0] is True
+    # Sama IP, teine endpoint — endiselt lubatud
+    assert rl.check_rate_limit("1.1.1.1", "/register")[0] is True


### PR DESCRIPTION
Ülevaate \`docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md\` (9ea1539) järelt tehtud
„Kiire madala riskiga PR" — 4 sõltumatut, testidega kaetud parandust.

## Muudatused

| Leid | Teema | Fail(id) |
|------|-------|----------|
| 9 | Eemaldatud vana kommenteeritud OCR prompt \`INSTRUCTION_OLD\` (surnud kood) | `loss/kataloogi-jalgimine-ja-ocr.py` |
| 5 | \`_ssh_rm_rf()\` helper \`shlex.quote\` + \`rm -rf --\` abil; asendatud 3 \`exec_command\` kordust (import/replace/cancel voogudes) | `server/upload_ops.py` |
| 4 | Blocking file I/O threadpooli: \`admin_collection_works_count\` → \`def\`; \`get_work_meta_direct\` faililugemine \`run_in_threadpool\` kaudu | `server/main.py` |
| 8 | \`check_rate_limit\` testid (IP-põhine limiter) — 5 uut testi | `tests/test_login_throttle.py` |

## Kontekst

- **Leid 5 (command injection):** ei olnud ekspluateeritav ka varem (\`upload_id\` \`^[a-z0-9]{1,20}$\`, \`ocr_model\` kõvasti \`hand\`/\`print\`, \`OCR_SERVER_PATH\` env-ist), aga \`f'rm -rf "{...}"'\` muster nägi staatilises analüüsis halvasti ja kandis tulevikuriski. \`shlex.quote\` + \`--\` muudab mustrist puhta.
- **Leid 4 (blocking I/O):** \`get_work_meta_direct\` ei tohi \`def\`-iks muutuda, sest kasutab \`await get_json_data(request)\` — faililugemine eraldatud sync abifunktsiooni ja \`run_in_threadpool\` kaudu. \`admin_collection_works_count\` ei kasuta \`await\` → \`def\` (FastAPI jooksutab threadpoolis).
- **Leid 8:** \`test_login_throttle.py\` kattis vaid \`check_account_lockout\`; lisatud 5 testi \`check_rate_limit\` jaoks. Laiendatud \`_clean_store\` fixture puhastab ka \`_rate_limit_store\`-i.

## Testid

\`\`\`
473 passed in 10.94s   (468 eelnevalt + 5 uut)
\`\`\`

## Välja jäänud (eraldi/vajavad eeltööd)

Suured refaktooringud (\`sync_work_to_meilisearch\`, \`save_and_transfer_to_ocr\`) ja \`crossLang*Map\` eemaldus jäävad eraldi PR-ideks / issue-deks — vajavad fixture-testi eelnevalt või serveri Meilisearchi andmekontrolli. Vt ülevaatedokumendi „Eraldi PR-id".