### PR TITLE
fix(meili): normaliseeri tühi location/publisher → None mõlemas teed (#23)

### DIFF
--- a/server/meili_doc.py
+++ b/server/meili_doc.py
@@ -309,6 +309,15 @@ def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_
     creators = work_ctx['creators']
     tags = work_ctx['tags']
 
+    # Normaliseeri tühi location/publisher → None (mitte '').
+    # _metadata.json-is võib location/publisher olla tühi string '' — seed-tee
+    # get_work_metadata teisendab selle `or`-iga None-iks, live-tee jättis '' alles
+    # → *_object väljad lahknesid (issue #23 verifitseerimine leidis 51 teost).
+    # Ühtlustame ÜHES kohas → mõlemad teed annavad None. Flat väljad (get_label jms)
+    # ei muutu, sest get_label('') == get_label(None) == ''.
+    location = work_ctx['location'] or None
+    publisher = work_ctx['publisher'] or None
+
     doc = {
         "id": page_id,
         "work_id": work_ctx['work_id'],  # Nanoid (püsiv lühikood)
@@ -359,14 +368,14 @@ def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_
             for c in work_ctx['work_collections']
         ) if work_ctx['work_collections'] else True,
         "shareable": work_ctx['shareable'],
-        "location": get_label(work_ctx['location']),
-        "location_object": work_ctx['location'],
-        "location_id": get_id(work_ctx['location']),
-        "location_search": get_all_labels(work_ctx['location']),
-        "publisher": get_label(work_ctx['publisher']),
-        "publisher_object": work_ctx['publisher'],
-        "publisher_id": get_id(work_ctx['publisher']),
-        "publisher_search": get_all_labels(work_ctx['publisher']) + work_ctx['publisher_aliases'],
+        "location": get_label(location),
+        "location_object": location,
+        "location_id": get_id(location),
+        "location_search": get_all_labels(location),
+        "publisher": get_label(publisher),
+        "publisher_object": publisher,
+        "publisher_id": get_id(publisher),
+        "publisher_search": get_all_labels(publisher) + work_ctx['publisher_aliases'],
         "genre": get_label(work_ctx['genre']),
         "genre_et": get_labels_by_lang(work_ctx['genre'], 'et', labels_store),
         "genre_en": get_labels_by_lang(work_ctx['genre'], 'en', labels_store),

--- a/tests/test_meili_seed_live_parity.py
+++ b/tests/test_meili_seed_live_parity.py
@@ -248,6 +248,21 @@ def test_seed_ja_live_sequence_fallback_ja_text_content_fallback(tmp_path, monke
         assert seed_doc == live_clean
 
 
+def test_seed_ja_live_tyhi_location_publisher(tmp_path, monkeypatch):
+    """Tühi string location/publisher → MÕLEMAD teed annavad location_object/publisher_object = None.
+
+    Regressioon (issue #23 server-verifitseerimine, 51 teost): live jättis '' alles,
+    seed teisendas None-iks → *_object lahknes. Nüüd normaliseeritud _build_page_document-is."""
+    work_dir = _build_fixture(tmp_path, location="", publisher="")
+    live = _live_docs(tmp_path, monkeypatch)
+    seed_docs = _seed_docs(work_dir)
+    for live_doc, seed_doc in zip(live, seed_docs):
+        live_clean = {k: v for k, v in live_doc.items() if k != "teose_staatus"}
+        assert seed_doc == live_clean
+        assert seed_doc["location_object"] is None
+        assert seed_doc["publisher_object"] is None
+
+
 def test_seed_ja_live_minimaalne_metadata(tmp_path, monkeypatch):
     """Minimaalne teos (ainult id/slug/title, ei type/languages/year) — defaultide pariteet.
 


### PR DESCRIPTION
## Leid (server-verifitseerimine)
`scripts/verify_meili_seed_live_parity.py` päris serveri andmetel (1301 teost) leidis **51 erinevust**, kõik AINULT kahel väljal: `location_object` ja `publisher_object`.

Põhjus: `_metadata.json`-is on `location`/`publisher` mõnel teosel **tühi string `''`**, ja:
- **live-tee** jättis `''` alles → `location_object: ''`
- **seed-tee** `get_work_metadata` teisendas `meta.get('location') or meta.get('koht')` kaudu `None`-iks → `location_object: None`

See on **pre-existing triiv** (mõlemad VANAD teed käitusid nii) — mitte #26 regressioon. Tootmisindeks hoiab praegu `None` (ehitatud seed-iga), seega iga `/save` neil 51 teosel oleks pööranud välja `''`-ks.

## Parandus
`_build_page_document` normaliseerib `location/publisher = work_ctx[..] or None` **ühes kohas** → mõlemad teed annavad `None`. Flat väljad (`location`/`location_id`/`location_search`) EI muutu, sest `get_label('') == get_label(None) == ''` (seetõttu lahknesidki ainult toored `*_object` väljad).

## Verifitseerimine
- **Serveris päris andmetel: 51 → 0 erinevust** (patched `meili_doc.py` konteinerisse kopeeritud, `verify_...py` uuesti jooksutatud).
- Lisatud pariteeditest `test_seed_ja_live_tyhi_location_publisher`.
- Kogu suite: **525 passed**.

Pärast merge'i: deploy (`server_update.sh --no-cache`) + täis-reseed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)