### PR TITLE
refactor: _clean_search_text wrapper (1/4 sync_work_to_meilisearch refaktoorist)

### DIFF
--- a/scripts/1-1_consolidate_data.py
+++ b/scripts/1-1_consolidate_data.py
@@ -119,6 +119,18 @@ def clean_text_for_search(text):
     return text
 
 
+def _clean_search_text(page_text):
+    """Eraldab marginaalia ja puhastab mõlemad osad otsinguindeksi jaoks.
+
+    Võtab toore lehekülje teksti ja tagastab tuple
+    (põhitekst_puhastatud, marginaalia_puhastatud).
+    NB: hoia SÜNKROONIS server/meilisearch_ops.py _clean_search_text-iga
+    (live vs seed/reseed-tee pariteet — vt issue #16).
+    """
+    main_text, marginalia_text = split_marginalia(page_text)
+    return clean_text_for_search(main_text), clean_text_for_search(marginalia_text)
+
+
 def calculate_work_status(page_statuses):
     """Arvutab teose koondstaatuse lehekülgede staatuste põhjal."""
     if not page_statuses:
@@ -506,7 +518,7 @@ def create_meilisearch_data_per_page():
                 last_mod = int(os.path.getmtime(os.path.join(doc_path, jpg_filename)) * 1000)
 
             image_path = os.path.join(dir_name, jpg_filename)
-            main_text, marginalia_text = split_marginalia(page_text)
+            lehekylje_tekst, marginaalia_tekst = _clean_search_text(page_text)
 
             # Meilisearch dokument (v2/v3 formaat)
             meili_doc = {
@@ -568,8 +580,8 @@ def create_meilisearch_data_per_page():
                 # Lehekülje andmed
                 'teose_lehekylgede_arv': teose_lehekylgede_arv,
                 'lehekylje_number': page_index + 1,
-                'lehekylje_tekst': clean_text_for_search(main_text),   # OTSING: põhitekst ILMA marginaaliata
-                'marginaalia_tekst': clean_text_for_search(marginalia_text),  # OTSING: marginaalia eraldi väljal (alati olemas, ka tühjana — attributesToSearchOn nõuab)
+                'lehekylje_tekst': lehekylje_tekst,               # OTSING: põhitekst ILMA marginaaliata
+                'marginaalia_tekst': marginaalia_tekst,           # OTSING: marginaalia eraldi väljal (alati olemas, ka tühjana — attributesToSearchOn nõuab)
                 'text_content': page_text,                          # REDAKTORI JAOKS (algne tekst koos kõigi märkidega)
                 'lehekylje_pilt': image_path,
                 'originaal_kataloog': dir_name,

--- a/server/meilisearch_ops.py
+++ b/server/meilisearch_ops.py
@@ -123,6 +123,24 @@ def build_text_annotations_text(text_annotations):
     return " ".join(parts) if parts else None
 
 
+def _clean_search_text(page_text):
+    """Eraldab marginaalia ja puhastab mõlemad osad otsinguindeksi jaoks.
+
+    Võtab toore lehekülje teksti (raw editoritekst) ja tagastab tuple
+    (põhitekst_puhastatud, marginaalia_puhastatud), kus:
+    - põhitekst = marginaalia `<m>`-plokidest vabastatud ja vormindusmärkidest
+      puhastatud (poolitused liidetud, ws kollapseeritud) — otsinguks `lehekylje_tekst`;
+    - marginaalia = `<m>`-plokkide sisu samuti puhastatud — otsinguks `marginaalia_tekst`.
+
+    Kombineerib `split_marginalia` (eraldab plokid, sh ristuvad tägiga) ja
+    `clean_text_for_search` (eemaldab XML/markdown märgid, liidab poolitused).
+    NB: hoia SÜNKROONIS scripts/1-1_consolidate_data.py _clean_search_text-iga
+    (seed/reseed-tee pariteet — vt issue #16).
+    """
+    main_text, marginalia_text = split_marginalia(page_text)
+    return clean_text_for_search(main_text), clean_text_for_search(marginalia_text)
+
+
 def load_people_aliases():
     """Laeb inimeste aliased JSON failist."""
     if os.path.exists(PEOPLE_FILE):
@@ -508,7 +526,7 @@ def sync_work_to_meilisearch(dir_name):
                     if inverted:
                         tag_aliases.append(inverted)
 
-        main_text, marginalia_text = split_marginalia(page_text)
+        lehekylje_tekst, marginaalia_tekst = _clean_search_text(page_text)
         doc = {
             "id": page_id,
             "work_id": work_id,  # Nanoid (püsiv lühikood)
@@ -522,8 +540,8 @@ def sync_work_to_meilisearch(dir_name):
             "year_end": year_end,
             "lehekylje_number": page_num,
             "teose_lehekylgede_arv": len(images),
-            "lehekylje_tekst": clean_text_for_search(main_text),   # OTSING: põhitekst ILMA marginaaliata
-            "marginaalia_tekst": clean_text_for_search(marginalia_text),  # OTSING: marginaalia eraldi väljal (alati olemas, ka tühjana — attributesToSearchOn nõuab)
+            "lehekylje_tekst": lehekylje_tekst,               # OTSING: põhitekst ILMA marginaaliata
+            "marginaalia_tekst": marginaalia_tekst,           # OTSING: marginaalia eraldi väljal (alati olemas, ka tühjana — attributesToSearchOn nõuab)
             "text_content": page_text,                             # REDAKTOR: algne tekst koos kõigi märkidega
             "lehekylje_pilt": os.path.join(dir_name, img_name),
             "originaal_kataloog": dir_name,

--- a/tests/test_meilisearch_ops.py
+++ b/tests/test_meilisearch_ops.py
@@ -129,7 +129,41 @@ def test_generate_work_scoped_meili_token_different_works():
 
 
 # --- split_marginalia ---
-from server.meilisearch_ops import split_marginalia, clean_text_for_search
+from server.meilisearch_ops import split_marginalia, clean_text_for_search, _clean_search_text
+
+
+# --- _clean_search_text (split_marginalia + clean_text_for_search kompositsioon) ---
+class TestCleanSearchText:
+    def test_eraldab_ja_puhastab_mõlemad_osad(self):
+        # põhitekst sisaldab XML märgendit + hyphen-poolitust; marginaalia plokk eraldi
+        raw = "welcher i\u015ft der Teuffel\n<m>Vide <i>Picrium</i></m>\nvnd Satanas."
+        main, marg = _clean_search_text(raw)
+        assert main == "welcher i\u015ft der Teuffel vnd Satanas."
+        assert marg == "Vide Picrium"   # sisemine <i> täg eemaldatud
+
+    def test_tühi_sisend(self):
+        assert _clean_search_text("") == ("", "")
+        assert _clean_search_text(None) == ("", "")
+
+    def test_inline_m_ei_liimi_sõnu(self):
+        """Wrapper (läbi split_marginalia) ei tohi 'foo<m>x</m>bar' -> 'foobar'."""
+        main, marg = _clean_search_text("foo<m>note</m>bar")
+        assert main == "foo bar"
+        assert marg == "note"
+
+    def test_hyphen_poolituse_liitmine(self):
+        """coa-\ncervare -> coacervare (üle rea poolituse liitmine)."""
+        main, _ = _clean_search_text("coa-\ncervare")
+        assert main == "coacervare"
+
+    def test_ainult_marginaalia(self):
+        """Kogu tekst on marginaalia → põhitekst tühi, marginaalia täis."""
+        main, marg = _clean_search_text("<m>terve plokk</m>")
+        assert main == ""
+        assert marg == "terve plokk"
+
+
+# --- split_marginalia (alused) ---
 
 
 class TestSplitMarginalia:


### PR DESCRIPTION
Issue #16 refaktoori **esimene samm**: välja eraldatud kõige isoleeritum tük — \`split_marginalia\` + \`clean_text_for_search\` kompositsioon. Puhas refaktor, **käitumismuudatus puudub**.

## Muudatused

| Fail | Mis |
|------|-----|
| \`server/meilisearch_ops.py\` | **Live-tee:** lisatud \`_clean_search_text(page_text)\` → \`(põhitekst, marginaalia)\`; 3 rida (split + 2× clean) asendatud ühe kõnega \`sync_work_to_meilisearch\` tsüklis. |
| \`scripts/1-1_consolidate_data.py\` | **Seed-tee (pariteet):** SAMA muudatus. Seed-skriptil on oma duplikaat \`split_marginalia\`/\`clean_text_for_search\`; wrapper lisatud koopiana, sünkroonimärk mõlema docstringis (vt issue #16 seed-tee hoiatus). |
| \`tests/test_meilisearch_ops.py\` | 5 uut unit-testi \`_clean_search_text\` wrapperile otse (eraldab+puhastab, tühi sisend, inline \`<m>\` ei liimi sõnu, hyphen-poolitus, ainult marginaalia). |

## Miks see on turvaline

- **15 snapshot-testi** (\`sync_work_to_meilisearch\` väljund, PR #20) lähevad läbi → null-käitumismuutus.
- **5 uut wrapper unit-testi** lukustavad kompositsiooni otse.
- **Mutatsioonitest** kinnitas kaitsevõimet: kui wrapper jätab marginaalia puhastamata → testid nurjuvad.
- **Seed-tee pariteet** säilinud (sama muudatus mõlemas tees).

\`\`\`
509 passed in 10.83s   (504 + 5 uut)
\`\`\`

## Kontekst (refaktoori võrgustik)

See on 4 abifunktsioonist esimene:
1. ✅ \`_clean_search_text\` — **see PR** (kõige isoleeritum: raw text → 2 stringi)
2. ⬜ \`_load_work_index_context\` — people/labels/collections eellaadimine (üks kord enne tsüklit)
3. ⬜ \`_build_page_document\` — ühe lehe dokumendi ehitamine
4. ⬜ \`_upsert_work_documents\` — Meilisearchi saatmine + \`_delete_extra_pages\`

Iga samm eraldi PR, snapshot-testid (PR #20) garanteerivad, et dokumendi väljund ei muutu. NB: väljanimesid \`lehekylje_tekst\` jne (vanem \`y\`-ortograafia) ei tohi ümber nimetada.