### PR TITLE
refactor: _upsert_work_documents — eralda saatmine + teose_staatus (4/4, lõpetab #16)

### DIFF
--- a/server/meilisearch_ops.py
+++ b/server/meilisearch_ops.py
@@ -722,20 +722,10 @@ def sync_work_to_meilisearch(dir_name):
         )
         documents.append(doc)
 
-    # 3. Arvuta teose koondstaatus
-    teose_staatus = calculate_work_status(page_statuses)
-    for doc in documents:
-        doc['teose_staatus'] = teose_staatus
-
-    # 4. Saada uued dokumendid Meilisearchi (upsert — uuendab olemasolevad, lisab uued)
-    # Kustutame PÄRAST lisamist ainult need dokumendid mis jäid üle (leheküljed kustutati).
-    # NB: Ära kustuta enne lisamist — sellel ajal oleks teos otsinguks kättesaamatu (race condition).
+    # 3. Arvuta teose koondstaatus, saada Meilisearchi ja kustuta üleliigne.
+    # tsüklile järgnev samm on eraldatud _upsert_work_documents (vt issue #16 refaktoor).
     if documents and work_id:
-        new_count = len(documents)
-        logger.info(f"AUTOMAATNE SÜNK: Teos {slug} ({new_count} lk), staatus: {teose_staatus}")
-        result = send_to_meilisearch(documents)
-        _delete_extra_pages(work_id, new_count)
-        return result
+        return _upsert_work_documents(work_id, slug, documents, page_statuses)
 
 
 def _delete_extra_pages(work_id, new_count):
@@ -779,6 +769,33 @@ def _delete_extra_pages(work_id, new_count):
                 logger.info(f"Kustutatud üleliigsed leheküljed (work_id={work_id}, new_count={new_count})")
     except Exception as e:
         logger.error(f"Viga üleliigsete lehekülgede kustutamisel: {e}")
+
+
+def _upsert_work_documents(work_id, slug, documents, page_statuses):
+    """Lisab teose koondstaatuse kõikidele dokumentidele ja saadab Meilisearchi.
+
+    Teostab tsüklile järgneva sammu (vt issue #16 refaktoor):
+    1. arvutab teose koondstaatuse kõikide lehtede staatustest
+       (Toores/Valmis/Töös — vt utils.calculate_work_status);
+    2. kannab selle igale dokumendile (teose_staatus väli);
+    3. saadab uued dokumendid upsert'ina (send_to_meilisearch);
+    4. kustutab üleliigsed (kustutatud) leheküljed PÄRAST lisamist
+       (_delete_extra_pages — ärge kustuta enne, muidu teos on hetkeks otsinguks kättesaamatu).
+
+    Tagastab send_to_meilisearch tulemi (True/False) või None kui dokumendid puuduvad.
+    """
+    if not documents:
+        return None
+
+    teose_staatus = calculate_work_status(page_statuses)
+    for doc in documents:
+        doc['teose_staatus'] = teose_staatus
+
+    new_count = len(documents)
+    logger.info(f"AUTOMAATNE SÜNK: Teos {slug} ({new_count} lk), staatus: {teose_staatus}")
+    result = send_to_meilisearch(documents)
+    _delete_extra_pages(work_id, new_count)
+    return result
 
 
 def delete_work_from_meilisearch(work_id):

--- a/tests/test_meilisearch_ops.py
+++ b/tests/test_meilisearch_ops.py
@@ -210,6 +210,71 @@ class TestComputeWorkAliases:
         assert tag_aliases == []                              # Q777 pole registeris
 
 
+# --- _upsert_work_documents (tsüklile järgnev saatmise + kustutamise samm) ---
+from server.meilisearch_ops import _upsert_work_documents
+import server.meilisearch_ops as ops
+
+
+class TestUpsertWorkDocuments:
+    """Teose koondstaatuse arvutamine + Meilisearchi saatmine + üleliigse kustutamine.
+
+    Need testid mockivad send_to_meilisearch / _delete_extra_pages / calculate_work_status
+    ei eksisteeri — calculate_work_status on puhas (vt tests/test_transform_page.py või
+    siin otse), send/delete mockitakse kinnipüüdmiseks.
+    """
+
+    def test_tühi_dokumentide_list_tagastab_none(self, monkeypatch):
+        """Tühjad dokumendid → ei saateta, tagastab None (varajane väljumine)."""
+        sent = []
+        monkeypatch.setattr(ops, "send_to_meilisearch", lambda docs, wait=True: sent.extend(docs) or True)
+        deleted = []
+        monkeypatch.setattr(ops, "_delete_extra_pages", lambda wid, n: deleted.append((wid, n)))
+        assert _upsert_work_documents("W1", "slug", [], []) is None
+        assert sent == [] and deleted == []   # midagi ei tehtud
+
+    def test_kandis_teose_staatus_kõikidele_dokumentidele(self, monkeypatch):
+        """Segatud lehtede staatused → 'Töös' kantakse igale dokumendile."""
+        sent = []
+        monkeypatch.setattr(ops, "send_to_meilisearch", lambda docs, wait=True: sent.extend(docs) or True)
+        monkeypatch.setattr(ops, "_delete_extra_pages", lambda wid, n: None)
+        docs = [{"id": "W1-1"}, {"id": "W1-2"}]
+        result = _upsert_work_documents("W1", "slug", docs, ["Toores", "Valmis"])
+        assert result is True
+        # mõlemale dokumendile lisati sama koondstaatus
+        assert docs[0]["teose_staatus"] == "Töös"
+        assert docs[1]["teose_staatus"] == "Töös"
+        # saadetud dokumendid sisaldavad teose_staatus välja
+        assert all("teose_staatus" in d for d in sent)
+
+    def test_kõik_valmis_annab_valmis(self, monkeypatch):
+        monkeypatch.setattr(ops, "send_to_meilisearch", lambda docs, wait=True: True)
+        monkeypatch.setattr(ops, "_delete_extra_pages", lambda wid, n: None)
+        docs = [{"id": "W1-1"}]
+        _upsert_work_documents("W1", "slug", docs, ["Valmis"])
+        assert docs[0]["teose_staatus"] == "Valmis"
+
+    def test_saadab_ja_kustutab_üleliigse_pärast_lisamist(self, monkeypatch):
+        """Kõigepealt saatmine, siis kustutamine (järgnevus — mitte ümberpöördult)."""
+        order = []
+        monkeypatch.setattr(ops, "send_to_meilisearch",
+                            lambda docs, wait=True: order.append("send") or True)
+        monkeypatch.setattr(ops, "_delete_extra_pages",
+                            lambda wid, n: order.append("delete") or None)
+        docs = [{"id": "W1-1"}, {"id": "W1-2"}, {"id": "W1-3"}]
+        _upsert_work_documents("W1", "slug", docs, ["Toores"] * 3)
+        # järgnevus: kustutamine peab toimuma PÄRAST saatmist (et vältida downtime-akent)
+        assert order == ["send", "delete"]
+        # _delete_extra_pages sai õige new_count (dokumentide arv)
+        assert len(docs) == 3
+
+    def test_tagastab_send_tulemi(self, monkeypatch):
+        """Tagastab send_to_meilisearch tulemi (edastus võib ebaõnnestuda)."""
+        monkeypatch.setattr(ops, "send_to_meilisearch", lambda docs, wait=True: False)
+        monkeypatch.setattr(ops, "_delete_extra_pages", lambda wid, n: None)
+        result = _upsert_work_documents("W1", "slug", [{"id": "W1-1"}], ["Toores"])
+        assert result is False
+
+
 # --- split_marginalia (alused) ---
 
 


### PR DESCRIPTION
Issue #16 refaktoori **neljas ja viimane samm** — \`_upsert_work_documents\`. Puhas refaktor, **käitumismuudatus puudub**. **Lõpetab #16.**

## Mis muutus (\`server/meilisearch_ops.py\`)

Tsüklile järgnev samm tõstetud \`_upsert_work_documents(work_id, slug, documents, page_statuses)\`-i. Funktsioon teeb **järjestuses** (oluline):

1. \`calculate_work_status(page_statuses)\` → \`teose_staatus\` (Toores/Valmis/Töös);
2. kannab \`teose_staatus\` igale dokumendile;
3. \`send_to_meilisearch(documents)\` — upsert;
4. \`_delete_extra_pages(work_id, new_count)\` — **PÄRAST** saatmist (mitte enne — muidu teos on downtime-aknas otsinguks kättesaamatu; race condition, dokumenteeritud).

\`\`\`
sync_work_to_meilisearch: 229 → 219 rida
\`\`\`

## Kogu refaktoori (#16) kokkuvõte

\`\`\`
sync_work_to_meilisearch: 328 → 219 rida  (-33%)
\`\`\`

| Samm | PR | Mis |
|------|----|-----|
| 1. \`_clean_search_text\` | #21 | raw text → (põhitekst, marginaalia) puhastatud |
| 2. \`_compute_work_aliases\` | #22 | work-level aliased ühekordselt (N×4 → 1×4) |
| 3. \`_build_page_document\` | #24 | dokumendi dict ehitamine + \`work_ctx\` |
| 4. \`_upsert_work_documents\` | **see PR** | teose_staatus + saatmine + kustutamine |

Funktsioon on nüüd liigendatud: metadata laadimine → tsükkel (\`page_text\`/\`page_meta\`) → \`_build_page_document\` → \`_upsert_work_documents\`.

## Miks turvaline

- **15 snapshot-testi** (PR #20) lähevad läbi → null-käitumismuutus kõigis 4 sammus.
- **5 uut unit-testi** \`_upsert_work_documents\` otse (tühi list, teose_staatus kandmine, kõik-Valmis, järjekord send→delete, tulemi edastamine).
- **Mutatsioonitestid** kinnitasid kaitsevõimet:
  - kustutamine enne saatmist (downtime-aken) → ❌ tabatud
  - \`teose_staatus\` jätmata → ❌ tabatud

\`\`\`
519 passed in 10.98s   (514 + 5 uut)
\`\`\`

## Seos issue #23-ga (järgmine)

#16 on lõpetatud → \`#23\` (jagatud \`server/meili_doc.py\` moodul) on nüüd **ette valmis**. Kõik 4 abifunktsiooni (+ \`work_ctx\` ehitamine) on isoleeritud ja importeeritavad ilma raskeid kõrvalsõltuvusi (\`ThreadPoolExecutor\`, \`git_ops\`, Meili-klient) kaasamata. See võimaldab \`1-1_consolidate_data.py\`-st dubleeritud koopiad kustutada ja mõlemad teed samast moodulist importida.

Closes #16.