### PR TITLE
refactor: _compute_work_aliases — tõsta aliase arvutus ühekordseks (2/4)

### DIFF
--- a/server/meilisearch_ops.py
+++ b/server/meilisearch_ops.py
@@ -214,6 +214,46 @@ def normalize_creator(creator, people_data):
     return canonical_name, best_id
 
 
+def _compute_work_aliases(creators, publisher, tags, people_data):
+    """Arvutab work-level aliased ja authors_text ühe teose jaoks.
+
+    Need väärtused sõltuvad AINULT teose metadatast (creators/publisher/tags +
+    people register), mitte konkreetsest lehest — seega arvutatakse üks kord
+    enne lehtede tsüklit, mitte igal lehel uuesti (vt issue #16 refaktoor).
+
+    Tagastab (aliases, authors_text, publisher_aliases, tag_aliases):
+    - aliases: kõikide creatorite nimevariandid (+ invereedid 'Pere, Ees' → 'Ees Pere');
+    - authors_text: creatorite nimed + aliased (otsingu jaoks, nt 'Lorenz' → 'Laurentius');
+    - publisher_aliases: trükkali nimevariandid;
+    - tag_aliases: isiku-märksõnade nimevariandid (nt 'Ludenius' → 'Luden').
+    """
+    aliases = get_creator_aliases(creators, people_data)
+    authors_text = [c['name'] for c in creators if c.get('name')] + aliases
+
+    # Trükkali aliased (trükkalid on ka mitme nimega)
+    publisher_aliases = []
+    pub_id = get_id(publisher)
+    if pub_id and people_data.get(pub_id):
+        for alias in people_data[pub_id].get('aliases', []):
+            publisher_aliases.append(alias)
+            inverted = _invert_name(alias)
+            if inverted:
+                publisher_aliases.append(inverted)
+
+    # Märksõna aliased (isiku märksõnade nimevariandid)
+    tag_aliases = []
+    for tag in tags if isinstance(tags, list) else []:
+        tag_id = get_id(tag) if isinstance(tag, dict) else None
+        if tag_id and people_data.get(tag_id):
+            for alias in people_data[tag_id].get('aliases', []):
+                tag_aliases.append(alias)
+                inverted = _invert_name(alias)
+                if inverted:
+                    tag_aliases.append(inverted)
+
+    return aliases, authors_text, publisher_aliases, tag_aliases
+
+
 def load_collections():
     """Laeb kollektsioonide hierarhia."""
     if os.path.exists(COLLECTIONS_FILE):
@@ -451,6 +491,12 @@ def sync_work_to_meilisearch(dir_name):
     people_data = load_people_aliases()
     labels_store = load_labels_store()
 
+    # Work-level aliased (creators/publisher/tags) sõltuvad ainult metadatast, mitte lehest
+    # — arvutatakse üks kord, mitte igal lehel (vt issue #16 refaktoor).
+    aliases, authors_text, publisher_aliases, tag_aliases = _compute_work_aliases(
+        creators, publisher, tags, people_data
+    )
+
     for i, img_name in enumerate(images):
         page_num = i + 1
         page_id = f"{work_id}-{page_num}"
@@ -498,33 +544,6 @@ def sync_work_to_meilisearch(dir_name):
 
     # NB: page_meta['tags'] sisaldab lehekülje märksõnu (loetud page_tags väljalt)
         page_tags_data = page_meta.get('tags', [])
-
-        # Kasuta eellaetud people_data (laetud enne tsüklit)
-        aliases = get_creator_aliases(creators, people_data)
-
-        # authors_text sisaldab nüüd ka aliaseid, et otsing leiaks "Lorenz" kui nimi on "Laurentius"
-        authors_text = [c['name'] for c in creators if c.get('name')] + aliases
-
-        # Trükkali aliased (trükkalid on ka mitme nimega)
-        publisher_aliases = []
-        pub_id = get_id(publisher)
-        if pub_id and people_data.get(pub_id):
-            for alias in people_data[pub_id].get('aliases', []):
-                publisher_aliases.append(alias)
-                inverted = _invert_name(alias)
-                if inverted:
-                    publisher_aliases.append(inverted)
-
-        # Märksõna aliased (isiku märksõnade nimevariandid, nt Ludenius → Luden)
-        tag_aliases = []
-        for tag in tags if isinstance(tags, list) else []:
-            tag_id = get_id(tag) if isinstance(tag, dict) else None
-            if tag_id and people_data.get(tag_id):
-                for alias in people_data[tag_id].get('aliases', []):
-                    tag_aliases.append(alias)
-                    inverted = _invert_name(alias)
-                    if inverted:
-                        tag_aliases.append(inverted)
 
         lehekylje_tekst, marginaalia_tekst = _clean_search_text(page_text)
         doc = {

--- a/tests/test_meilisearch_ops.py
+++ b/tests/test_meilisearch_ops.py
@@ -163,6 +163,53 @@ class TestCleanSearchText:
         assert marg == "terve plokk"
 
 
+# --- _compute_work_aliases (work-level aliase arvutus üks kord) ---
+from server.meilisearch_ops import _compute_work_aliases
+
+
+class TestComputeWorkAliases:
+    """Work-level aliased sõltuvad ainult metadatast, mitte lehest — arvutatakse üks kord."""
+
+    def test_authors_text_sisaldab_creator_nimesid_ja_aliaseid(self):
+        creators = [{"name": "Laurentius Ludenius", "id": "Q123", "role": "auctor"}]
+        people = {"Q123": {"primary_name": "Lorenz Luden", "aliases": ["Ludenius"], "ids": {}}}
+        aliases, authors_text, _, _ = _compute_work_aliases(creators, None, [], people)
+        assert aliases == ["Ludenius"]                       # creator alias
+        assert "Laurentius Ludenius" in authors_text         # creator nimi
+        assert "Ludenius" in authors_text                    # alias lisatud
+
+    def test_publisher_aliases_sh_inverteeritud_nimega(self):
+        """Publisher alias lisab ka invereeditud 'Pere, Ees' → 'Ees Pere'."""
+        publisher = {"label": "Trükikoda", "id": "Q777"}
+        people = {"Q777": {"aliases": ["Müller, Heinrich"]}}
+        _, _, publisher_aliases, _ = _compute_work_aliases([], publisher, [], people)
+        assert "Müller, Heinrich" in publisher_aliases
+        assert "Heinrich Müller" in publisher_aliases        # invereeditud
+
+    def test_tag_aliases_isiku_märksõnadele(self):
+        tags = [{"label": "Margin", "id": "Q500"}]
+        people = {"Q500": {"aliases": ["Ludenius"]}}
+        _, _, _, tag_aliases = _compute_work_aliases([], None, tags, people)
+        assert tag_aliases == ["Ludenius"]
+
+    def test_tühi_sisend(self):
+        """Tühjad creators/publisher/tags ja tühi register → kõik tühjad."""
+        aliases, authors_text, publisher_aliases, tag_aliases = _compute_work_aliases([], None, [], {})
+        assert aliases == [] and authors_text == []
+        assert publisher_aliases == [] and tag_aliases == []
+
+    def test_olematu_id_aliaseid_ei_leita(self):
+        """ID mis pole people registeris → aliaseid ei lisata."""
+        creators = [{"name": "Tundmatu", "id": "Q999"}]
+        aliases, authors_text, publisher_aliases, tag_aliases = _compute_work_aliases(
+            creators, {"id": "Q888"}, [{"id": "Q777"}], {"Q123": {"aliases": ["x"]}}
+        )
+        assert aliases == []                                  # Q999 pole registeris
+        assert authors_text == ["Tundmatu"]                  # nimi jääb
+        assert publisher_aliases == []                        # Q888 pole registeris
+        assert tag_aliases == []                              # Q777 pole registeris
+
+
 # --- split_marginalia (alused) ---
 
 


### PR DESCRIPTION
Issue #16 refaktoori **teine samm**: work-level aliase arvutused (\`aliases\`, \`authors_text\`, \`publisher_aliases\`, \`tag_aliases\`) tõstetud lehe tsüklist välja. Puhas refaktor + jõudlusparandus, **käitumismuudatus puudub**.

## Mis muutus

`server/meilisearch_ops.py`: lisatud \`_compute_work_aliases(creators, publisher, tags, people_data)\` → \`(aliases, authors_text, publisher_aliases, tag_aliases)\`. Kutsutakse **üks kord enne lehtede tsüklit** (varem arvutati need 4 asja **iga lehe jaoks uuesti**, kuigi sõltuvad ainult teose metadatast).

**Jõudlus:** teostel N lehega — \`N × 4\` aliase arvutust → \`1 × 4\`.

`tests/test_meilisearch_ops.py`: 5 uut unit-testi \`_compute_work_aliases\` otse (authors_text+aliased, publisher_aliases+inverteeritud nimi, tag_aliases, tühi sisend, olematu ID).

## Turvalisus kinnitatud

- **15 snapshot-testi** (PR #20) lähevad läbi → null-käitumismuutus.
- **5 uut wrapper unit-testi** lukustavad arvutuse otse.
- **Mutatsioonitest** tabas mõlema testikihi: aliases \`authors_text\`-ist välja jätmine → nii unit- kui snapshot-test nurjuvad.

\`\`\`
514 passed in 10.90s   (509 + 5 uut)
\`\`\`

## ⚠️ Seed-tee pariteet (issue #16 hoiatus)

\`scripts/1-1_consolidate_data.py\` on **puutumata**. Põhjendus:

- Seed on juba osaliselt ühekordne (\`aliases\`/\`authors_text\` teose tsükli tasandil, rida 437).
- Publisher/tag aliaseid arvutatakse seal **teise, samaväärse koodiga** (\`get_entity_aliases\`, ridadel 576/635 lehe tsükli sees).
- \`authors_text\` konstrueeritakse seal **teisiti** (\`doc_metadata.get('authors_text')\` vs live \`[c['name'] for c in creators]\`).

See on olemasolev pariteedi-lõhe, mida issue #16 hoiatus katab. Selle ühtlustamine on **eraldi otsus** (vajab serveri andmekontrolli, sarnane crossLang map issue #18-ga) — see ei kuulu siia puhtasse refaktorisse.

## Refaktoori võrgustik (4 abifunktsiooni)

1. ✅ \`_clean_search_text\` (PR #21)
2. ✅ \`_compute_work_aliases\` — **see PR**
3. ⬜ \`_build_page_document\` — ühe lehe dokumendi ehitamine
4. ⬜ \`_upsert_work_documents\` — saatmine + \`_delete_extra_pages\`

Iga samm eraldi PR, snapshot-testid garanteerivad väljundi stabiilsuse.