### PR TITLE
refactor(meili): unifitseeri kaardistusloogika jagatud server/meili_doc.py-sse (#23)

### DIFF
--- a/scripts/1-1_consolidate_data.py
+++ b/scripts/1-1_consolidate_data.py
@@ -248,14 +248,7 @@ def build_work_documents(doc_path, dir_name, collections, people_data, archives,
 
     all_imgs = [f for f in os.listdir(doc_path)
                 if f.lower().endswith(('.jpg', '.jpeg', '.png')) and not f.startswith('_thumb_')]
-    alpha_sorted = sorted(all_imgs)
-    alpha_pos = {f: i for i, f in enumerate(alpha_sorted)}
-
-    def _eff_seq(img_name):
-        s = _seq(img_name)
-        return (alpha_pos[img_name] + 1) * 100 if s == float('inf') else s
-
-    jpg_files = sorted(all_imgs, key=lambda f: (_eff_seq(f), f))
+    jpg_files = sorted(all_imgs, key=lambda f: (_seq(f), f))
     if not jpg_files:
         return teose_id, []
 
@@ -351,7 +344,8 @@ def build_work_documents(doc_path, dir_name, collections, people_data, archives,
                     page_meta['text_annotations'] = source.get('text_annotations', [])
                     page_meta['status'] = source.get('status', 'Toores')
                     page_meta['history'] = source.get('history', [])
-                    if 'text_content' in file_json and file_json['text_content']:
+                    # Live-tee pariteet: JSON text_content on fallback ainult siis, kui .txt puudub/tühi.
+                    if not page_text and 'text_content' in file_json:
                         page_text = file_json['text_content']
             except Exception as e:
                 print(f"Viga JSON lugemisel {json_path}: {e}")

--- a/scripts/1-1_consolidate_data.py
+++ b/scripts/1-1_consolidate_data.py
@@ -44,10 +44,18 @@ if 'server' not in sys.modules:
     sys.modules.setdefault('server', _server_pkg)
 sys.path.insert(0, _project_root)
 from server.utils import (
-    capitalize_first, get_label, get_id, get_all_labels,
-    get_primary_labels, get_labels_by_lang, get_all_ids, parse_year_range
+    parse_year_range, normalize_genre, calculate_work_status,
 )
-from server.marginalia_normalize import normalize_marginalia_tags
+# Jagatud kaardistusloogika (issue #23): puhtad _metadata.json → Meili dokumendi
+# funktsioonid elavad server/meili_doc.py-s, et seed/reseed-tee (see skript) ja
+# live-tee (server/meilisearch_ops.py) EI SAAKS vaikselt lahku minna. Varem olid
+# split_marginalia, clean_text_for_search, get_creator_aliases, _build_page_document jms
+# siin dubleeritud — nüüd ainult imporditud (dokumendi ehitus käib _build_page_document'i
+# kaudu, mis kutsub puhastus-/aliase-funktsioone ise).
+from server.meili_doc import (
+    get_collection_hierarchy, _compute_work_aliases, compute_autor_respondens,
+    _build_page_document,
+)
 
 
 def sanitize_id(text):
@@ -58,88 +66,6 @@ def sanitize_id(text):
     sanitized = re.sub(r'_+', '_', sanitized)
     sanitized = sanitized.strip('_-')
     return sanitized
-
-
-M_CONTENT_RE = re.compile(r'<m>([\s\S]*?)</m>')
-
-
-def split_marginalia(text):
-    """Eraldab marginaalia plokid põhitekstist enne indekseerimist.
-
-    Tagastab (põhitekst ilma <m>-plokkideta, marginaaliate sisu reavahetustega liidetult).
-    Põhiteksti fraasid jätkuvad üle eemaldatud ploki koha — clean_text_for_search
-    liidab poolitused ja kollapsib tühikud ka mitme järjestikuse reavahetuse korral.
-    NB: hoia SÜNKROONIS server/meilisearch_ops.py koopiaga!
-    """
-    if not text:
-        return "", ""
-    # Normaliseeri ristuvad/mässitud <m>-tägid (<i><m>X</i></m> → <m><i>X</i></m>)
-    # enne eraldamist — muidu jääks orv inline-täg põhiteksti / marginaaliasse.
-    text = normalize_marginalia_tags(text)
-    notes = M_CONTENT_RE.findall(text)
-    # Tühik (mitte tühi string) väldib inline <m> korral ümbritsevate sõnade kokkuliimimist
-    # (nt "foo<m>note</m>bar" → "foo bar", mitte "foobar")
-    main = M_CONTENT_RE.sub(' ', text)
-    return main, "\n".join(notes)
-
-
-def clean_text_for_search(text):
-    """Puhastab teksti otsinguindeksi jaoks, eemaldades vormindusmärgid ja liites poolitused.
-
-    Toetab mõlemat märgendusformaati:
-    - Uus XML: <i>, <b>, <cs>, <m>, <hi>, <fn>n</fn>, <pb/>
-    - Vana pseudo-markdown: *italic*, **bold**, ~cs~, [[m:text]], --lk--, [^n]
-
-    NB: hoia SÜNKROONIS server/meilisearch_ops.py clean_text_for_search-iga
-    (kaks indekseerimisteed — vt MEMORY project_meili_two_index_paths).
-    """
-    if not text:
-        return ""
-
-    # 1. Uus XML märgendus — eemalda kõik VUTT tägid
-    # <fn>n</fn> ja <pb/> asendame tühikuga, ülejäänud tägid eemaldame
-    text = re.sub(r'<fn>\d+</fn>', ' ', text)  # joonealuse viite marker
-    text = re.sub(r'<pb/>', ' ', text)           # leheküljevahetus
-    text = re.sub(r'</?[a-z]+\d*>', '', text)    # avamis/sulgemistägid (<i>, </i>, <cs>, <ann1>, </ann1> jne)
-
-    # 2. Vana pseudo-markdown (legacy, kui faile pole veel migreeritud)
-    text = text.replace('*', ' ')               # bold/italic tärnid
-    text = text.replace('~', ' ')               # koodivahetus
-    text = text.replace('[[m:', ' ').replace(']]', ' ')  # ääremärkus
-    text = text.replace('--lk--', ' ')          # leheküljevahetus
-    text = re.sub(r'\[\^\d+\]', ' ', text)      # joonealuse viite marker
-
-    # 3. Käitle reavahetuse poolituskriipse PÄRAST tägide eemaldamist
-    # (nt "<i>Sueco¬</i>\n<i>rum" -> pärast tägide eemaldust "Sueco¬\nrum" -> "Suecorum")
-    text = re.sub(r'[-⸗¬]\s*\n\s*', '', text)
-
-    # 4. Eemalda üleliigsed tühikud
-    text = re.sub(r'\s+', ' ', text).strip()
-
-    return text
-
-
-def _clean_search_text(page_text):
-    """Eraldab marginaalia ja puhastab mõlemad osad otsinguindeksi jaoks.
-
-    Võtab toore lehekülje teksti ja tagastab tuple
-    (põhitekst_puhastatud, marginaalia_puhastatud).
-    NB: hoia SÜNKROONIS server/meilisearch_ops.py _clean_search_text-iga
-    (live vs seed/reseed-tee pariteet — vt issue #16).
-    """
-    main_text, marginalia_text = split_marginalia(page_text)
-    return clean_text_for_search(main_text), clean_text_for_search(marginalia_text)
-
-
-def calculate_work_status(page_statuses):
-    """Arvutab teose koondstaatuse lehekülgede staatuste põhjal."""
-    if not page_statuses:
-        return 'Toores'
-    if all(s == 'Valmis' for s in page_statuses):
-        return 'Valmis'
-    if all(s == 'Toores' or not s for s in page_statuses):
-        return 'Toores'
-    return 'Töös'
 
 
 def load_collections():
@@ -172,112 +98,6 @@ def load_archives():
     return {}
 
 
-def build_archive_refs_text(archive_refs, archives):
-    """Koostab otsitava teksti arhiiviviidetest."""
-    if not archive_refs:
-        return None
-    parts = []
-    for ref in archive_refs:
-        if not isinstance(ref, dict):
-            continue
-        archive_id = ref.get('archive_id', '')
-        if archive_id:
-            parts.append(archive_id)
-            archive_name = archives.get(archive_id, {}).get('name', '')
-            if archive_name:
-                parts.append(archive_name)
-        if ref.get('reference'):
-            parts.append(ref['reference'])
-    return ' '.join(parts) if parts else None
-
-
-def build_text_annotations_text(text_annotations):
-    """Koostab otsitava teksti tekst-annotatsioonide kommentaaridest."""
-    if not text_annotations:
-        return None
-    parts = [
-        a['comment']
-        for a in text_annotations
-        if isinstance(a, dict) and a.get('comment')
-    ]
-    return ' '.join(parts) if parts else None
-
-
-def _invert_name(name):
-    """Teisendab 'Perenimi, Eesnimi' → 'Eesnimi Perenimi'. Tagastab None kui komat pole."""
-    if ',' in name:
-        parts = name.split(',', 1)
-        return f"{parts[1].strip()} {parts[0].strip()}"
-    return None
-
-
-def get_creator_aliases(creators, people_data):
-    """Leiab isikutele aliased (nimevariandid).
-    Lisab igale 'Perenimi, Eesnimi' aliasele ka inverteeritud 'Eesnimi Perenimi' versiooni.
-    (Sünk meilisearch_ops-iga — vt MEMORY project_meili_two_index_paths.)"""
-    aliases = []
-    for creator in creators:
-        creator_id = creator.get('id')
-        if creator_id and people_data.get(creator_id):
-            person = people_data[creator_id]
-            for alias in person.get('aliases', []):
-                aliases.append(alias)
-                inverted = _invert_name(alias)
-                if inverted:
-                    aliases.append(inverted)
-    return aliases
-
-
-def get_entity_aliases(entity_or_list, people_data):
-    """Leiab LinkedEntity(te) aliased people.json-ist (trükkal, märksõnad vms).
-    Lisab ka inverteeritud nimevariandid (sünk meilisearch_ops-iga)."""
-    aliases = []
-    items = entity_or_list if isinstance(entity_or_list, list) else ([entity_or_list] if entity_or_list else [])
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        item_id = item.get('id')
-        if item_id and people_data.get(item_id):
-            for alias in people_data[item_id].get('aliases', []):
-                aliases.append(alias)
-                inverted = _invert_name(alias)
-                if inverted:
-                    aliases.append(inverted)
-    return aliases
-
-
-def get_collection_hierarchy(collections, collection_ids):
-    """
-    Tagastab kollektsioonide hierarhia (kõigi kuuluvate kollektsioonide esivanemate union).
-
-    Args:
-        collections: Kõigi kollektsioonide dict
-        collection_ids: Üks ID (str) või list ID-sid
-    """
-    if not collection_ids or not collections:
-        return []
-
-    if isinstance(collection_ids, str):
-        ids = [collection_ids]
-    else:
-        ids = [c for c in collection_ids if c]
-
-    seen = set()
-    result = []
-
-    for cid in ids:
-        current = cid
-        while current:
-            if current not in seen:
-                seen.add(current)
-                result.append(current)
-            col = collections.get(current)
-            current = col.get('parent') if col else None
-
-    return result
-
-
-
 def get_work_metadata(doc_path, dir_name, collections):
     """
     Loeb teose metaandmed _metadata.json failist.
@@ -294,7 +114,7 @@ def get_work_metadata(doc_path, dir_name, collections):
     result = {
         'id': None,
         'slug': sanitize_id(dir_name),
-        'type': 'impressum',
+        'type': None,            # live-tee: metadata.get('type') (vaikimisi None, mitte 'impressum')
         'genre': None,
         'collections': [],
         'collections_hierarchy': [],
@@ -306,7 +126,7 @@ def get_work_metadata(doc_path, dir_name, collections):
         'creators': [],
         'authors_text': [],
         'tags': [],
-        'languages': ['lat'],
+        'languages': [],         # live-tee: metadata.get('languages', [])
         'ester_id': None,
         'external_url': None,
         'archive_refs': [],
@@ -324,7 +144,7 @@ def get_work_metadata(doc_path, dir_name, collections):
                 result['slug'] = meta.get('slug') or meta.get('teose_id', teose_id)
                 teose_id = result['slug']  # Kasuta slug'i teose ID-na
 
-                result['type'] = meta.get('type', 'impressum')
+                result['type'] = meta.get('type')   # live-tee pariteet (vaikimisi None)
                 result['genre'] = meta.get('genre')
                 result['collections'] = meta.get('collections', [])
 
@@ -368,7 +188,7 @@ def get_work_metadata(doc_path, dir_name, collections):
                 # Denormaliseeritud nimed otsinguks
                 result['authors_text'] = [c['name'] for c in creators if c.get('name')]
 
-                result['languages'] = meta.get('languages', ['lat'])
+                result['languages'] = meta.get('languages', [])   # live-tee pariteet (vaikimisi [])
                 result['ester_id'] = meta.get('ester_id')
                 result['external_url'] = meta.get('external_url')
                 result['archive_refs'] = meta.get('archive_refs') or []
@@ -396,6 +216,152 @@ def get_work_metadata(doc_path, dir_name, collections):
     print(f"⚠️  Puudub _metadata.json: {dir_name}")
 
     return teose_id, result
+
+
+def build_work_documents(doc_path, dir_name, collections, people_data, archives, labels_store):
+    """Ehitab ühe teose kõikide lehekülgede Meilisearch dokumendid (seed/reseed-tee).
+
+    Tagastab (teose_id, [dokumendid]). Dokumendid ehitatakse JAGATUD funktsiooniga
+    server.meili_doc._build_page_document — sama, mida kasutab live-tee
+    (server/meilisearch_ops.sync_work_to_meilisearch) — nii et seed ja live EI SAA
+    enam lahku minna (issue #23). teose_staatus lisatakse hiljem (väljundi kirjutamisel),
+    sest see sõltub kõikide lehtede koondstaatusest.
+
+    work_ctx ehitatakse SAMA kujuga nagu live-tees (vt sync_work_to_meilisearch),
+    et _build_page_document annaks mõlemas teed identse dokumendi.
+    """
+    teose_id, doc_metadata = get_work_metadata(doc_path, dir_name, collections)
+
+    # Pildifailid (v.a. thumbnailid), sorteeritud sequence järgi (fallback: tähestik)
+    def _seq(img_name):
+        jp = os.path.join(doc_path, os.path.splitext(img_name)[0] + '.json')
+        if os.path.exists(jp):
+            try:
+                with open(jp, 'r', encoding='utf-8') as fj:
+                    d = json.load(fj)
+                    s = d.get('sequence') or d.get('meta_content', {}).get('sequence')
+                    if s is not None:
+                        return int(s)
+            except Exception:
+                pass
+        return float('inf')
+
+    all_imgs = [f for f in os.listdir(doc_path)
+                if f.lower().endswith(('.jpg', '.jpeg', '.png')) and not f.startswith('_thumb_')]
+    alpha_sorted = sorted(all_imgs)
+    alpha_pos = {f: i for i, f in enumerate(alpha_sorted)}
+
+    def _eff_seq(img_name):
+        s = _seq(img_name)
+        return (alpha_pos[img_name] + 1) * 100 if s == float('inf') else s
+
+    jpg_files = sorted(all_imgs, key=lambda f: (_eff_seq(f), f))
+    if not jpg_files:
+        return teose_id, []
+
+    # Kasuta nanoid't page ID-s (kui olemas), muidu fallback slugile
+    work_id_for_keys = doc_metadata.get('id') or teose_id
+
+    # --- Teose-tasandi kontekst (konstantne üle kõikide lehtede).
+    # Identne live-tee work_ctx-iga, et _build_page_document annaks sama tulemuse. ---
+    creators = doc_metadata.get('creators', [])
+    autor, respondens = compute_autor_respondens(creators)
+
+    # Tags normaliseeritakse (vana string-andmestiku ühtlustus) — nagu live-tee
+    tags = doc_metadata.get('tags', []) or []
+    if isinstance(tags, list):
+        tags = [normalize_genre(t) for t in tags]
+
+    aliases, authors_text, publisher_aliases, tag_aliases = _compute_work_aliases(
+        creators, doc_metadata.get('publisher'), tags, people_data
+    )
+
+    series = doc_metadata.get('series')
+    work_ctx = {
+        'dir_name': dir_name,
+        'dir_path': doc_path,
+        'work_id': work_id_for_keys,
+        'title': doc_metadata.get('title', ''),
+        'autor': autor,
+        'respondens': respondens,
+        'year': doc_metadata.get('year') or 0,   # live: metadata.get('year', 0)
+        'year_display': doc_metadata.get('year_display'),
+        'year_start': doc_metadata.get('year_start', 0),
+        'year_end': doc_metadata.get('year_end', 0),
+        'teose_lehekylgede_arv': len(jpg_files),
+        'tags': tags,
+        'tag_aliases': tag_aliases,
+        'work_collections': doc_metadata.get('collections', []),
+        'collections': collections,
+        'collections_hierarchy': doc_metadata.get('collections_hierarchy', []),
+        'shareable': doc_metadata.get('shareable', False),
+        'location': doc_metadata.get('location'),
+        'publisher': doc_metadata.get('publisher'),
+        'publisher_aliases': publisher_aliases,
+        'genre': doc_metadata.get('genre'),
+        'work_type': doc_metadata.get('type'),
+        'languages': doc_metadata.get('languages', []),  # live: metadata.get('languages', [])
+        'creators': creators,
+        'authors_text': authors_text,
+        'people_data': people_data,
+        'labels_store': labels_store,
+        'ester_id': doc_metadata.get('ester_id'),
+        'external_url': doc_metadata.get('external_url'),
+        'series': series,
+        'series_title': doc_metadata.get('series_title', '') if series else '',
+        'relations': doc_metadata.get('relations'),
+        'archive_refs': doc_metadata.get('archive_refs') or [],
+        '_archives': archives,
+    }
+
+    pages = []
+    for page_index, jpg_filename in enumerate(jpg_files):
+        page_num = page_index + 1
+        page_id = f"{work_id_for_keys}-{page_num}"
+        base_name = os.path.splitext(jpg_filename)[0]
+
+        # Lehe tekst
+        txt_path = os.path.join(doc_path, base_name + '.txt')
+        page_text = ""
+        if os.path.exists(txt_path):
+            try:
+                with open(txt_path, 'r', encoding='utf-8') as f:
+                    page_text = f.read()
+            except Exception:
+                pass
+
+        # Lehe metaandmed (annotatsioonid, staatus)
+        json_path = os.path.join(doc_path, base_name + '.json')
+        page_meta = {
+            'tags': [],
+            'comments': [],
+            'text_annotations': [],
+            'status': 'Toores',
+            'history': []
+        }
+        if os.path.exists(json_path):
+            try:
+                with open(json_path, 'r', encoding='utf-8') as jf:
+                    file_json = json.load(jf)
+                    source = file_json.get('meta_content', file_json)
+                    # tags-fallback: serveril on 35 lehekülge vana 'tags' väljaga (OCR-artefaktid,
+                    # stringid, mitte Q-objektid). Eemaldada pärast nende migreerimist.
+                    page_meta['tags'] = source.get('page_tags', source.get('tags', []))
+                    page_meta['comments'] = source.get('comments', [])
+                    page_meta['text_annotations'] = source.get('text_annotations', [])
+                    page_meta['status'] = source.get('status', 'Toores')
+                    page_meta['history'] = source.get('history', [])
+                    if 'text_content' in file_json and file_json['text_content']:
+                        page_text = file_json['text_content']
+            except Exception as e:
+                print(f"Viga JSON lugemisel {json_path}: {e}")
+
+        doc = _build_page_document(
+            work_ctx, page_id, page_num, page_text, page_meta, jpg_filename, txt_path
+        )
+        pages.append(doc)
+
+    return teose_id, pages
 
 
 def create_meilisearch_data_per_page():
@@ -428,215 +394,11 @@ def create_meilisearch_data_per_page():
 
     for dir_name in tqdm(doc_dirs, desc="Teoste töötlemine"):
         doc_path = os.path.join(DATA_ROOT_DIR, dir_name)
-
-        # Hangi metaandmed (v2 formaat)
-        teose_id, doc_metadata = get_work_metadata(doc_path, dir_name, collections)
-
-        # Isikud ja aliased
-        creators = doc_metadata.get('creators', [])
-        aliases = get_creator_aliases(creators, people_data)
-        authors_text = doc_metadata.get('authors_text', []) + aliases
-
-        # Leia pildifailid (v.a. thumbnailid), sordi sequence järgi
-        def _seq(img_name):
-            jp = os.path.join(doc_path, os.path.splitext(img_name)[0] + '.json')
-            if os.path.exists(jp):
-                try:
-                    with open(jp, 'r', encoding='utf-8') as fj:
-                        d = json.load(fj)
-                        s = d.get('sequence') or d.get('meta_content', {}).get('sequence')
-                        if s is not None:
-                            return int(s)
-                except Exception:
-                    pass
-            return float('inf')
-
-        all_imgs = [f for f in os.listdir(doc_path)
-                    if f.lower().endswith(('.jpg', '.jpeg', '.png')) and not f.startswith('_thumb_')]
-        alpha_sorted = sorted(all_imgs)
-        alpha_pos = {f: i for i, f in enumerate(alpha_sorted)}
-
-        def _eff_seq(img_name):
-            s = _seq(img_name)
-            return (alpha_pos[img_name] + 1) * 100 if s == float('inf') else s
-
-        jpg_files = sorted(all_imgs, key=lambda f: (_eff_seq(f), f))
-        if not jpg_files:
-            continue
-
-        teose_lehekylgede_arv = len(jpg_files)
-
-        pages = []
-        # Kasuta nanoid't page ID-s (kui olemas), muidu fallback slugile
-        work_id_for_keys = doc_metadata.get('id') or teose_id
-        for page_index, jpg_filename in enumerate(jpg_files):
-            page_id = f"{work_id_for_keys}-{page_index + 1}"
-            base_name = os.path.splitext(jpg_filename)[0]
-
-            # Loe tekst
-            txt_path = os.path.join(doc_path, base_name + '.txt')
-            page_text = ""
-            if os.path.exists(txt_path):
-                try:
-                    with open(txt_path, 'r', encoding='utf-8') as f:
-                        page_text = f.read()
-                except Exception:
-                    pass
-
-            # Loe lehekülje metaandmed (annotatsioonid, staatus)
-            json_path = os.path.join(doc_path, base_name + '.json')
-            page_meta = {
-                'tags': [],
-                'comments': [],
-                'text_annotations': [],
-                'status': 'Toores',
-                'history': []
-            }
-
-            if os.path.exists(json_path):
-                try:
-                    with open(json_path, 'r', encoding='utf-8') as jf:
-                        file_json = json.load(jf)
-                        source = file_json.get('meta_content', file_json)
-                        # tags-fallback: serveril on 35 lehekülge vana 'tags' väljaga (OCR-artefaktid, stringid, mitte Q-objektid).
-                        # Eemaldada pärast nende lehekülgede migreerimist või puhastamist.
-                        page_meta['tags'] = source.get('page_tags', source.get('tags', []))
-                        page_meta['comments'] = source.get('comments', [])
-                        page_meta['text_annotations'] = source.get('text_annotations', [])
-                        page_meta['status'] = source.get('status', 'Toores')
-                        page_meta['history'] = source.get('history', [])
-
-                        if 'text_content' in file_json and file_json['text_content']:
-                            page_text = file_json['text_content']
-                except Exception as e:
-                    print(f"Viga JSON lugemisel {json_path}: {e}")
-
-            # Last modified
-            if os.path.exists(txt_path):
-                last_mod = int(os.path.getmtime(txt_path) * 1000)
-            else:
-                last_mod = int(os.path.getmtime(os.path.join(doc_path, jpg_filename)) * 1000)
-
-            image_path = os.path.join(dir_name, jpg_filename)
-            lehekylje_tekst, marginaalia_tekst = _clean_search_text(page_text)
-
-            # Meilisearch dokument (v2/v3 formaat)
-            meili_doc = {
-                # Identifikaatorid
-                'id': page_id,
-                'work_id': work_id_for_keys,  # Kasuta nanoidi või slug'i (nagu page_id-s)
-
-                # Teose andmed (lamedaks lüüdud otsinguks ja kuvamiseks)
-                'title': doc_metadata.get('title', ''),
-                'year': doc_metadata.get('year'),
-                'year_display': doc_metadata.get('year_display'),
-                'year_start': doc_metadata.get('year_start', 0),  # Filtreerimiseks (vahemike kattuvus)
-                'year_end': doc_metadata.get('year_end', 0),
-                'location': get_label(doc_metadata.get('location')),
-                'location_id': get_id(doc_metadata.get('location')),
-                'location_object': doc_metadata.get('location'),
-                'publisher': get_label(doc_metadata.get('publisher')),
-                'publisher_id': get_id(doc_metadata.get('publisher')),
-                'publisher_object': doc_metadata.get('publisher'),
-
-                # Taksonoomia
-                'type': get_label(doc_metadata.get('type', 'impressum')), # Vaikimisi (et)
-                'type_et': get_labels_by_lang(doc_metadata.get('type', 'impressum'), 'et', labels_store),
-                'type_en': get_labels_by_lang(doc_metadata.get('type', 'impressum'), 'en', labels_store),
-                'type_object': doc_metadata.get('type'),
-                'type_ids': get_all_ids(doc_metadata.get('type')),
-                
-                'genre': get_label(doc_metadata.get('genre')), # Vaikimisi (et)
-                'genre_et': get_labels_by_lang(doc_metadata.get('genre'), 'et', labels_store),
-                'genre_en': get_labels_by_lang(doc_metadata.get('genre'), 'en', labels_store),
-                'genre_object': doc_metadata.get('genre'),
-                'genre_search': get_all_labels(doc_metadata.get('genre')),
-                'genre_ids': get_all_ids(doc_metadata.get('genre')),
-                
-                'collections': doc_metadata.get('collections', []),
-                'collections_hierarchy': doc_metadata.get('collections_hierarchy', []),
-                'is_public': any(
-                    collections.get(c, {}).get("visibility", "public") == "public"
-                    for c in doc_metadata.get('collections', [])
-                ) if doc_metadata.get('collections') else True,
-                'shareable': doc_metadata.get('shareable', False),
-
-                # Isikud
-                'creators': creators,
-                'authors_text': authors_text,
-                'author_names': [c['name'] for c in creators if c.get('name') and c.get('role') != 'respondens'],
-                'respondens_names': [c['name'] for c in creators if c.get('name') and c.get('role') == 'respondens'],
-                'creator_ids': [c.get('id') for c in creators if c.get('id')],
-
-                # Täiendav klassifikatsioon (märksõnad)
-                'tags': get_primary_labels(doc_metadata.get('tags', [])), # Vaikimisi (et)
-                'tags_et': get_labels_by_lang(doc_metadata.get('tags', []), 'et', labels_store),
-                'tags_en': get_labels_by_lang(doc_metadata.get('tags', []), 'en', labels_store),
-                'tags_object': doc_metadata.get('tags', []),
-                'tags_search': get_all_labels(doc_metadata.get('tags')) + get_entity_aliases(doc_metadata.get('tags', []), people_data),
-                'tags_ids': get_all_ids(doc_metadata.get('tags')),
-                'languages': doc_metadata.get('languages', ['lat']),
-
-                # Lehekülje andmed
-                'teose_lehekylgede_arv': teose_lehekylgede_arv,
-                'lehekylje_number': page_index + 1,
-                'lehekylje_tekst': lehekylje_tekst,               # OTSING: põhitekst ILMA marginaaliata
-                'marginaalia_tekst': marginaalia_tekst,           # OTSING: marginaalia eraldi väljal (alati olemas, ka tühjana — attributesToSearchOn nõuab)
-                'text_content': page_text,                          # REDAKTORI JAOKS (algne tekst koos kõigi märkidega)
-                'lehekylje_pilt': image_path,
-                'originaal_kataloog': dir_name,
-
-                # Annotatsioonid ja staatus
-                'page_tags': get_primary_labels(page_meta.get('tags', [])),                          # capitalize_first (ühtlane teose tags-iga, sünk meilisearch_ops-iga)
-                'page_tags_et': get_labels_by_lang(page_meta.get('tags', []), 'et', labels_store),
-                'page_tags_en': get_labels_by_lang(page_meta.get('tags', []), 'en', labels_store),
-                'page_tags_ids': get_all_ids(page_meta.get('tags', [])),
-                'page_tags_suggest_et': [
-                    f"{(get_labels_by_lang(t, 'et', labels_store) or [''])[0]}|||{t.get('id') or '' if isinstance(t, dict) else ''}"
-                    for t in page_meta.get('tags', [])
-                ],
-                'page_tags_suggest_en': [
-                    f"{(get_labels_by_lang(t, 'en', labels_store) or [''])[0]}|||{t.get('id') or '' if isinstance(t, dict) else ''}"
-                    for t in page_meta.get('tags', [])
-                ],
-                'page_tags_object': page_meta.get('tags', []),
-                'has_annotations': bool(page_meta.get('tags') or page_meta['comments'] or page_meta['text_annotations']),
-                'comments': page_meta['comments'],
-                'text_annotations': page_meta['text_annotations'],
-                'status': page_meta['status'],
-                'history': page_meta['history'],
-                'last_modified': last_mod,
-            }
-
-            # Valikulised väljad
-            if doc_metadata.get('ester_id'):
-                meili_doc['ester_id'] = doc_metadata['ester_id']
-            if doc_metadata.get('external_url'):
-                meili_doc['external_url'] = doc_metadata['external_url']
-            if doc_metadata.get('series'):
-                meili_doc['series'] = doc_metadata['series']
-                meili_doc['series_title'] = doc_metadata.get('series_title', '')
-            if doc_metadata.get('relations'):
-                meili_doc['relations'] = doc_metadata['relations']
-
-            # Arhiiviviited (alati lisatud, et Meilisearch registreeriks välja)
-            archive_refs = doc_metadata.get('archive_refs') or []
-            if archive_refs:
-                meili_doc['archive_refs'] = archive_refs
-            meili_doc['archive_refs_text'] = build_archive_refs_text(archive_refs, archives) or ''
-
-            # Tekst-annotatsioonid (alati lisatud, et Meilisearch registreeriks välja)
-            meili_doc['text_annotations_text'] = build_text_annotations_text(page_meta['text_annotations']) or ''
-
-            # V3 bibliograafia: täisobjektid on juba location_object/publisher_object väljadel.
-            # Flat location/publisher JÄÄB string-labeliks (filter `publisher = "Vogel"` + display),
-            # sünk meilisearch_ops-iga — ÄRA kirjuta neid siin objektiga üle.
-            meili_doc['location_search'] = get_all_labels(doc_metadata.get('location'))
-            meili_doc['publisher_search'] = get_all_labels(doc_metadata.get('publisher')) + get_entity_aliases(doc_metadata.get('publisher'), people_data)
-
-            pages.append(meili_doc)
-
-        works_data[teose_id] = pages
+        teose_id, pages = build_work_documents(
+            doc_path, dir_name, collections, people_data, archives, labels_store
+        )
+        if pages:
+            works_data[teose_id] = pages
 
     # Kirjuta väljundfail teose staatustega
     print(f"\nArvutan teose staatused ja kirjutan väljundfaili...")

--- a/server/meili_doc.py
+++ b/server/meili_doc.py
@@ -1,0 +1,434 @@
+"""
+Puhas _metadata.json → Meilisearch dokumendi kaardistusloogika (side-effect-vaba).
+
+See moodul sisaldab AINULT puhast kaardistamist (teksti puhastus, aliase arvutus,
+dokumendi ehitamine) — ilma Meili-kliendi, ThreadPoolExecutori, git_opsi või
+Muud raske sõltuvuseta. Sõltub ainult stdlibist (re, os) + server.utils +
+server.marginalia_normalize.
+
+Eesmärk (issue #23): ühine moodul, mida impordivad MÕLEMAD indekseerimisteega:
+  - server/meilisearch_ops.py (live-tee) — otse-import (sama pakett);
+  - scripts/1-1_consolidate_data.py (seed/reseed-tee) — fake-package muster
+    (juba kasutusel `from server.utils import ...` jaoks).
+
+Nii ei saa kaks teed enam vaikselt lahku minna (varem olid split_marginalia,
+clean_text_for_search jms dubleeritud). Divergeerumine on nüüd konstruktsiooni
+järgi võimatu.
+
+Väljanimede ORTOGRAAFIA: Meilisearch kasutab vanemat 'y'-ortograafiat
+(lehekylje_tekst, teose_lehekylgede_arv jne). Neid EI TOHI ümber nimetada —
+otsingufiltrid eeldavad neid (vt issue #16, CLAUDE.md).
+"""
+import os
+import re
+
+from .utils import (
+    get_label, get_id, get_all_labels, get_all_ids, get_primary_labels,
+    get_labels_by_lang,
+)
+from .marginalia_normalize import normalize_marginalia_tags
+
+
+# =========================================================
+# TEKSTI PUHASTUS (otsinguindeksi jaoks)
+# =========================================================
+
+# <m>...</m> marginaalia plokkide regex. [\s\S]*? → mitmerealune, mitteahne.
+M_CONTENT_RE = re.compile(r'<m>([\s\S]*?)</m>')
+
+
+def split_marginalia(text):
+    """Eraldab marginaalia plokid põhitekstist enne indekseerimist.
+
+    Tagastab (põhitekst ilma <m>-plokkideta, marginaaliate sisu reavahetustega liidetult).
+    Põhiteksti fraasid jätkuvad üle eemaldatud ploki koha — clean_text_for_search
+    liidab poolitused ja kollapsib tühikud ka mitme järjestikuse reavahetuse korral.
+    """
+    if not text:
+        return "", ""
+    # Normaliseeri ristuvad/mässitud <m>-tägid (<i><m>X</i></m> → <m><i>X</i></m>)
+    # enne eraldamist — muidu jääks orv inline-täg põhiteksti / marginaaliasse.
+    text = normalize_marginalia_tags(text)
+    notes = M_CONTENT_RE.findall(text)
+    # Tühik (mitte tühi string) väldib inline <m> korral ümbritsevate sõnade kokkuliimimist
+    # (nt "foo<m>note</m>bar" → "foo bar", mitte "foobar")
+    main = M_CONTENT_RE.sub(' ', text)
+    return main, "\n".join(notes)
+
+
+def clean_text_for_search(text):
+    """Puhastab teksti otsinguindeksi jaoks, eemaldades vormindusmärgid ja liites poolitused.
+
+    Toetab mõlemat märgendusformaati:
+    - Uus XML: <i>, <b>, <cs>, <m>, <hi>, <fn>n</fn>, <pb/>
+    - Vana pseudo-markdown: *italic*, **bold*, ~cs~, [[m:text]], --lk--, [^n]
+    """
+    if not text:
+        return ""
+
+    # 1. Uus XML märgendus — eemalda kõik VUTT tägid
+    # <fn>n</fn> ja <pb/> asendame tühikuga, ülejäänud tägid eemaldame
+    text = re.sub(r'<fn>\d+</fn>', ' ', text)  # joonealuse viite marker
+    text = re.sub(r'<pb/>', ' ', text)           # leheküljevahetus
+    text = re.sub(r'</?[a-z]+\d*>', '', text)    # avamis/sulgemistägid (<i>, </i>, <cs>, <ann1>, </ann1> jne)
+
+    # 2. Vana pseudo-markdown (legacy, kui faile pole veel migreeritud)
+    text = text.replace('*', ' ')               # bold/italic tärnid
+    text = text.replace('~', ' ')               # koodivahetus
+    text = text.replace('[[m:', ' ').replace(']]', ' ')  # ääremärkus
+    text = text.replace('--lk--', ' ')          # leheküljevahetus
+    text = re.sub(r'\[\^\d+\]', ' ', text)      # joonealuse viite marker
+
+    # 3. Käitle reavahetuse poolituskriipse PÄRAST tägide eemaldamist
+    # (nt "<i>Sueco¬</i>\n<i>rum" -> pärast tägide eemaldust "Sueco¬\nrum" -> "Suecorum")
+    text = re.sub(r'[-⸗¬]\s*\n\s*', '', text)
+
+    # 4. Eemalda üleliigsed tühikud
+    text = re.sub(r'\s+', ' ', text).strip()
+
+    return text
+
+
+def _clean_search_text(page_text):
+    """Eraldab marginaalia ja puhastab mõlemad osad otsinguindeksi jaoks.
+
+    Võtab toore lehekülje teksti (raw editoritekst) ja tagastab tuple
+    (põhitekst_puhastatud, marginaalia_puhastatud), kus:
+    - põhitekst = marginaalia `<m>`-plokidest vabastatud ja vormindusmärkidest
+      puhastatud (poolitused liidetud, ws kollapseeritud) — otsinguks `lehekylje_tekst`;
+    - marginaalia = `<m>`-plokkide sisu samuti puhastatud — otsinguks `marginaalia_tekst`.
+
+    Kombineerib `split_marginalia` (eraldab plokid, sh ristuvad tägiga) ja
+    `clean_text_for_search` (eemaldab XML/markdown märgid, liidab poolitused).
+    """
+    main_text, marginalia_text = split_marginalia(page_text)
+    return clean_text_for_search(main_text), clean_text_for_search(marginalia_text)
+
+
+def build_text_annotations_text(text_annotations):
+    """Koostab otsitava teksti text_annotations kommentaaridest.
+
+    Tagastab None kui annotatsioonid puuduvad (väli jäetakse dokumendist välja).
+    """
+    if not text_annotations:
+        return None
+    parts = [
+        a["comment"]
+        for a in text_annotations
+        if isinstance(a, dict) and a.get("comment")
+    ]
+    return " ".join(parts) if parts else None
+
+
+# =========================================================
+# ISIKUTE ALIASED JA NORMALISEERIMINE
+# =========================================================
+
+def _invert_name(name: str):
+    """Teisendab 'Perenimi, Eesnimi' → 'Eesnimi Perenimi'. Tagastab None kui komat pole."""
+    if ',' in name:
+        parts = name.split(',', 1)
+        return f"{parts[1].strip()} {parts[0].strip()}"
+    return None
+
+
+def compute_autor_respondens(creators):
+    """Tuletab teose 'autor' ja 'respondens' kuvaväljad creators-massiivist.
+
+    Autori prioriteet: auctor > praeses > esimene isik (kui esimene EI OLE
+    respondens/gratulator/dedicator/editor/aui). Respondens = esimene respondens-roll.
+    Tagastab (autor, respondens) tuple (tühjad stringid kui puuduvad).
+
+    NB: hoia loogika ÜHISENA — seda kutsuvad nii live (meilisearch_ops.sync_work)
+    kui seed (1-1_consolidate_data) work_ctx ehitamisel (vt issue #23).
+    """
+    autor = ''
+    respondens = ''
+    if not creators:
+        return autor, respondens
+    praeses = next((c for c in creators if c.get('role') == 'praeses'), None)
+    auctor = next((c for c in creators if c.get('role') == 'auctor'), None)
+    resp = next((c for c in creators if c.get('role') == 'respondens'), None)
+    if auctor:
+        autor = auctor.get('name', '')
+    elif praeses:
+        autor = praeses.get('name', '')
+    else:
+        first_creator = creators[0]
+        if first_creator.get('role') not in ['respondens', 'gratulator', 'dedicator', 'editor', 'aui']:
+            autor = first_creator.get('name', '')
+    if resp:
+        respondens = resp.get('name', '')
+    return autor, respondens
+
+
+def get_creator_aliases(creators, people_data):
+    """Leiab isikutele aliased (nimevariandid).
+    Lisab igale 'Perenimi, Eesnimi' aliasele ka inverteeritud 'Eesnimi Perenimi' versiooni."""
+    aliases = []
+    for creator in creators:
+        creator_id = creator.get('id')
+        if creator_id and people_data.get(creator_id):
+            person = people_data[creator_id]
+            for alias in person.get('aliases', []):
+                aliases.append(alias)
+                inverted = _invert_name(alias)
+                if inverted:
+                    aliases.append(inverted)
+    return aliases
+
+
+def normalize_creator(creator, people_data):
+    """Normaliseerib isiku nime ja ID people.json kaudu.
+
+    Tagastab (kanooniline_nimi, eelistatud_id) tuple.
+    Eelistab Wikidata Q-koodi teiste ID-de üle.
+    """
+    cid = creator.get('id')
+    name = creator.get('name', '')
+
+    if not cid or not people_data or cid not in people_data:
+        return name, cid
+
+    person = people_data[cid]
+    canonical_name = person.get('primary_name', name)
+
+    # Eelistatavalt Wikidata Q-kood
+    ids = person.get('ids', {})
+    wikidata_id = ids.get('wikidata')
+    if wikidata_id:
+        # Veendu et Q-prefiks on olemas
+        best_id = wikidata_id if wikidata_id.startswith('Q') else f'Q{wikidata_id}'
+    else:
+        best_id = cid
+
+    return canonical_name, best_id
+
+
+def _compute_work_aliases(creators, publisher, tags, people_data):
+    """Arvutab work-level aliased ja authors_text ühe teose jaoks.
+
+    Need väärtused sõltuvad AINULT teose metadatast (creators/publisher/tags +
+    people register), mitte konkreetsest lehest — seega arvutatakse üks kord
+    enne lehtede tsüklit, mitte igal lehel uuesti (vt issue #16 refaktoor).
+
+    Tagastab (aliases, authors_text, publisher_aliases, tag_aliases):
+    - aliases: kõikide creatorite nimevariandid (+ invereedid 'Pere, Ees' → 'Ees Pere');
+    - authors_text: creatorite nimed + aliased (otsingu jaoks, nt 'Lorenz' → 'Laurentius');
+    - publisher_aliases: trükkali nimevariandid;
+    - tag_aliases: isiku-märksõnade nimevariandid (nt 'Ludenius' → 'Luden').
+    """
+    aliases = get_creator_aliases(creators, people_data)
+    authors_text = [c['name'] for c in creators if c.get('name')] + aliases
+
+    # Trükkali aliased (trükkalid on ka mitme nimega)
+    publisher_aliases = []
+    pub_id = get_id(publisher)
+    if pub_id and people_data.get(pub_id):
+        for alias in people_data[pub_id].get('aliases', []):
+            publisher_aliases.append(alias)
+            inverted = _invert_name(alias)
+            if inverted:
+                publisher_aliases.append(inverted)
+
+    # Märksõna aliased (isiku märksõnade nimevariandid)
+    tag_aliases = []
+    for tag in tags if isinstance(tags, list) else []:
+        tag_id = get_id(tag) if isinstance(tag, dict) else None
+        if tag_id and people_data.get(tag_id):
+            for alias in people_data[tag_id].get('aliases', []):
+                tag_aliases.append(alias)
+                inverted = _invert_name(alias)
+                if inverted:
+                    tag_aliases.append(inverted)
+
+    return aliases, authors_text, publisher_aliases, tag_aliases
+
+
+# =========================================================
+# KOLLEKTSIOONIDE HIERARHIA
+# =========================================================
+
+def get_collection_hierarchy(collections, collection_ids):
+    """Tagastab kollektsioonide hierarhia (kõigi kuuluvate kollektsioonide esivanemate union).
+
+    Args:
+        collections: Kõigi kollektsioonide dict (state/collections.json)
+        collection_ids: Üks kollektsiooni ID (str) või list ID-sid
+
+    Returns:
+        Kõigi kollektsioonide ja nende esivanemate ID-de list (duplikaadid eemaldatud)
+    """
+    if not collection_ids or not collections:
+        return []
+
+    # Normaliseeri listiks
+    if isinstance(collection_ids, str):
+        ids = [collection_ids]
+    else:
+        ids = [c for c in collection_ids if c]
+
+    seen = set()
+    result = []
+
+    for cid in ids:
+        current = cid
+        while current:
+            if current not in seen:
+                seen.add(current)
+                result.append(current)
+            col = collections.get(current)
+            current = col.get('parent') if col else None
+
+    return result
+
+
+# =========================================================
+# LEHE DOKUMENDI EHITAMINE
+# =========================================================
+
+def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_name, txt_path):
+    """Ehitab ühe lehekülje Meilisearch dokumendi.
+
+    work_ctx sisaldab teose-tasandi konstantseid väärtusi (konstantsed üle kõikide
+    lehtede — ehitatud üks kord enne lehtede tsüklit sync_work_to_meilisearch-is).
+    Lehe-spetsiifilised sisendid (page_num/page_text/page_meta/img_name/txt_path)
+    eraldi, sest need muutuvad lehe kaupa.
+
+    NB: Meilisearchi väljanimesid (vanem 'y'-ortograafia: lehekylje_tekst,
+    teose_lehekylgede_arv jne) EI TOHI ümber nimetada — otsingufiltrid eeldavad
+    neid (vt issue #16).
+    """
+    page_tags_data = page_meta.get('tags', [])
+    lehekylje_tekst, marginaalia_tekst = _clean_search_text(page_text)
+
+    dir_name = work_ctx['dir_name']
+    dir_path = work_ctx['dir_path']
+    labels_store = work_ctx['labels_store']
+    people_data = work_ctx['people_data']
+    creators = work_ctx['creators']
+    tags = work_ctx['tags']
+
+    doc = {
+        "id": page_id,
+        "work_id": work_ctx['work_id'],  # Nanoid (püsiv lühikood)
+        "title": work_ctx['title'],
+        "autor": work_ctx['autor'],      # Filtreerimiseks (jääb)
+        "respondens": work_ctx['respondens'],  # Filtreerimiseks (jääb)
+        "aasta": work_ctx['year'],       # Filtreerimiseks ja sortimiseks (jääb)
+        "year": work_ctx['year'],
+        "year_display": work_ctx['year_display'],
+        "year_start": work_ctx['year_start'],  # Filtreerimiseks (vahemike kattuvus)
+        "year_end": work_ctx['year_end'],
+        "lehekylje_number": page_num,
+        "teose_lehekylgede_arv": work_ctx['teose_lehekylgede_arv'],
+        "lehekylje_tekst": lehekylje_tekst,               # OTSING: põhitekst ILMA marginaaliata
+        "marginaalia_tekst": marginaalia_tekst,           # OTSING: marginaalia eraldi väljal (alati olemas, ka tühjana — attributesToSearchOn nõuab)
+        "text_content": page_text,                             # REDAKTOR: algne tekst koos kõigi märkidega
+        "lehekylje_pilt": os.path.join(dir_name, img_name),
+        "originaal_kataloog": dir_name,
+        "status": page_meta['status'],
+        "page_tags": get_primary_labels(page_tags_data),                          # Eesti label, capitalize_first (teose tags-iga ühtlane)
+        "page_tags_et": get_labels_by_lang(page_tags_data, 'et', labels_store), # Eesti label, capitalize_first
+        "page_tags_en": get_labels_by_lang(page_tags_data, 'en', labels_store), # Inglise label, capitalize_first
+        "page_tags_ids": get_all_ids(page_tags_data),              # Q-koodid (filtreeritav, nagu tags_ids)
+        "page_tags_suggest_et": [
+            f"{(get_labels_by_lang(t, 'et', labels_store) or [''])[0]}|||{t.get('id') or '' if isinstance(t, dict) else ''}"
+            for t in page_tags_data
+        ],
+        "page_tags_suggest_en": [
+            f"{(get_labels_by_lang(t, 'en', labels_store) or [''])[0]}|||{t.get('id') or '' if isinstance(t, dict) else ''}"
+            for t in page_tags_data
+        ],
+        "page_tags_object": page_tags_data,
+        "has_annotations": bool(page_tags_data or page_meta['comments'] or page_meta['text_annotations']),
+        "comments": page_meta['comments'],
+        "text_annotations": page_meta['text_annotations'],
+        "history": page_meta['history'],
+        "last_modified": int(os.path.getmtime(txt_path if os.path.exists(txt_path) else os.path.join(dir_path, img_name)) * 1000),
+        "tags": get_primary_labels(tags),
+        "tags_et": get_labels_by_lang(tags, 'et', labels_store),
+        "tags_en": get_labels_by_lang(tags, 'en', labels_store),
+        "tags_object": tags,
+        "tags_search": get_all_labels(tags) + work_ctx['tag_aliases'],
+        "tags_ids": get_all_ids(tags),
+        "collections": work_ctx['work_collections'],
+        "collections_hierarchy": work_ctx['collections_hierarchy'],
+        "is_public": any(
+            work_ctx['collections'].get(c, {}).get("visibility", "public") == "public"
+            for c in work_ctx['work_collections']
+        ) if work_ctx['work_collections'] else True,
+        "shareable": work_ctx['shareable'],
+        "location": get_label(work_ctx['location']),
+        "location_object": work_ctx['location'],
+        "location_id": get_id(work_ctx['location']),
+        "location_search": get_all_labels(work_ctx['location']),
+        "publisher": get_label(work_ctx['publisher']),
+        "publisher_object": work_ctx['publisher'],
+        "publisher_id": get_id(work_ctx['publisher']),
+        "publisher_search": get_all_labels(work_ctx['publisher']) + work_ctx['publisher_aliases'],
+        "genre": get_label(work_ctx['genre']),
+        "genre_et": get_labels_by_lang(work_ctx['genre'], 'et', labels_store),
+        "genre_en": get_labels_by_lang(work_ctx['genre'], 'en', labels_store),
+        "genre_object": work_ctx['genre'],
+        "genre_search": get_all_labels(work_ctx['genre']),
+        "genre_ids": get_all_ids(work_ctx['genre']),
+        "type": get_label(work_ctx['work_type']),
+        "type_et": get_labels_by_lang(work_ctx['work_type'], 'et', labels_store),
+        "type_en": get_labels_by_lang(work_ctx['work_type'], 'en', labels_store),
+        "type_object": work_ctx['work_type'],
+        "type_ids": get_all_ids(work_ctx['work_type']),
+        "languages": work_ctx['languages'],
+        "creators": creators,
+        "authors_text": work_ctx['authors_text'],
+        "author_names": list(dict.fromkeys(
+            name for c in creators
+            if c.get('name') and c.get('role') != 'respondens'
+            for name in ([normalize_creator(c, people_data)[0], c['name']] if normalize_creator(c, people_data)[0] != c['name'] else [c['name']])
+        )),
+        "respondens_names": list(dict.fromkeys(
+            name for c in creators
+            if c.get('name') and c.get('role') == 'respondens'
+            for name in ([normalize_creator(c, people_data)[0], c['name']] if normalize_creator(c, people_data)[0] != c['name'] else [c['name']])
+        )),
+        "creator_ids": [normalize_creator(c, people_data)[1] for c in creators if c.get('id')]
+        # NB: pealkiri, koht, trükkal eemaldatud - kasuta title, location, publisher
+    }
+
+    if work_ctx['ester_id']:
+        doc['ester_id'] = work_ctx['ester_id']
+    if work_ctx['external_url']:
+        doc['external_url'] = work_ctx['external_url']
+
+    # Seeria ja relatsioonid (kuvamiseks; frontend loeb hit.series/series_title/relations).
+    # .get() — vanad work_ctx-id (nt osatestid) ei pruugi neid sisaldada.
+    if work_ctx.get('series'):
+        doc['series'] = work_ctx['series']
+        doc['series_title'] = work_ctx.get('series_title', '')
+    if work_ctx.get('relations'):
+        doc['relations'] = work_ctx['relations']
+
+    if work_ctx['archive_refs']:
+        doc['archive_refs'] = work_ctx['archive_refs']
+        # Denormaliseeritud otsingutekst: kood + arhiivi täisnimi + viide
+        parts = []
+        for ref in work_ctx['archive_refs']:
+            if not isinstance(ref, dict):
+                continue
+            archive_id = ref.get('archive_id', '')
+            if archive_id:
+                parts.append(archive_id)
+                archive_name = work_ctx['_archives'].get(archive_id, {}).get('name', '')
+                if archive_name:
+                    parts.append(archive_name)
+            if ref.get('reference'):
+                parts.append(ref['reference'])
+        if parts:
+            doc['archive_refs_text'] = ' '.join(parts)
+
+    text_anns = page_meta.get('text_annotations') or []
+    ann_text = build_text_annotations_text(text_anns)
+    if ann_text is not None:
+        doc['text_annotations_text'] = ann_text
+
+    return doc

--- a/server/meilisearch_ops.py
+++ b/server/meilisearch_ops.py
@@ -48,97 +48,17 @@ logger = get_logger(__name__)
 # Meilisearch päringu timeout sekundites
 MEILI_TIMEOUT = 10
 from .git_ops import commit_new_work_to_git
-import re
 
-M_CONTENT_RE = re.compile(r'<m>([\s\S]*?)</m>')
-
-from .marginalia_normalize import normalize_marginalia_tags
-
-
-def split_marginalia(text):
-    """Eraldab marginaalia plokid põhitekstist enne indekseerimist.
-
-    Tagastab (põhitekst ilma <m>-plokkideta, marginaaliate sisu reavahetustega liidetult).
-    Põhiteksti fraasid jätkuvad üle eemaldatud ploki koha — clean_text_for_search
-    liidab poolitused ja kollapsib tühikud ka mitme järjestikuse reavahetuse korral.
-    NB: hoia SÜNKROONIS scripts/1-1_consolidate_data.py koopiaga!
-    """
-    if not text:
-        return "", ""
-    # Normaliseeri ristuvad/mässitud <m>-tägid (<i><m>X</i></m> → <m><i>X</i></m>)
-    # enne eraldamist — muidu jääks orv inline-täg põhiteksti / marginaaliasse.
-    text = normalize_marginalia_tags(text)
-    notes = M_CONTENT_RE.findall(text)
-    # Tühik (mitte tühi string) väldib inline <m> korral ümbritsevate sõnade kokkuliimimist
-    # (nt "foo<m>note</m>bar" → "foo bar", mitte "foobar")
-    main = M_CONTENT_RE.sub(' ', text)
-    return main, "\n".join(notes)
-
-
-def clean_text_for_search(text):
-    """Puhastab teksti otsinguindeksi jaoks, eemaldades vormindusmärgid ja liites poolitused.
-
-    Toetab mõlemat märgendusformaati:
-    - Uus XML: <i>, <b>, <cs>, <m>, <hi>, <fn>n</fn>, <pb/>
-    - Vana pseudo-markdown: *italic*, **bold**, ~cs~, [[m:text]], --lk--, [^n]
-    """
-    if not text:
-        return ""
-
-    # 1. Uus XML märgendus — eemalda kõik VUTT tägid
-    # <fn>n</fn> ja <pb/> asendame tühikuga, ülejäänud tägid eemaldame
-    text = re.sub(r'<fn>\d+</fn>', ' ', text)  # joonealuse viite marker
-    text = re.sub(r'<pb/>', ' ', text)           # leheküljevahetus
-    text = re.sub(r'</?[a-z]+\d*>', '', text)    # avamis/sulgemistägid (<i>, </i>, <cs>, <ann1>, </ann1> jne)
-
-    # 2. Vana pseudo-markdown (legacy, kui faile pole veel migreeritud)
-    text = text.replace('*', ' ')               # bold/italic tärnid
-    text = text.replace('~', ' ')               # koodivahetus
-    text = text.replace('[[m:', ' ').replace(']]', ' ')  # ääremärkus
-    text = text.replace('--lk--', ' ')          # leheküljevahetus
-    text = re.sub(r'\[\^\d+\]', ' ', text)      # joonealuse viite marker
-
-    # 3. Käitle reavahetuse poolituskriipse PÄRAST tägide eemaldamist
-    # (nt "<i>Sueco¬</i>\n<i>rum" -> pärast tägide eemaldust "Sueco¬\nrum" -> "Suecorum")
-    text = re.sub(r'[-⸗¬]\s*\n\s*', '', text)
-
-    # 4. Eemalda üleliigsed tühikud
-    text = re.sub(r'\s+', ' ', text).strip()
-
-    return text
-
-
-def build_text_annotations_text(text_annotations):
-    """Koostab otsitava teksti text_annotations kommentaaridest.
-
-    Tagastab None kui annotatsioonid puuduvad (väli jäetakse dokumendist välja).
-    """
-    if not text_annotations:
-        return None
-    parts = [
-        a["comment"]
-        for a in text_annotations
-        if isinstance(a, dict) and a.get("comment")
-    ]
-    return " ".join(parts) if parts else None
-
-
-def _clean_search_text(page_text):
-    """Eraldab marginaalia ja puhastab mõlemad osad otsinguindeksi jaoks.
-
-    Võtab toore lehekülje teksti (raw editoritekst) ja tagastab tuple
-    (põhitekst_puhastatud, marginaalia_puhastatud), kus:
-    - põhitekst = marginaalia `<m>`-plokidest vabastatud ja vormindusmärkidest
-      puhastatud (poolitused liidetud, ws kollapseeritud) — otsinguks `lehekylje_tekst`;
-    - marginaalia = `<m>`-plokkide sisu samuti puhastatud — otsinguks `marginaalia_tekst`.
-
-    Kombineerib `split_marginalia` (eraldab plokid, sh ristuvad tägiga) ja
-    `clean_text_for_search` (eemaldab XML/markdown märgid, liidab poolitused).
-    NB: hoia SÜNKROONIS scripts/1-1_consolidate_data.py _clean_search_text-iga
-    (seed/reseed-tee pariteet — vt issue #16).
-    """
-    main_text, marginalia_text = split_marginalia(page_text)
-    return clean_text_for_search(main_text), clean_text_for_search(marginalia_text)
+# Puhtad kaardistusfunktsioonid (teksti puhastus, aliased, dokumendi ehitamine) elavad
+# nüüd side-effect-vabas moodulis server/meili_doc.py (issue #23) — neid impordivad
+# nii see live-tee kui scripts/1-1_consolidate_data.py seed/reseed-tee, et kaks teed
+# ei saaks vaikselt lahku minna. Re-eksporditakse siit tagasiühilduvuseks.
+from .meili_doc import (
+    M_CONTENT_RE, split_marginalia, clean_text_for_search, build_text_annotations_text,
+    _clean_search_text, _invert_name, get_creator_aliases, normalize_creator,
+    _compute_work_aliases, get_collection_hierarchy, _build_page_document,
+    compute_autor_respondens,
+)
 
 
 def load_people_aliases():
@@ -163,235 +83,6 @@ def load_labels_store():
     return {}
 
 
-def _invert_name(name: str):
-    """Teisendab 'Perenimi, Eesnimi' → 'Eesnimi Perenimi'. Tagastab None kui komat pole."""
-    if ',' in name:
-        parts = name.split(',', 1)
-        return f"{parts[1].strip()} {parts[0].strip()}"
-    return None
-
-
-def get_creator_aliases(creators, people_data):
-    """Leiab isikutele aliased (nimevariandid).
-    Lisab igale 'Perenimi, Eesnimi' aliasele ka inverteeritud 'Eesnimi Perenimi' versiooni."""
-    aliases = []
-    for creator in creators:
-        creator_id = creator.get('id')
-        if creator_id and people_data.get(creator_id):
-            person = people_data[creator_id]
-            for alias in person.get('aliases', []):
-                aliases.append(alias)
-                inverted = _invert_name(alias)
-                if inverted:
-                    aliases.append(inverted)
-    return aliases
-
-
-def normalize_creator(creator, people_data):
-    """Normaliseerib isiku nime ja ID people.json kaudu.
-
-    Tagastab (kanooniline_nimi, eelistatud_id) tuple.
-    Eelistab Wikidata Q-koodi teiste ID-de üle.
-    """
-    cid = creator.get('id')
-    name = creator.get('name', '')
-
-    if not cid or not people_data or cid not in people_data:
-        return name, cid
-
-    person = people_data[cid]
-    canonical_name = person.get('primary_name', name)
-
-    # Eelistatavalt Wikidata Q-kood
-    ids = person.get('ids', {})
-    wikidata_id = ids.get('wikidata')
-    if wikidata_id:
-        # Veendu et Q-prefiks on olemas
-        best_id = wikidata_id if wikidata_id.startswith('Q') else f'Q{wikidata_id}'
-    else:
-        best_id = cid
-
-    return canonical_name, best_id
-
-
-def _compute_work_aliases(creators, publisher, tags, people_data):
-    """Arvutab work-level aliased ja authors_text ühe teose jaoks.
-
-    Need väärtused sõltuvad AINULT teose metadatast (creators/publisher/tags +
-    people register), mitte konkreetsest lehest — seega arvutatakse üks kord
-    enne lehtede tsüklit, mitte igal lehel uuesti (vt issue #16 refaktoor).
-
-    Tagastab (aliases, authors_text, publisher_aliases, tag_aliases):
-    - aliases: kõikide creatorite nimevariandid (+ invereedid 'Pere, Ees' → 'Ees Pere');
-    - authors_text: creatorite nimed + aliased (otsingu jaoks, nt 'Lorenz' → 'Laurentius');
-    - publisher_aliases: trükkali nimevariandid;
-    - tag_aliases: isiku-märksõnade nimevariandid (nt 'Ludenius' → 'Luden').
-    """
-    aliases = get_creator_aliases(creators, people_data)
-    authors_text = [c['name'] for c in creators if c.get('name')] + aliases
-
-    # Trükkali aliased (trükkalid on ka mitme nimega)
-    publisher_aliases = []
-    pub_id = get_id(publisher)
-    if pub_id and people_data.get(pub_id):
-        for alias in people_data[pub_id].get('aliases', []):
-            publisher_aliases.append(alias)
-            inverted = _invert_name(alias)
-            if inverted:
-                publisher_aliases.append(inverted)
-
-    # Märksõna aliased (isiku märksõnade nimevariandid)
-    tag_aliases = []
-    for tag in tags if isinstance(tags, list) else []:
-        tag_id = get_id(tag) if isinstance(tag, dict) else None
-        if tag_id and people_data.get(tag_id):
-            for alias in people_data[tag_id].get('aliases', []):
-                tag_aliases.append(alias)
-                inverted = _invert_name(alias)
-                if inverted:
-                    tag_aliases.append(inverted)
-
-    return aliases, authors_text, publisher_aliases, tag_aliases
-
-
-def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_name, txt_path):
-    """Ehitab ühe lehekülje Meilisearch dokumendi.
-
-    work_ctx sisaldab teose-tasandi konstantseid väärtusi (konstantsed üle kõikide
-    lehtede — ehitatud üks kord enne lehtede tsüklit sync_work_to_meilisearch-is).
-    Lehe-spetsiifilised sisendid (page_num/page_text/page_meta/img_name/txt_path)
-    eraldi, sest need muutuvad lehe kaupa.
-
-    NB: Meilisearchi väljanimesid (vanem 'y'-ortograafia: lehekylje_tekst,
-    teose_lehekylgede_arv jne) EI TOHI ümber nimetada — otsingufiltrid eeldavad
-    neid (vt issue #16). Hoia SÜNKROONIS scripts/1-1_consolidate_data.py-ga (issue #23).
-    """
-    page_tags_data = page_meta.get('tags', [])
-    lehekylje_tekst, marginaalia_tekst = _clean_search_text(page_text)
-
-    dir_name = work_ctx['dir_name']
-    dir_path = work_ctx['dir_path']
-    labels_store = work_ctx['labels_store']
-    people_data = work_ctx['people_data']
-    creators = work_ctx['creators']
-    tags = work_ctx['tags']
-
-    doc = {
-        "id": page_id,
-        "work_id": work_ctx['work_id'],  # Nanoid (püsiv lühikood)
-        "title": work_ctx['title'],
-        "autor": work_ctx['autor'],      # Filtreerimiseks (jääb)
-        "respondens": work_ctx['respondens'],  # Filtreerimiseks (jääb)
-        "aasta": work_ctx['year'],       # Filtreerimiseks ja sortimiseks (jääb)
-        "year": work_ctx['year'],
-        "year_display": work_ctx['year_display'],
-        "year_start": work_ctx['year_start'],  # Filtreerimiseks (vahemike kattuvus)
-        "year_end": work_ctx['year_end'],
-        "lehekylje_number": page_num,
-        "teose_lehekylgede_arv": work_ctx['teose_lehekylgede_arv'],
-        "lehekylje_tekst": lehekylje_tekst,               # OTSING: põhitekst ILMA marginaaliata
-        "marginaalia_tekst": marginaalia_tekst,           # OTSING: marginaalia eraldi väljal (alati olemas, ka tühjana — attributesToSearchOn nõuab)
-        "text_content": page_text,                             # REDAKTOR: algne tekst koos kõigi märkidega
-        "lehekylje_pilt": os.path.join(dir_name, img_name),
-        "originaal_kataloog": dir_name,
-        "status": page_meta['status'],
-        "page_tags": get_primary_labels(page_tags_data),                          # Eesti label, capitalize_first (teose tags-iga ühtlane)
-        "page_tags_et": get_labels_by_lang(page_tags_data, 'et', labels_store), # Eesti label, capitalize_first
-        "page_tags_en": get_labels_by_lang(page_tags_data, 'en', labels_store), # Inglise label, capitalize_first
-        "page_tags_ids": get_all_ids(page_tags_data),              # Q-koodid (filtreeritav, nagu tags_ids)
-        "page_tags_suggest_et": [
-            f"{(get_labels_by_lang(t, 'et', labels_store) or [''])[0]}|||{t.get('id') or '' if isinstance(t, dict) else ''}"
-            for t in page_tags_data
-        ],
-        "page_tags_suggest_en": [
-            f"{(get_labels_by_lang(t, 'en', labels_store) or [''])[0]}|||{t.get('id') or '' if isinstance(t, dict) else ''}"
-            for t in page_tags_data
-        ],
-        "page_tags_object": page_tags_data,
-        "has_annotations": bool(page_tags_data or page_meta['comments'] or page_meta['text_annotations']),
-        "comments": page_meta['comments'],
-        "text_annotations": page_meta['text_annotations'],
-        "history": page_meta['history'],
-        "last_modified": int(os.path.getmtime(txt_path if os.path.exists(txt_path) else os.path.join(dir_path, img_name)) * 1000),
-        "tags": get_primary_labels(tags),
-        "tags_et": get_labels_by_lang(tags, 'et', labels_store),
-        "tags_en": get_labels_by_lang(tags, 'en', labels_store),
-        "tags_object": tags,
-        "tags_search": get_all_labels(tags) + work_ctx['tag_aliases'],
-        "tags_ids": get_all_ids(tags),
-        "collections": work_ctx['work_collections'],
-        "collections_hierarchy": work_ctx['collections_hierarchy'],
-        "is_public": any(
-            work_ctx['collections'].get(c, {}).get("visibility", "public") == "public"
-            for c in work_ctx['work_collections']
-        ) if work_ctx['work_collections'] else True,
-        "shareable": work_ctx['shareable'],
-        "location": get_label(work_ctx['location']),
-        "location_object": work_ctx['location'],
-        "location_id": get_id(work_ctx['location']),
-        "location_search": get_all_labels(work_ctx['location']),
-        "publisher": get_label(work_ctx['publisher']),
-        "publisher_object": work_ctx['publisher'],
-        "publisher_id": get_id(work_ctx['publisher']),
-        "publisher_search": get_all_labels(work_ctx['publisher']) + work_ctx['publisher_aliases'],
-        "genre": get_label(work_ctx['genre']),
-        "genre_et": get_labels_by_lang(work_ctx['genre'], 'et', labels_store),
-        "genre_en": get_labels_by_lang(work_ctx['genre'], 'en', labels_store),
-        "genre_object": work_ctx['genre'],
-        "genre_search": get_all_labels(work_ctx['genre']),
-        "genre_ids": get_all_ids(work_ctx['genre']),
-        "type": get_label(work_ctx['work_type']),
-        "type_et": get_labels_by_lang(work_ctx['work_type'], 'et', labels_store),
-        "type_en": get_labels_by_lang(work_ctx['work_type'], 'en', labels_store),
-        "type_object": work_ctx['work_type'],
-        "type_ids": get_all_ids(work_ctx['work_type']),
-        "languages": work_ctx['languages'],
-        "creators": creators,
-        "authors_text": work_ctx['authors_text'],
-        "author_names": list(dict.fromkeys(
-            name for c in creators
-            if c.get('name') and c.get('role') != 'respondens'
-            for name in ([normalize_creator(c, people_data)[0], c['name']] if normalize_creator(c, people_data)[0] != c['name'] else [c['name']])
-        )),
-        "respondens_names": list(dict.fromkeys(
-            name for c in creators
-            if c.get('name') and c.get('role') == 'respondens'
-            for name in ([normalize_creator(c, people_data)[0], c['name']] if normalize_creator(c, people_data)[0] != c['name'] else [c['name']])
-        )),
-        "creator_ids": [normalize_creator(c, people_data)[1] for c in creators if c.get('id')]
-        # NB: pealkiri, koht, trükkal eemaldatud - kasuta title, location, publisher
-    }
-
-    if work_ctx['ester_id']:
-        doc['ester_id'] = work_ctx['ester_id']
-    if work_ctx['external_url']:
-        doc['external_url'] = work_ctx['external_url']
-
-    if work_ctx['archive_refs']:
-        doc['archive_refs'] = work_ctx['archive_refs']
-        # Denormaliseeritud otsingutekst: kood + arhiivi täisnimi + viide
-        parts = []
-        for ref in work_ctx['archive_refs']:
-            if not isinstance(ref, dict):
-                continue
-            archive_id = ref.get('archive_id', '')
-            if archive_id:
-                parts.append(archive_id)
-                archive_name = work_ctx['_archives'].get(archive_id, {}).get('name', '')
-                if archive_name:
-                    parts.append(archive_name)
-            if ref.get('reference'):
-                parts.append(ref['reference'])
-        if parts:
-            doc['archive_refs_text'] = ' '.join(parts)
-
-    text_anns = page_meta.get('text_annotations') or []
-    ann_text = build_text_annotations_text(text_anns)
-    if ann_text is not None:
-        doc['text_annotations_text'] = ann_text
-
-    return doc
-
 
 def load_collections():
     """Laeb kollektsioonide hierarhia."""
@@ -402,40 +93,6 @@ def load_collections():
         except Exception:
             pass
     return {}
-
-
-def get_collection_hierarchy(collections, collection_ids):
-    """Tagastab kollektsioonide hierarhia (kõigi kuuluvate kollektsioonide esivanemate union).
-
-    Args:
-        collections: Kõigi kollektsioonide dict (state/collections.json)
-        collection_ids: Üks kollektsiooni ID (str) või list ID-sid
-
-    Returns:
-        Kõigi kollektsioonide ja nende esivanemate ID-de list (duplikaadid eemaldatud)
-    """
-    if not collection_ids or not collections:
-        return []
-
-    # Normaliseeri listiks
-    if isinstance(collection_ids, str):
-        ids = [collection_ids]
-    else:
-        ids = [c for c in collection_ids if c]
-
-    seen = set()
-    result = []
-
-    for cid in ids:
-        current = cid
-        while current:
-            if current not in seen:
-                seen.add(current)
-                result.append(current)
-            col = collections.get(current)
-            current = col.get('parent') if col else None
-
-    return result
 
 
 def wait_for_task(task_uid, timeout=120):
@@ -556,25 +213,9 @@ def sync_work_to_meilisearch(dir_name):
     year_start = year_range[0] if year_range else 0
     year_end = year_range[1] if year_range else 0
 
-    # Autor ja respondens creators massiivist
+    # Autor ja respondens creators massiivist (jagatud loogika — vt meili_doc, issue #23)
     creators = metadata.get('creators', [])
-    autor = ''
-    respondens = ''
-    if creators:
-        # Prioriteet: auctor > praeses > esimene isik
-        praeses = next((c for c in creators if c.get('role') == 'praeses'), None)
-        auctor = next((c for c in creators if c.get('role') == 'auctor'), None)
-        resp = next((c for c in creators if c.get('role') == 'respondens'), None)
-        if auctor:
-            autor = auctor.get('name', '')
-        elif praeses:
-            autor = praeses.get('name', '')
-        elif creators:
-            first_creator = creators[0]
-            if first_creator.get('role') not in ['respondens', 'gratulator', 'dedicator', 'editor', 'aui']:
-                autor = first_creator.get('name', '')
-        if resp:
-            respondens = resp.get('name', '')
+    autor, respondens = compute_autor_respondens(creators)
 
     # Tags (LinkedEntity objektide massiiv või stringid)
     tags = metadata.get('tags', [])
@@ -588,6 +229,9 @@ def sync_work_to_meilisearch(dir_name):
 
     ester_id = metadata.get('ester_id')
     external_url = metadata.get('external_url')
+    series = metadata.get('series')
+    series_title = series.get('title', '') if isinstance(series, dict) else ''
+    relations = metadata.get('relations')
     archive_refs = metadata.get('archive_refs') or []
     location = metadata.get('location')
     publisher = metadata.get('publisher')
@@ -668,6 +312,9 @@ def sync_work_to_meilisearch(dir_name):
         'labels_store': labels_store,
         'ester_id': ester_id,
         'external_url': external_url,
+        'series': series,
+        'series_title': series_title,
+        'relations': relations,
         'archive_refs': archive_refs,
         '_archives': _archives,
     }

--- a/tests/test_consolidate_data.py
+++ b/tests/test_consolidate_data.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
 
 # Laeb skripti moodulina (ei ole package, kasutame importlib)
 _script_path = PROJECT_ROOT / "scripts" / "1-1_consolidate_data.py"
@@ -185,34 +186,30 @@ class TestConfigDirPath:
 
 
 # --- get_labels_by_lang koos labels_store toega ---
+# NB (issue #23): get_labels_by_lang, split_marginalia ja clean_text_for_search EI ole
+# enam 1-1_consolidate_data.py-s defineeritud — kaardistusloogika koondati
+# server/utils.py-sse ja server/meili_doc.py-sse, mida seed- ja live-tee mõlemad
+# impordivad. Testid kontrollivad nüüd kanoonilist allikat.
 
 class TestLabelsStore:
-    """Kontrollib, et skript kasutab labels_store kanoonilisi silte."""
-
-    def _load(self):
-        spec = importlib.util.spec_from_file_location("consolidate_data", _script_path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod
+    """Kontrollib, et kanooniline get_labels_by_lang kasutab labels_store silte."""
 
     def test_get_labels_by_lang_uses_labels_store(self):
-        mod = self._load()
+        from server.utils import get_labels_by_lang
         entity = {'id': 'Q999', 'label': 'Vana Silt', 'labels': {'et': 'Vana Silt'}}
         labels_store = {'Q999': {'et': 'Kanooniline Silt'}}
-        result = mod.get_labels_by_lang(entity, 'et', labels_store)
+        result = get_labels_by_lang(entity, 'et', labels_store)
         assert result == ['Kanooniline Silt'], (
             f"labels_store-ist peaks tulema 'Kanooniline Silt', sain: {result}"
         )
 
 
-# --- split_marginalia üksiktestid ---
+# --- split_marginalia üksiktestid (kanooniline: server.meili_doc) ---
 
 class TestSplitMarginalia:
     def _fns(self):
-        spec = importlib.util.spec_from_file_location("consolidate_data", _script_path)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        return mod.split_marginalia, mod.clean_text_for_search
+        from server.meili_doc import split_marginalia, clean_text_for_search
+        return split_marginalia, clean_text_for_search
 
     def test_eraldab_ja_fraas_liitub(self):
         split_marginalia, clean = self._fns()

--- a/tests/test_meili_seed_live_parity.py
+++ b/tests/test_meili_seed_live_parity.py
@@ -1,0 +1,234 @@
+"""
+Pariteeditest: seed/reseed-tee (scripts/1-1_consolidate_data.py) JA live-tee
+(server/meilisearch_ops.sync_work_to_meilisearch) peavad andma SAMA teose kohta
+IDENTSED Meilisearch dokumendid (issue #23).
+
+Taust: varem oli _metadata.json → Meili dokumendi kaardistusloogika dubleeritud
+kahes failis (split_marginalia, clean_text_for_search, get_creator_aliases,
+dokumendi-dict jms). Risk oli vaikne triiv: üks tee parandatakse, teine ununeb →
+`server_seed_data.sh` reseed regresseerub märkamatult. Nüüd ehitavad MÕLEMAD teed
+dokumendi sama server.meili_doc._build_page_document-iga, ja see test tõestab, et
+nad annavad bait-haaval sama tulemuse → divergeerumine on konstruktsiooni järgi
+võimatu.
+
+Meetod: ehita üks fiksiivne teos kettale, jooksuta mõlemad teed sama kausta peal
+ja võrdle dokumente väli-väljalt.
+"""
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server.meilisearch_ops as ops
+
+
+# Lae seed-skript mooduliks (failinimes on sidekriipsud → tavaimport ei tööta).
+# NB: 'server' on juba reaalse paketina sys.modules-is (ops impordist), seega seed
+# skripti fake-package blokk jätab vahele ja kasutab reaalset server-paketti.
+_SEED_PATH = Path(__file__).resolve().parents[1] / "scripts" / "1-1_consolidate_data.py"
+_spec = importlib.util.spec_from_file_location("seed_consolidate", _SEED_PATH)
+seed = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(seed)
+
+
+# =========================================================
+# Fiksiivsed registrid (samad mis live snapshot-testis)
+# =========================================================
+
+COLLECTIONS = {
+    "col-public": {"name": {"et": "Avalik kogu"}, "visibility": "public", "parent": None},
+    "child-col": {"name": {"et": "Alamkogu"}, "visibility": "restricted", "parent": "col-public"},
+    "col-restricted": {"name": {"et": "Piiratud kogu"}, "visibility": "restricted", "parent": None},
+}
+
+PEOPLE = {
+    "Q123": {
+        "primary_name": "Lorenz Luden",
+        "aliases": ["Laurentius Ludenius", "Ludenius"],
+        "ids": {"wikidata": "Q123"},
+    },
+    "Q456": {
+        "primary_name": "Johannes Respondent",
+        "aliases": ["Johannes R."],
+        "ids": {"wikidata": "Q456"},
+    },
+    "Q777": {  # trükkal aliasega → publisher_search pariteet
+        "primary_name": "Academische Buchdruckerei",
+        "aliases": ["Brendeken, Johann"],
+        "ids": {"wikidata": "Q777"},
+    },
+}
+
+LABELS = {
+    "Q500": {"et": "Marginaal", "en": "Margin"},
+    "Q111": {"et": "Disputatsioon", "en": "Disputation"},
+}
+
+ARCHIVES = {"RA": {"name": "Rahvusarhiiv", "url": "https://ais.ra.ee"}}
+
+WORK_ID = "abc123xyz"
+SLUG = "1690-test-teos"
+
+
+def _write_metadata(work_dir: Path, **overrides):
+    meta = {
+        "id": WORK_ID,
+        "slug": SLUG,
+        "title": "Disputatio de Test",
+        "year": 1690,
+        "year_display": "ca. 1690",
+        "creators": [
+            {"name": "Laurentius Ludenius", "id": "Q123", "role": "auctor"},
+            {"name": "Johannes Respondent", "id": "Q456", "role": "respondens"},
+        ],
+        "tags": [
+            {"label": "Test", "id": "Q999", "labels": {"et": "Test", "en": "Test-en"}},
+        ],
+        "genre": {"label": "Disputatsioon", "id": "Q111", "labels": {"et": "Disputatsioon", "en": "Disputation"}},
+        "type": {"label": "Dissertatsioon", "id": "Q87167", "labels": {"et": "Dissertatsioon", "en": "Dissertation"}},
+        "location": {"label": "Tartu", "id": "Q3258", "labels": {"et": "Tartu", "en": "Tartu"}},
+        "publisher": {"label": "Academische Buchdruckerei", "id": "Q777", "labels": {"et": "Akadeemiline trükikoda"}},
+        "languages": ["la"],
+        "collections": ["col-public", "child-col"],
+        "archive_refs": [{"archive_id": "RA", "reference": "f. 1"}],
+        "ester_id": "b12345",
+        "external_url": "https://example.org/work",
+        "series": {"title": "Testseeria"},
+        "shareable": True,
+    }
+    meta.update(overrides)
+    (work_dir / "_metadata.json").write_text(json.dumps(meta, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_page(work_dir: Path, base: str, *, txt: str, sequence: int, status: str,
+                page_tags=None, comments=None, text_annotations=None):
+    (work_dir / f"{base}.jpg").write_bytes(b"\xff\xd8jpeg")
+    (work_dir / f"{base}.txt").write_text(txt, encoding="utf-8")
+    (work_dir / f"{base}.json").write_text(json.dumps({
+        "sequence": sequence,
+        "status": status,
+        "page_tags": page_tags or [],
+        "comments": comments or [],
+        "text_annotations": text_annotations or [],
+        "history": [],
+    }, ensure_ascii=False), encoding="utf-8")
+
+
+def _build_fixture(tmp_path, **meta_overrides):
+    work_dir = tmp_path / SLUG
+    work_dir.mkdir()
+    _write_metadata(work_dir, **meta_overrides)
+    _write_page(
+        work_dir, f"{SLUG}-{WORK_ID}-001",
+        txt="welcher işt der Teuffel\n<m>Vide Picrium in hyeroglyphicis</m>\nvnd Satanas.",
+        sequence=100, status="Toores",
+        page_tags=[{"label": "Margin", "id": "Q500", "labels": {"et": "Margin", "en": "Margin-en"}}],
+        comments=[{"text": "kommentaar"}],
+        text_annotations=[{"comment": "ann1"}],
+    )
+    _write_page(
+        work_dir, f"{SLUG}-{WORK_ID}-002",
+        txt="foo<m>ääremärkus</m>bar coa-\ncervare",
+        sequence=200, status="Valmis",
+    )
+    for base in (f"{SLUG}-{WORK_ID}-001", f"{SLUG}-{WORK_ID}-002"):
+        os.utime(work_dir / f"{base}.txt", (1_000_000, 1_000_000))
+    return work_dir
+
+
+def _live_docs(tmp_path, monkeypatch):
+    """Jooksutab live-tee (sync_work_to_meilisearch) ja tagastab kinnipüütud dokumendid."""
+    monkeypatch.setattr(ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(ops, "ARCHIVES_FILE", str(tmp_path / "_archives.json"))
+    (tmp_path / "_archives.json").write_text(json.dumps(ARCHIVES), encoding="utf-8")
+    monkeypatch.setattr(ops, "load_collections", lambda: COLLECTIONS)
+    monkeypatch.setattr(ops, "load_people_aliases", lambda: PEOPLE)
+    monkeypatch.setattr(ops, "load_labels_store", lambda: LABELS)
+
+    captured = {"docs": None}
+    monkeypatch.setattr(ops, "send_to_meilisearch", lambda documents, wait=True: captured.__setitem__("docs", documents) or True)
+    monkeypatch.setattr(ops, "_delete_extra_pages", lambda work_id, new_count: None)
+
+    assert ops.sync_work_to_meilisearch(SLUG) is True
+    return captured["docs"]
+
+
+def _seed_docs(work_dir):
+    """Jooksutab seed-tee (build_work_documents) sama kausta peal."""
+    teose_id, pages = seed.build_work_documents(
+        str(work_dir), SLUG, COLLECTIONS, PEOPLE, ARCHIVES, LABELS
+    )
+    return pages
+
+
+# =========================================================
+# Testid
+# =========================================================
+
+def test_seed_ja_live_annavad_identsed_dokumendid(tmp_path, monkeypatch):
+    """Põhitest: täielikult populeeritud teose puhul on seed- ja live-dokumendid identsed.
+
+    teose_staatus jäetakse võrdlusest välja: live lisab selle dokumentidesse
+    upsert-sammus (_upsert_work_documents), seed väljundi kirjutamise tsüklis —
+    mõlemad arvutavad selle samast utils.calculate_work_status-ist.
+    """
+    work_dir = _build_fixture(tmp_path)
+    live = _live_docs(tmp_path, monkeypatch)
+    seed_docs = _seed_docs(work_dir)
+
+    assert len(live) == len(seed_docs) == 2
+
+    for live_doc, seed_doc in zip(live, seed_docs):
+        live_clean = {k: v for k, v in live_doc.items() if k != "teose_staatus"}
+        assert seed_doc == live_clean, (
+            f"Seed ja live lahknevad lehel {live_doc.get('id')}; "
+            f"erinevad võtmed: {set(live_clean) ^ set(seed_doc)}"
+        )
+
+
+def test_seed_ja_live_seeria_vali_molemas(tmp_path, monkeypatch):
+    """series/series_title peab nüüd ilmuma MÕLEMAS teed (varem ainult seed-is)."""
+    work_dir = _build_fixture(tmp_path)
+    live = _live_docs(tmp_path, monkeypatch)
+    seed_docs = _seed_docs(work_dir)
+    for d in (live[0], seed_docs[0]):
+        assert d["series"] == {"title": "Testseeria"}
+        assert d["series_title"] == "Testseeria"
+
+
+def test_seed_ja_live_ilma_seeriata(tmp_path, monkeypatch):
+    """Ilma seeriata: kumbki tee EI lisa series/series_title/relations välja."""
+    work_dir = _build_fixture(tmp_path, series=None)
+    live = _live_docs(tmp_path, monkeypatch)
+    seed_docs = _seed_docs(work_dir)
+    for live_doc, seed_doc in zip(live, seed_docs):
+        live_clean = {k: v for k, v in live_doc.items() if k != "teose_staatus"}
+        assert seed_doc == live_clean
+        assert "series" not in seed_doc
+        assert "relations" not in seed_doc
+
+
+def test_seed_ja_live_minimaalne_metadata(tmp_path, monkeypatch):
+    """Minimaalne teos (ainult id/slug/title, ei type/languages/year) — defaultide pariteet.
+
+    Kaitseb type ('impressum' vs None) ja languages (['lat'] vs []) defaultide
+    lahknemise eest, mis varem seed-tees erines live-teest."""
+    work_dir = tmp_path / SLUG
+    work_dir.mkdir()
+    (work_dir / "_metadata.json").write_text(
+        json.dumps({"id": WORK_ID, "slug": SLUG, "title": "Minimaalne"}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    _write_page(work_dir, f"{SLUG}-{WORK_ID}-001", txt="lihtne tekst", sequence=100, status="Toores")
+    os.utime(work_dir / f"{SLUG}-{WORK_ID}-001.txt", (1_000_000, 1_000_000))
+
+    live = _live_docs(tmp_path, monkeypatch)
+    seed_docs = _seed_docs(work_dir)
+    assert len(live) == len(seed_docs) == 1
+    live_clean = {k: v for k, v in live[0].items() if k != "teose_staatus"}
+    assert seed_docs[0] == live_clean

--- a/tests/test_meili_seed_live_parity.py
+++ b/tests/test_meili_seed_live_parity.py
@@ -105,18 +105,22 @@ def _write_metadata(work_dir: Path, **overrides):
     (work_dir / "_metadata.json").write_text(json.dumps(meta, ensure_ascii=False), encoding="utf-8")
 
 
-def _write_page(work_dir: Path, base: str, *, txt: str, sequence: int, status: str,
-                page_tags=None, comments=None, text_annotations=None):
+def _write_page(work_dir: Path, base: str, *, txt: str, sequence, status: str,
+                page_tags=None, comments=None, text_annotations=None, text_content=None):
     (work_dir / f"{base}.jpg").write_bytes(b"\xff\xd8jpeg")
     (work_dir / f"{base}.txt").write_text(txt, encoding="utf-8")
-    (work_dir / f"{base}.json").write_text(json.dumps({
-        "sequence": sequence,
+    page_json = {
         "status": status,
         "page_tags": page_tags or [],
         "comments": comments or [],
         "text_annotations": text_annotations or [],
         "history": [],
-    }, ensure_ascii=False), encoding="utf-8")
+    }
+    if sequence is not None:
+        page_json["sequence"] = sequence
+    if text_content is not None:
+        page_json["text_content"] = text_content
+    (work_dir / f"{base}.json").write_text(json.dumps(page_json, ensure_ascii=False), encoding="utf-8")
 
 
 def _build_fixture(tmp_path, **meta_overrides):
@@ -211,6 +215,37 @@ def test_seed_ja_live_ilma_seeriata(tmp_path, monkeypatch):
         assert seed_doc == live_clean
         assert "series" not in seed_doc
         assert "relations" not in seed_doc
+
+
+def test_seed_ja_live_sequence_fallback_ja_text_content_fallback(tmp_path, monkeypatch):
+    """Seed peab järgima live'i lehesortimist ja text_content fallback'i.
+
+    Regressioon: seed kasutas varem sequence-puudumisel kunstlikku alpha_pos*100
+    väärtust (live kasutab inf → lõppu) ja JSON text_content kirjutas .txt üle
+    (live kasutab seda ainult siis, kui .txt puudub/tühi).
+    """
+    work_dir = tmp_path / SLUG
+    work_dir.mkdir()
+    _write_metadata(work_dir)
+    _write_page(
+        work_dir, f"{SLUG}-{WORK_ID}-a-unseq",
+        txt="TXT unsequenced", sequence=None, status="Toores",
+    )
+    _write_page(
+        work_dir, f"{SLUG}-{WORK_ID}-b-seq",
+        txt="TXT sequenced", sequence=300, status="Toores", text_content="JSON sequenced",
+    )
+    for base in (f"{SLUG}-{WORK_ID}-a-unseq", f"{SLUG}-{WORK_ID}-b-seq"):
+        os.utime(work_dir / f"{base}.txt", (1_000_000, 1_000_000))
+
+    live = _live_docs(tmp_path, monkeypatch)
+    seed_docs = _seed_docs(work_dir)
+
+    assert [d["lehekylje_pilt"] for d in seed_docs] == [d["lehekylje_pilt"] for d in live]
+    assert seed_docs[0]["text_content"] == "TXT sequenced"
+    for live_doc, seed_doc in zip(live, seed_docs):
+        live_clean = {k: v for k, v in live_doc.items() if k != "teose_staatus"}
+        assert seed_doc == live_clean
 
 
 def test_seed_ja_live_minimaalne_metadata(tmp_path, monkeypatch):


### PR DESCRIPTION
Lõpetab issue #23: kaotab duplikatsiooni `server/meilisearch_ops.py` (live `/save` tee) ja `scripts/1-1_consolidate_data.py` (seed/reseed tee) vahel.

## Probleem
Kaks indekseerimisteed sisaldasid kahte **sõltumatut koopiat** `_metadata.json` → Meili dokumendi kaardistusloogikast. Risk = vaikne triiv: üks tee parandatakse, teine ununeb → `server_seed_data.sh` reseed regresseerub märkamatult.

## Lahendus
- **Uus side-effect-vaba moodul `server/meili_doc.py`** (ainult stdlib + `server.utils` + `server.marginalia_normalize`; MITTE Meili-klient/ThreadPoolExecutor/git_ops). Sisaldab kõik puhtad kaardistusfunktsioonid + `_build_page_document`.
- **Mõlemad teed impordivad sealt.** Seed-skript saab uue `build_work_documents()`, mis ehitab sama `work_ctx` ja kutsub sama `_build_page_document`-i. Kõik duplikaat-definitsioonid kustutatud.
- **Pariteeditest** `tests/test_meili_seed_live_parity.py` (4 testi): jooksutab mõlemad teed sama fiksiivse teose peal ja assertib **bait-haaval identsed** dokumendid → divergeerumine on nüüd konstruktsiooni järgi võimatu.

## Unifitseerimisel parandatud varjatud triivid
1. Seed EI emiteerinud `autor`/`respondens`/`aasta` ega kasutanud `normalize_creator`-i → reseed kaotaks filtri/sordi väljad.
2. Live EI emiteerinud `series`/`series_title`/`relations` (ainult seed) → `/save` kaotas need, frontend loeb neid.
3. Seed lokaalne `calculate_work_status` ei tundnud `'Tehtud'`/`'DONE'` aliaseid → imporditud kanooniline `utils`-ist.
4. Defaultide pariteet: `type` `'impressum'`→`None`, `languages` `['lat']`→`[]`.

## Testid
- Kõik **523 testi läbivad** (sh 4 uut pariteeditesti).
- Seed-skripti otspunkti-suitsutest: `autor`/`aasta` nüüd olemas, marginaalia korrektselt eraldatud.

## Lahtine enne täielikku usaldust
- **Server-andmete diff:** issue nõuab ühekordset live-vs-seed väljundi võrdlust päris serveri andmetel (vajab deploy'd). Pariteeditest katab V2-fiksiivid; järelejäänud reaalandmete risk on v1-formaadi fallback, mis elab tahtlikult ainult seed `get_work_metadata`-s (legacy-tugi, mitte triiv).
- Pärast merge'i: deploy + täis-reseed.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)