### PR TITLE
Testilüngad: trash_ops.py ja poll_reocr_job (Leid 8)

### DIFF
--- a/docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md
+++ b/docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md
@@ -1,0 +1,335 @@
+# Koodi ülevaade: reaalsed leiud ja soovitused
+
+Kuupäev: 2026-06-24  
+Allikas: Gemini/Jules soovituste järelkontroll koodibaasi põhjal  
+Eesmärk: jätta alles ainult reaalsed probleemid/küsimused, mida implementatsioonil arvesse võtta.
+
+---
+
+## Kokkuvõte
+
+| # | Teema | Hinnang | Prioriteet | Viide |
+|---|-------|---------|------------|-------|
+| 1 | `sync_work_to_meilisearch` on liiga suur | reaalne hooldatavuse risk | keskmine | `server/meilisearch_ops.py:315-642` |
+| 2 | `save_and_transfer_to_ocr` on keeruline | reaalne hooldatavuse risk | madal/keskmine | `server/upload_ops.py:426-665` |
+| 3 | `_find_works_with_collection` skaneerib failisüsteemi | ebaefektiivne, admin-only | madal | `server/main.py:1815-1830` |
+| 4 | Blocking file I/O async endpointides | tehniliselt reaalne | madal | `server/main.py:1156-1161`, `1853-1856` |
+| 5 | OCR cleanup kasutab shellkäsku `rm -rf` | mitte ekspluateeritav, aga halb muster | madal | `server/upload_ops.py:1201,1458,1503` |
+| 6 | Tootmise secretite seadistus vajab kinnitamist | konfiguratsiooniküsimus | kontroll | `server/config.py:183,234-267` |
+| 7 | `crossLangTypeMap` / `crossLangGenreMap` eemaldamise eeltingimus | andmekontroll enne kustutamist | keskmine | `src/components/AdvancedFilters.tsx:185-210` |
+| 8 | Testilüngad | reaalne, mitte kriitiline | madal | vt allpool |
+| 9 | Kommenteeritud vana OCR prompt | cleanup | triviaalne | `loss/kataloogi-jalgimine-ja-ocr.py:94-119` |
+
+---
+
+## 1. `sync_work_to_meilisearch` on liiga suur
+
+**Viide:** `server/meilisearch_ops.py:315-642` — umbes 328 rida ühes funktsioonis.
+
+Funktsioonis on koos mitu vastutust:
+- metadata lugemine ja normaliseerimine;
+- lehekülgede `.txt`/`.json` lugemine;
+- otsinguteksti puhastus (`lehekylje_tekst`) vs raw editoritekst (`text_content`);
+- autorite/aliaste/labelite väljade koostamine;
+- Meilisearchi upsert/delete loogika.
+
+See pole otsene bug, aga muudatuste regressioonirisk on kõrge.
+
+**Soovitus:** enne refaktooringut lisa fixture/snapshot-test, mis fikseerib ühe väikese teose Meilisearchi dokumendi väljad:
+- `lehekylje_tekst` vs `text_content`;
+- `type_ids` / `genre_ids`;
+- `authors_text` aliastega;
+- collection fields;
+- aasta vahemik (`parse_year_range`).
+
+Seejärel refaktoori väiksemateks abifunktsioonideks, nt:
+- `_build_page_document(...)`;
+- `_clean_search_text(...)`;
+- `_load_work_index_context(...)`;
+- `_upsert_work_documents(...)`.
+
+**Prioriteet:** keskmine. Planeerida eraldi PR/issue-na.
+
+---
+
+## 2. `save_and_transfer_to_ocr` on keeruline
+
+**Viide:** `server/upload_ops.py:426-665` — umbes 239 rida.
+
+Funktsioon haldab korraga:
+- faili tüübi tuvastust;
+- PDF-i `pdfinfo` loogikat;
+- pildi/PDF SFTP uploadi;
+- PNG/TIFF → JPEG konverteerimist;
+- state.json staatuseid;
+- taustalõime ja progressi.
+
+Kood on kommenteeritud ja funktsionaalselt arusaadav, aga muutmine on riskantne.
+
+**Soovitus:** refaktoori järk-järgult, mitte koos käitumismuudatustega:
+- `_prepare_pdf_upload(...)`;
+- `_prepare_image_upload(...)`;
+- `_sftp_transfer_pdf(...)`;
+- `_sftp_transfer_image(...)`;
+- ühine state/progress helper.
+
+**Prioriteet:** madal/keskmine. Mitte esimese kiire PR-i osa.
+
+---
+
+## 3. `_find_works_with_collection` on ebaefektiivne
+
+**Viide:** `server/main.py:1815-1830`.
+
+Funktsioon käib iga kõne ajal läbi kõik `BASE_DIR` kaustad ja loeb iga `_metadata.json` faili. Seda kasutavad:
+- `admin_collection_works_count` — `server/main.py:1853-1856`;
+- `admin_delete_collection` — `server/main.py:1874`.
+
+Mõju on piiratud, sest tegu on admin-only vooga, aga teoste arvu kasvades muutub see aeglaseks.
+
+**Soovitus:**
+- lühiajaliselt piisab blocking-I/O parandusest (vt punkt 4);
+- pikemalt kaaluda cached indeksit `collection_id → works` või Meilisearchi filtrit;
+- kui kasutada cache’i, tuleb see invalideerida metadata salvestamisel ja kollektsioonide muutmisel.
+
+**Prioriteet:** madal.
+
+---
+
+## 4. Blocking file I/O async endpointides
+
+### 4.1 `admin_collection_works_count`
+
+**Viide:** `server/main.py:1853-1856`.
+
+Endpoint ei kasuta `await`, aga on `async def`. Kuna ta teeb `_find_works_with_collection` kaudu sync faililugemist, blokeerib ta event loopi.
+
+**Soovitus:** muuta endpoint tavaliseks `def`-iks. FastAPI jooksutab sync endpointid threadpoolis.
+
+```python
+@app.get("/admin/collections/{collection_id}/works-count")
+def admin_collection_works_count(collection_id: str, user=Depends(require_role("admin"))):
+    count = len(_find_works_with_collection(collection_id))
+    return {"status": "success", "count": count}
+```
+
+### 4.2 `get_work_meta_direct`
+
+**Viide:** `server/main.py:1156-1161`.
+
+Seda ei tohi pimesi `def`-iks muuta, sest endpoint kutsub `await get_json_data(request)`.
+
+**Soovitus:** endpoint jääb `async`, aga faililugemine tõsta threadpooli:
+
+```python
+from starlette.concurrency import run_in_threadpool
+
+
+def _read_work_meta_direct_sync(work_id: str, original_path: str):
+    path = find_directory_by_id(work_id) or os.path.join(
+        BASE_DIR,
+        os.path.basename(original_path or ''),
+    )
+    meta_path = os.path.join(path, '_metadata.json')
+    if os.path.exists(meta_path):
+        with open(meta_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+
+@app.post("/get-work-metadata")
+async def get_work_meta_direct(request: Request, user=Depends(require_role("editor"))):
+    data = await get_json_data(request)
+    metadata = await run_in_threadpool(
+        _read_work_meta_direct_sync,
+        data.get('work_id'),
+        data.get('original_path', ''),
+    )
+    return {"status": "success", "metadata": metadata}
+```
+
+**Testisoovitus:** kontrollida vähemalt:
+- olemasolev metadata tagastatakse;
+- puuduva `_metadata.json` korral vastus on `metadata: {}`.
+
+**Prioriteet:** madal, aga kiire ja puhas parandus.
+
+---
+
+## 5. `upload_ops.py` OCR cleanup kasutab shellkäsku
+
+**Viide:** `server/upload_ops.py:1201,1458,1503`.
+
+Kolmes kohas kasutatakse:
+
+```python
+chan.exec_command(f'rm -rf "{remote_staging}"')
+```
+
+See ei paista praegu ekspluateeritav, sest:
+- `upload_id` on piiratud vorminguga;
+- `ocr_model` on ainult `hand` või `print`;
+- `remote_staging_path` koostatakse serveris;
+- `OCR_SERVER_PATH` tuleb serveri env-ist, mitte kasutajalt.
+
+Aga muster on siiski halb: shellkäsk + string interpolation. Tulevikumuudatus võib selle ohtlikuks muuta.
+
+**Soovitus:** tee üks helper ja kasuta `shlex.quote` + `--`:
+
+```python
+import shlex
+
+
+def _ssh_rm_rf(upload_id: str, remote_path: str):
+    """Kustutab OCR serveris staging-kausta. remote_path peab olema serveri koostatud tee."""
+    transport = get_or_create_ssh(upload_id)
+    chan = transport.open_session()
+    try:
+        chan.set_combine_stderr(True)
+        chan.exec_command(f"rm -rf -- {shlex.quote(remote_path)}")
+        status = chan.recv_exit_status()
+        if status != 0:
+            raise RuntimeError(f"rm -rf ebaõnnestus (exit={status}): {remote_path}")
+    finally:
+        chan.close()
+```
+
+Seejärel asendada kolm kordust:
+
+```python
+_ssh_rm_rf(upload_id, remote_staging)
+```
+
+**Testisoovitus:** mockida `get_or_create_ssh` / channel ja kontrollida, et käsk sisaldab `rm -rf --` ja `shlex.quote`-itud path’i.
+
+**Prioriteet:** madal, aga soovitatav kiire parandus.
+
+---
+
+## 6. Tootmise secretite seadistus vajab kinnitamist
+
+**Viited:**
+- `server/config.py:183` — `IMAGE_TOKEN_SECRET` dev fallback;
+- `server/config.py:234-267` — `check_production_secrets()`;
+- `docker-compose.yml` — `VUTT_ENV=${VUTT_ENV:-dev}` ja secretite fallbackid.
+
+Koodis on juba kaitse: kui `VUTT_ENV=production`, siis `check_production_secrets()` keeldub käivitumast dev-secretitega. Kontroll käivitatakse mooduli importimisel (`server/config.py:267`).
+
+**Reaalne küsimus:** kas tootmise `.env`-is on `VUTT_ENV=production` päriselt seatud?
+
+**Kontroll serveris:**
+
+```bash
+ssh vutt
+grep -E 'VUTT_ENV|IMAGE_TOKEN_SECRET|MEILI_MASTER_KEY' ~/VUTT/.env
+```
+
+Oodatav:
+
+```bash
+VUTT_ENV=production
+IMAGE_TOKEN_SECRET=<päris juhuslik väärtus>
+MEILI_MASTER_KEY=<päris juhuslik väärtus>
+```
+
+Kui `VUTT_ENV` puudub või on `dev`, siis startup-kontroll ei rakendu. See on konfiguratsiooniprobleem, mitte uus koodiviga.
+
+**Prioriteet:** kontrollida kohe. Koodimuudatust pole vaja, kui `.env` on korras.
+
+---
+
+## 7. `crossLangTypeMap` / `crossLangGenreMap` eemaldamise eeltingimus
+
+**Viide:** `src/components/AdvancedFilters.tsx:185-210`.
+
+Koodis on juba TODO: mapid võib eemaldada, kui kõigil teostel on `type_ids` ja `genre_ids` indekseeritud.
+
+**Oluline:** seda ei saa kindlalt kontrollida lokaalses koopias, sest lokaalne masin ei peegelda serveri `data/` ega Meilisearchi sisu.
+
+**Soovituslik protsess:**
+1. kontrollida serveri Meilisearchis, kui palju dokumente on ilma `type_ids`/`genre_ids` väljadeta;
+2. kui leidub, käivitada serveris reindekseerimine (`./scripts/server_seed_data.sh`);
+3. kontrollida uuesti;
+4. alles siis eemaldada fallback-mapid frontendist.
+
+**Prioriteet:** keskmine, aga ainult pärast andmekontrolli.
+
+---
+
+## 8. Testilüngad
+
+Reaalselt puuduvad või vajavad täiendust:
+
+| Teema | Viide | Soovitus |
+|-------|-------|----------|
+| `check_rate_limit` | `server/rate_limit.py:101` | lisada testid olemasolevasse `tests/test_login_throttle.py` |
+| `trash_ops.py` | `server/trash_ops.py` | lisada baas-testid prügikasti operatsioonidele |
+| `poll_reocr_job` | `server/reocr_ops.py:466` | lisada test mockitud OCR/SFTP olekutega |
+| `fetchWithTimeout` | `src/utils/fetchWithTimeout.ts` | testida timeout/abort/error handling |
+| `entityLabelsService.ts` | `src/services/entityLabelsService.ts` | fetch-mock testid |
+| `collectionService.ts` | `src/services/collectionService.ts` | fetch-mock testid + värvide helperid kui katmata |
+| `workService.ts` | `src/services/workService.ts` | fetch-mock testid |
+| username derivation | `server/registration.py:117,122,149` | testida `_base_username_from_email`, `_next_available_username`, `suggest_username_for_email` |
+| `parse_year_range` edge case’id | `server/utils.py:121`, `tests/test_year_range.py` | lisada puuduvad piirjuhtumid, kui neid tuvastatakse |
+
+**`check_rate_limit` soovitatud testid:**
+- tundmatu endpoint → `(True, 0)`;
+- limiidi all lubab;
+- limiit täis → `(False, retry_after > 0)`;
+- akna aegumine lubab uuesti;
+- eri IP-d ja endpointid on isoleeritud.
+
+**Prioriteet:** madal. Testid võib jagada eraldi PR-i.
+
+---
+
+## 9. Kommenteeritud vana OCR prompt
+
+**Viide:** `loss/kataloogi-jalgimine-ja-ocr.py:94-119`.
+
+Seal on vana `INSTRUCTION_OLD` prompt plokk-kommentaarina. Kui seda ei kasutata dokumentatsioonina, kustutada. Kui soovitakse säilitada ajaloo tõttu, tõsta pigem `docs/` alla.
+
+**Prioriteet:** triviaalne cleanup.
+
+---
+
+## Soovitatav implementatsioonijärjekord
+
+### Kiire madala riskiga PR
+
+1. Kustutada vana OCR prompt plokk või tõsta dokumentatsiooni.
+2. Lisada `_ssh_rm_rf` helper + asendada 3 `exec_command` kohta.
+3. Parandada blocking-I/O endpointid:
+   - `admin_collection_works_count` → `def`;
+   - `get_work_meta_direct` faililugemine `run_in_threadpool` kaudu.
+4. Lisada `check_rate_limit` testid.
+
+### Eraldi PR-id
+
+1. `trash_ops.py` ja `poll_reocr_job` testid.
+2. `sync_work_to_meilisearch` fixture/snapshot-test + refaktooring.
+3. `save_and_transfer_to_ocr` järkjärguline refaktooring.
+4. `crossLang*Map` eemaldamine pärast serveri Meilisearchi andmekontrolli.
+
+---
+
+## Kontrollkäsud
+
+```bash
+# Suured funktsioonid
+awk '/^def sync_work_to_meilisearch\(dir_name\)/{s=NR} s&&/^def /&&NR>s{print NR-s" rida"; exit}' server/meilisearch_ops.py
+awk '/^def save_and_transfer_to_ocr\(/{s=NR} s&&/^def /&&NR>s{print NR-s" rida"; exit}' server/upload_ops.py
+
+# OCR cleanup shellkäsud
+grep -n "exec_command" server/upload_ops.py
+
+# Blocking-I/O endpointid
+grep -n "def get_work_meta_direct\|def admin_collection_works_count" server/main.py
+
+# Testilüngad
+grep -R "check_account_lockout" -n tests/
+grep -R "check_rate_limit" -n tests/ || true
+
+# Tootmisseadistus serveris
+ssh vutt 'grep -E "VUTT_ENV|IMAGE_TOKEN_SECRET|MEILI_MASTER_KEY" ~/VUTT/.env'
+```

--- a/tests/test_reocr_poll.py
+++ b/tests/test_reocr_poll.py
@@ -1,0 +1,154 @@
+"""
+Testid reocr_ops.poll_reocr_job jaoks (üksiku lehe re-OCR staatuse pollimine).
+
+poll_reocr_job on varem katmata (test_reocr_batch.py katab ainult batch-voolu).
+Siin kaetud:
+- tundmatu job_id → not_found;
+- varajane tagastamine (uploading/done/error) ilma SFTP-ta;
+- processing + TXT veel pole valmis → processing, text None;
+- processing + TXT valmis → done, tekst allalaaditud, .ocr kirjutatud, cleanup käidud.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server.reocr_ops as reocr_ops
+
+
+class _FakeSFTP:
+    """Minimaalne SFTP-mock poll_reocr_job jaoks."""
+
+    def __init__(self, *, txt_ready: bool, txt_content: bytes = b"OCR tekst"):
+        self.txt_ready = txt_ready
+        self.txt_content = txt_content
+        self.removed = []
+        self.rmdired = []
+        self.closed = False
+
+    def stat(self, path):
+        if not self.txt_ready:
+            raise FileNotFoundError(path)
+        # olemas — ei viska erandit
+        return None
+
+    def getfo(self, path, buf):
+        buf.write(self.txt_content)
+
+    def remove(self, path):
+        self.removed.append(path)
+
+    def rmdir(self, path):
+        self.rmdired.append(path)
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _clean_jobs():
+    """Tühjenda _reocr_jobs iga testi eel/järel."""
+    with reocr_ops._reocr_jobs_lock:
+        reocr_ops._reocr_jobs.clear()
+    yield
+    with reocr_ops._reocr_jobs_lock:
+        reocr_ops._reocr_jobs.clear()
+
+
+def _make_job(status="processing", **overrides):
+    job = {
+        "status": status,
+        "text": None,
+        "error": None,
+        "slug": "1690-w1",
+        "page_filename": "1690-w1-abc-001.txt",
+        "remote_staging": "AUTO-OCR/print/j1/staging",
+        "remote_work": "AUTO-OCR/print/j1/work",
+        "remote_img": "AUTO-OCR/print/j1/img.jpg",
+        "remote_txt": "AUTO-OCR/print/j1/out.txt",
+    }
+    job.update(overrides)
+    return job
+
+
+def test_poll_not_found():
+    assert reocr_ops.poll_reocr_job("olematu") == {"status": "not_found"}
+
+
+@pytest.mark.parametrize("status", ["uploading", "done", "error"])
+def test_poll_early_return_without_sftp(monkeypatch, status):
+    """uploading/done/error staatuses SFTP-d ei avata."""
+    called = {"sftp": False}
+
+    def _boom(*a, **kw):
+        called["sftp"] = True
+        raise AssertionError("SFTP ei tohiks avada")
+
+    monkeypatch.setattr(reocr_ops, "_sftp_open", _boom)
+    reocr_ops._reocr_jobs["j1"] = _make_job(status=status, text="x", error=None)
+
+    res = reocr_ops.poll_reocr_job("j1")
+    assert res["status"] == status
+    assert called["sftp"] is False
+
+
+def test_poll_processing_txt_not_ready(monkeypatch):
+    """TXT veel pole OCR serveris valmis → processing, text None."""
+    sftp = _FakeSFTP(txt_ready=False)
+    # Esimene _sftp_open otsib TXT-d; teine (cleanup) ei tohigi käivuda
+    monkeypatch.setattr(reocr_ops, "_sftp_open", lambda jid: sftp)
+    reocr_ops._reocr_jobs["j1"] = _make_job(status="processing")
+
+    res = reocr_ops.poll_reocr_job("j1")
+    assert res == {"status": "processing", "text": None, "error": None}
+    assert sftp.closed is True
+    # Job staatus ei muutunud
+    assert reocr_ops._reocr_jobs["j1"]["status"] == "processing"
+
+
+def test_poll_processing_txt_ready_done(monkeypatch):
+    """TXT on valmis → done, tekst dekodeeritud, .ocr kirjutatud, SSH suletud."""
+    sftp = _FakeSFTP(txt_ready=True, txt_content="Töötlenud OCR tekst".encode("utf-8"))
+    monkeypatch.setattr(reocr_ops, "_sftp_open", lambda jid: sftp)
+
+    closed = {"ssh": False}
+    monkeypatch.setattr(reocr_ops, "close_ssh", lambda jid: closed.__setitem__("ssh", True))
+
+    written = {}
+    monkeypatch.setattr(reocr_ops, "_write_ocr_file",
+                        lambda slug, page_fn, text: written.setdefault("call", (slug, page_fn, text)))
+    monkeypatch.setattr(reocr_ops, "_append_to_log", lambda job, jid: None)
+
+    reocr_ops._reocr_jobs["j1"] = _make_job(status="processing")
+
+    res = reocr_ops.poll_reocr_job("j1")
+
+    assert res["status"] == "done"
+    assert res["text"] == "Töötlenud OCR tekst"
+    assert written["call"][0] == "1690-w1"
+    assert written["call"][2] == "Töötlenud OCR tekst"
+    assert closed["ssh"] is True
+    # Job siseolek uuendatud
+    assert reocr_ops._reocr_jobs["j1"]["status"] == "done"
+    assert reocr_ops._reocr_jobs["j1"]["text"] == "Töötlenud OCR tekst"
+    # Cleanup: TXT + IMG eemaldatud, work + staging kaustad eemaldatud
+    assert any("out.txt" in p for p in sftp.removed)
+    assert any("img.jpg" in p for p in sftp.removed)
+    assert len(sftp.rmdired) == 2  # work + staging
+
+
+def test_poll_processing_no_page_filename_skips_ocr_write(monkeypatch):
+    """Kui page_filename puudub, .ocr faili ei kirjutata (aga done siiski)."""
+    sftp = _FakeSFTP(txt_ready=True)
+    monkeypatch.setattr(reocr_ops, "_sftp_open", lambda jid: sftp)
+    monkeypatch.setattr(reocr_ops, "close_ssh", lambda jid: None)
+    monkeypatch.setattr(reocr_ops, "_write_ocr_file",
+                        lambda *a, **kw: pytest.fail(".ocr ei tohiks kirjutada"))
+    monkeypatch.setattr(reocr_ops, "_append_to_log", lambda job, jid: None)
+
+    reocr_ops._reocr_jobs["j1"] = _make_job(status="processing", page_filename="")
+
+    res = reocr_ops.poll_reocr_job("j1")
+    assert res["status"] == "done"

--- a/tests/test_trash_ops.py
+++ b/tests/test_trash_ops.py
@@ -1,0 +1,249 @@
+"""
+Testid prügikasti operatsioonidele (server/trash_ops.py).
+
+trash_ops.py-l polnud varem ühtegi testi. Kaetud:
+- guard/edge-case'iteed (puuduvad kaustad, puuduvad failid) — ilma gita;
+- restore_deleted_work täisvoog päris (ajutises) git-repos;
+- restore_deleted_page täisvoog päris git-repos;
+- list_deleted_works ristviitab õigesti git logiga.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from git import Repo, Actor
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server.trash_ops as trash_ops
+import server.git_ops as git_ops
+
+
+# =========================================================
+# Guard / edge-case testid (ilma gita)
+# =========================================================
+
+def test_list_deleted_works_empty_when_no_trash(monkeypatch):
+    """TRASH_DIR puudumisel tagastab tühi list, mitte vea."""
+    monkeypatch.setattr(trash_ops, "TRASH_DIR", "/ei/ole/olemas/trash_xyz")
+    assert trash_ops.list_deleted_works() == []
+
+
+def test_list_deleted_pages_empty_when_no_pages(monkeypatch, tmp_path):
+    """pages alamkausta pole → tühi list."""
+    monkeypatch.setattr(trash_ops, "TRASH_DIR", str(tmp_path / "._trash"))
+    assert trash_ops.list_deleted_pages("w1", "1690-w1") == []
+
+
+def test_restore_deleted_work_missing_in_trash(monkeypatch, tmp_path):
+    """Prügikastis puuduv work_id → ok:False."""
+    monkeypatch.setattr(trash_ops, "TRASH_DIR", str(tmp_path / "._trash"))
+    res = trash_ops.restore_deleted_work("puudub_id")
+    assert res["ok"] is False
+    assert "Prügikastis ei leitud" in res["error"]
+
+
+def test_restore_deleted_page_missing_img(monkeypatch, tmp_path):
+    """Kustutatud pilti pole prügikastis → ok:False (enne git otsingut)."""
+    trash_root = tmp_path / "._trash"
+    (trash_root / "w1" / "pages").mkdir(parents=True)
+    monkeypatch.setattr(trash_ops, "TRASH_DIR", str(trash_root))
+    monkeypatch.setattr(trash_ops, "BASE_DIR", str(tmp_path / "data"))
+    res = trash_ops.restore_deleted_page("w1", "1690-w1", "pg1.jpg")
+    assert res["ok"] is False
+    assert "Kustutatud faili ei leitud" in res["error"]
+
+
+def test_restore_deleted_page_missing_work_dir(monkeypatch, tmp_path):
+    """Pilt on prügikastis, aga teose kausta pole → ok:False."""
+    trash_root = tmp_path / "._trash"
+    pages = trash_root / "w1" / "pages"
+    pages.mkdir(parents=True)
+    (pages / "pg1.jpg").write_bytes(b"x")
+    data_dir = tmp_path / "data"  # teadlikult ei loo 1690-w1 all
+    monkeypatch.setattr(trash_ops, "TRASH_DIR", str(trash_root))
+    monkeypatch.setattr(trash_ops, "BASE_DIR", str(data_dir))
+    res = trash_ops.restore_deleted_page("w1", "1690-w1", "pg1.jpg")
+    assert res["ok"] is False
+    assert "Teose kataloog ei leitud" in res["error"]
+
+
+# =========================================================
+# Täisvood päris (ajutises) git-repos
+# =========================================================
+
+@pytest.fixture
+def trash_repo(tmp_path, monkeypatch):
+    """Ajutine git-repo + monkeypatchitud trash_ops sõltuvused.
+
+    Repo juur == BASE_DIR == tmp_path (sama muster nagu tests/test_delete_pages_git.py),
+    et git working-dir ja failide asukoht klappiks. Peegeldab tegelikku kustutamisvoogu:
+    JPG-d liigutatakse prügikasti ENNE git rm-i (vt git_ops.delete_work_from_git docstring).
+    """
+    repo = Repo.init(str(tmp_path))
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "test").set_value("user", "email", "t@t")
+
+    trash_root = tmp_path / "._trash"
+
+    # sync_work_to_meilisearch ei tohi päris Meilisearchi puutuda
+    monkeypatch.setattr(trash_ops, "sync_work_to_meilisearch", lambda slug: True)
+    monkeypatch.setattr(trash_ops, "get_or_init_repo", lambda: repo)
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: repo)
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(trash_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(trash_ops, "TRASH_DIR", str(trash_root))
+
+    return {"repo": repo, "tmp": tmp_path, "base_dir": tmp_path, "trash_root": trash_root}
+
+
+def test_restore_deleted_work_full_flow(trash_repo):
+    """Kustutatud teos taastub: git checkout taastab txt/json/metadata,
+    JPG-d liiguvad prügikastist tagasi, tehakse taastamise commit."""
+    repo = trash_repo["repo"]
+    base_dir = trash_repo["base_dir"]
+    trash_root = trash_repo["trash_root"]
+    work_id = "abc123xyz"
+    folder = "1690-w1"
+    folder_path = base_dir / folder
+
+    # 1. Loo teose failid
+    folder_path.mkdir()
+    (folder_path / "pg1.txt").write_text("sisu", encoding="utf-8")
+    (folder_path / "pg1.json").write_text("{}", encoding="utf-8")
+    (folder_path / "_metadata.json").write_text('{"id": "abc123xyz"}', encoding="utf-8")
+    (folder_path / "pg1.jpg").write_bytes(b"\xff\xd8jpeg")
+    repo.index.add([
+        f"{folder}/pg1.txt", f"{folder}/pg1.json",
+        f"{folder}/_metadata.json",
+    ])
+    repo.index.commit("init")
+
+    # 2. Liiguta JPG prügikasti (nagu päris vool)
+    trash_work = trash_root / work_id
+    trash_work.mkdir(parents=True)
+    import shutil
+    shutil.move(str(folder_path / "pg1.jpg"), str(trash_work / "pg1.jpg"))
+
+    # 3. git rm + kustutamise commit (peegeldab delete_work_from_git formaati)
+    repo.git.rm(f"{folder}/pg1.txt", f"{folder}/pg1.json", f"{folder}/_metadata.json")
+    actor = Actor("kustutaja", "k@vutt.local")
+    repo.index.commit(f"Kustuta teos: Minu Teos [{work_id}]", author=actor, committer=actor)
+    # Tühjaks jäänud kaust eemaldatakse (git ei jälgi tühje kaustu)
+    if folder_path.exists() and not any(folder_path.iterdir()):
+        folder_path.rmdir()
+
+    # 4. Taasta
+    res = trash_ops.restore_deleted_work(work_id, username="taastaja")
+
+    # 5. Kontrolli
+    assert res["ok"] is True
+    assert res["folder_name"] == folder
+    assert res["title"] == "Minu Teos"
+    assert (folder_path / "pg1.txt").exists()
+    assert (folder_path / "pg1.json").exists()
+    assert (folder_path / "_metadata.json").exists()
+    # JPG liigutatud prügikastist tagasi
+    assert (folder_path / "pg1.jpg").exists()
+    assert not (trash_work / "pg1.jpg").exists()
+    # Prügikasti kaust koristatud
+    assert not trash_work.exists()
+    # Cache uuendatud
+    assert trash_ops.WORK_ID_CACHE[work_id] == str(folder_path)
+    # Taastamise commit olemas
+    log = repo.git.log("--oneline")
+    assert "Taasta teos: Minu Teos" in log
+
+
+def test_restore_deleted_work_git_commit_missing(trash_repo):
+    """Prügikastis on kaust, aga gitis puudub kustutamise commit → ok:False."""
+    trash_root = trash_repo["trash_root"]
+    work_id = "no_commit_id"
+    (trash_root / work_id).mkdir(parents=True)
+    (trash_root / work_id / "pg1.jpg").write_bytes(b"\xff\xd8")
+
+    res = trash_ops.restore_deleted_work(work_id)
+    assert res["ok"] is False
+    assert "Git kustutamise commiti ei leitud" in res["error"]
+
+
+def test_restore_deleted_page_full_flow(trash_repo):
+    """Kustutatud leht taastub: git checkout taastab txt/json, JPG tagasi, commit."""
+    repo = trash_repo["repo"]
+    base_dir = trash_repo["base_dir"]
+    trash_root = trash_repo["trash_root"]
+    work_id = "page_w1"
+    folder = "1690-w1"
+    folder_path = base_dir / folder
+
+    # 1. Loo teos kahe lehega (pg2 jääb puutumata, et kaust püsiks)
+    folder_path.mkdir()
+    for pn in ("pg1", "pg2"):
+        (folder_path / f"{pn}.txt").write_text(f"{pn}-sisu", encoding="utf-8")
+        (folder_path / f"{pn}.json").write_text("{}", encoding="utf-8")
+        (folder_path / f"{pn}.jpg").write_bytes(b"\xff\xd8jpg")
+    repo.index.add([
+        f"{folder}/pg1.txt", f"{folder}/pg1.json",
+        f"{folder}/pg2.txt", f"{folder}/pg2.json",
+    ])
+    repo.index.commit("init")
+
+    # 2. Liiguta pg1 pilt prügikasti pages alla
+    trash_pages = trash_root / work_id / "pages"
+    trash_pages.mkdir(parents=True)
+    import shutil
+    shutil.move(str(folder_path / "pg1.jpg"), str(trash_pages / "pg1.jpg"))
+
+    # 3. git rm pg1 + kustutamise commit (sõnum sisaldab folder/base, nagu trash otsib)
+    repo.git.rm(f"{folder}/pg1.txt", f"{folder}/pg1.json")
+    actor = Actor("kustutaja", "k@vutt.local")
+    repo.index.commit(f"Kustuta leht: {folder}/pg1 [{work_id}]", author=actor, committer=actor)
+
+    # 4. Taasta
+    res = trash_ops.restore_deleted_page(work_id, folder, "pg1.jpg", username="taastaja")
+
+    # 5. Kontrolli
+    assert res["ok"] is True
+    assert (folder_path / "pg1.txt").exists()
+    assert (folder_path / "pg1.json").exists()
+    assert (folder_path / "pg1.jpg").exists()  # tagasi prügikastist
+    # pg2 puutumata
+    assert (folder_path / "pg2.txt").exists()
+    assert (folder_path / "pg2.jpg").exists()
+    assert not (trash_pages / "pg1.jpg").exists()
+    log = repo.git.log("--oneline")
+    assert "Taasta leht:" in log
+
+
+def test_list_deleted_works_ristviitab_gitiga(trash_repo):
+    """list_deleted_works leiab prügikastis teose ja ristviitab kustutamise commidiga."""
+    repo = trash_repo["repo"]
+    base_dir = trash_repo["base_dir"]
+    trash_root = trash_repo["trash_root"]
+    work_id = "list_w1"
+    folder = "1690-w1"
+    folder_path = base_dir / folder
+
+    folder_path.mkdir()
+    (folder_path / "pg1.txt").write_text("x", encoding="utf-8")
+    repo.index.add([f"{folder}/pg1.txt"])
+    repo.index.commit("init")
+
+    trash_work = trash_root / work_id
+    trash_work.mkdir(parents=True)
+    (trash_work / "pg1.jpg").write_bytes(b"\xff\xd8")
+    (trash_work / "pg2.jpg").write_bytes(b"\xff\xd8")
+
+    repo.git.rm(f"{folder}/pg1.txt")
+    actor = Actor("kustutaja", "k@vutt.local")
+    repo.index.commit(f"Kustuta teos: List Teos [{work_id}]", author=actor, committer=actor)
+
+    works = trash_ops.list_deleted_works()
+    assert len(works) == 1
+    item = works[0]
+    assert item["work_id"] == work_id
+    assert item["title"] == "List Teos"
+    assert item["jpg_count"] == 2
+    assert item["commit_hash"] is not None
+    assert item["deleted_by"] == "kustutaja"


### PR DESCRIPTION
Ülevaate \`docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md\` (9ea1539) järelt tehtud
„Eraldi PR #1: trash_ops.py ja poll_reocr_job testid". Ainult testid — koodi ei muudetud.

## Muudatused

| Uus fail | Teste | Kata |
|----------|-------|------|
| `tests/test_trash_ops.py` | 9 | `trash_ops.py` — `list_deleted_works`, `restore_deleted_work`, `restore_deleted_page`, `list_deleted_pages` (kõik olid katmata) |
| `tests/test_reocr_poll.py` | 7 | `reocr_ops.poll_reocr_job` (`test_reocr_batch.py` katab ainult batch-voolu) |

## trash_ops.py (9 testi)

- **Guard'id ilma gita** (5): puuduv TRASH_DIR, puuduv pages-kaust, puudub prügikastis, puudub pilt, puudub work_dir.
- **Täisvood päris git-repos** (3): \`restore_deleted_work\` (checkout + JPG tagasi + commit + cache), \`restore_deleted_page\`, \`list_deleted_works\` ristviitab \`Kustuta teos: {title} [{work_id}]\` commidiga.
- \`trash_repo\` fixture peegeldab tegelikku voogu: JPG-d liigutatakse prügikasti ENNE \`git rm\`-i (\`git_ops.delete_work_from_git\` docstring).

## poll_reocr_job (7 testi)

- \`not_found\` (tundmatu job_id);
- varajane tagastamine \`uploading\`/\`done\`/\`error\` ilma SFTP-ta (parametriseeritud, 3);
- \`processing\` + TXT pole valmis → \`processing\`, \`text: None\`;
- \`processing\` + TXT valmis → \`done\`, tekst dekodeeritud, \`.ocr\` kirjutatud, cleanup (TXT+IMG remove, work+staging rmdir), SSH suletud;
- \`page_filename\` puudub → \`.ocr\` faili ei kirjutata.

SFTP mockitud \`_FakeSFTP\` klassiga; \`_write_ocr_file\`, \`_append_to_log\`, \`close_ssh\`, \`sync_work_to_meilisearch\` monkeypatchitud.

## Testid

\`\`\`
484 passed in 10.82s   (468 baas + 16 uut)
\`\`\`

Sõltumatu PR1-st (#14) — kattuvaid faile pole.