### PR TITLE
fix(utils): parse_year_range — sorteeri aastad + sajandite vahemik (#31)

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -114,6 +114,10 @@ def pick_best_label(labels_dict, lang):
 
 # Sajandimuster: "19. saj", "19. sajand", "19 saj" (stringi algusest, trimmituna)
 _CENTURY_RE = re.compile(r'^(\d{1,2})\.?\s*saj', re.IGNORECASE)
+# Sajandite vahemik: "17.-19. saj", "17-19. saj", "17. – 19. saj" (vt issue #31).
+# Eraldi muster, kontrollitakse ENNE _CENTURY_RE-d, sest üksik-sajandi muster
+# (ankerdatud, nõuab 'saj' kohe pärast numbrit) ei taba vahemikku.
+_CENTURY_RANGE_RE = re.compile(r'^(\d{1,2})\.?\s*[-\u2013\u2014]\s*(\d{1,2})\.?\s*saj', re.IGNORECASE)
 _YEAR4_RE = re.compile(r'\d{4}')
 _APPROX_RE = re.compile(r'\bca\.?\b', re.IGNORECASE)
 
@@ -121,20 +125,29 @@ _APPROX_RE = re.compile(r'\bca\.?\b', re.IGNORECASE)
 def parse_year_range(year, year_display) -> Optional[Tuple[int, int]]:
     """Tuletab teose aastavahemiku (year_start, year_end) filtreerimise jaoks.
 
-    "19. saj"   -> (1801, 1900)   N. sajand = (N-1)*100+1 ... N*100
-    "ca. 1750"  -> (1740, 1760)
-    "1670-1690" -> (1670, 1690)
-    "1750"      -> (1750, 1750)
+    "19. saj"      -> (1801, 1900)   N. sajand = (N-1)*100+1 ... N*100
+    "17.-19. saj"  -> (1601, 1900)   sajandite vahemik: 17. saj algusest kuni 19. saj lõpuni
+    "ca. 1750"     -> (1740, 1760)
+    "1670-1690"    -> (1670, 1690)   aastad sorititakse (vt issue #31)
+    "1690-1670"    -> (1670, 1690)   tagurpidi vahemik normaliseeritakse
+    "1750"         -> (1750, 1750)
     Tagastab None kui aastat ei tuvastata.
     NB: peegelloogika frontendis: src/utils/yearDisplayUtils.ts parseYearDisplayRange
     """
     if year_display:
         s = str(year_display).strip()
+        # Sajandite vahemik kõigepealt (üksik-sajandi muster seda ei taba)
+        mr = _CENTURY_RANGE_RE.match(s)
+        if mr:
+            c1, c2 = sorted((int(mr.group(1)), int(mr.group(2))))
+            return ((c1 - 1) * 100 + 1, c2 * 100)
         m = _CENTURY_RE.match(s)
         if m:
             c = int(m.group(1))
             return ((c - 1) * 100 + 1, c * 100)
-        years = [int(y) for y in _YEAR4_RE.findall(s)]
+        # Aastad sorititakse, et tagurpidi vahemik ("1690-1670") annaks
+        # (1670, 1690), mitte (1690, 1670) — year_start peab <= year_end (vt issue #31)
+        years = sorted(int(y) for y in _YEAR4_RE.findall(s))
         if len(years) >= 2:
             return (years[0], years[-1])
         if len(years) == 1:

--- a/src/utils/__tests__/yearDisplayUtils.test.ts
+++ b/src/utils/__tests__/yearDisplayUtils.test.ts
@@ -40,6 +40,28 @@ describe('parseYearDisplayRange', () => {
   it('sajand võidab numeric-fallbacki', () => {
     expect(parseYearDisplayRange(1850, '19. saj')).toEqual({ start: 1801, end: 1900 });
   });
+
+  // Uus: sajandite vahemik (issue #31)
+  it('sajandite vahemik "17.-19. saj"', () => {
+    expect(parseYearDisplayRange(null, '17.-19. saj')).toEqual({ start: 1601, end: 1900 });
+  });
+  it('sajandite vahemik ilma punktita "17-19. saj"', () => {
+    expect(parseYearDisplayRange(null, '17-19. saj')).toEqual({ start: 1601, end: 1900 });
+  });
+  it('sajandite vahemik tühikutega', () => {
+    expect(parseYearDisplayRange(null, '17. - 19. saj')).toEqual({ start: 1601, end: 1900 });
+  });
+  it('tagurpidi sajandite vahemik normaliseeritakse', () => {
+    expect(parseYearDisplayRange(null, '19.-17. saj')).toEqual({ start: 1601, end: 1900 });
+  });
+  it('sajandite vahemik võidab numeric-fallbacki', () => {
+    expect(parseYearDisplayRange(1850, '17.-19. saj')).toEqual({ start: 1601, end: 1900 });
+  });
+
+  // Uus: tagurpidi aastavahemik normaliseeritakse (issue #31)
+  it('tagurpidi vahemik normaliseeritakse', () => {
+    expect(parseYearDisplayRange(null, '1690-1670')).toEqual({ start: 1670, end: 1690 });
+  });
 });
 
 // Mock-t: tagastab võtme ja parameetrid kontrollitaval kujul

--- a/src/utils/yearDisplayUtils.ts
+++ b/src/utils/yearDisplayUtils.ts
@@ -10,6 +10,10 @@ import type { TFunction } from 'i18next';
 
 // Sajandimuster: "19. saj", "19. sajand", "19 saj" (stringi algusest, trimmituna)
 export const CENTURY_RE = /^(\d{1,2})\.?\s*saj/i;
+// Sajandite vahemik: "17.-19. saj", "17-19. saj", "17. – 19. saj" (vt issue #31).
+// Kontrollitakse ENNE CENTURY_RE-d, sest üksik-sajandi muster (ankerdatud,
+// nõuab 'saj' kohe pärast numbrit) vahemikku ei taba.
+export const CENTURY_RANGE_RE = /^(\d{1,2})\.?\s*[-\u2013\u2014]\s*(\d{1,2})\.?\s*saj/i;
 
 export function parseYearDisplayRange(
   numericYear: number | string | null | undefined,
@@ -18,6 +22,17 @@ export function parseYearDisplayRange(
   const numeric = Number(numericYear) || 0;
 
   if (yearDisplay) {
+    // Sajandite vahemik kõigepealt (üksik-sajandi muster seda ei taba)
+    const crm = yearDisplay.trim().match(CENTURY_RANGE_RE);
+    if (crm) {
+      const c1 = Number(crm[1]);
+      const c2 = Number(crm[2]);
+      const cLo = Math.min(c1, c2);
+      const cHi = Math.max(c1, c2);
+      // 17.-19. saj → 17. saj algusest (1601) kuni 19. saj lõpuni (1900)
+      return { start: (cLo - 1) * 100 + 1, end: cHi * 100 };
+    }
+
     const cm = yearDisplay.trim().match(CENTURY_RE);
     if (cm) {
       // N. sajand = (N-1)*100+1 … N*100 (ajaloolaste konventsioon: 19. saj = 1801–1900)
@@ -26,8 +41,9 @@ export function parseYearDisplayRange(
     }
 
     const isApprox = /\bca\.?\b/i.test(yearDisplay);
-    const years = [...yearDisplay.matchAll(/\d{4}/g)].map(m => Number(m[0]));
-
+    // Aastad sorititakse, et tagurpidi vahemik ("1690-1670") annaks
+    // (1670, 1690), mitte (1690, 1670) — start peab <= end (vt issue #31)
+    const years = [...yearDisplay.matchAll(/\d{4}/g)].map(m => Number(m[0])).sort((a, b) => a - b);
     if (years.length >= 2) {
       return { start: years[0], end: years[years.length - 1] };
     }

--- a/tests/test_year_range.py
+++ b/tests/test_year_range.py
@@ -80,7 +80,6 @@ def test_kolm_aastat_votab_esimene_ja_viimane():
     # Mitmest aastast võetakse esimene ja viimane (vahemik)
     assert parse_year_range(None, "1670, 1680, 1690") == (1670, 1690)
 
-
 def test_ca_ilma_punktita():
     # "ca 1750" (ilma punktita) → samuti approx ±10
     assert parse_year_range(None, "ca 1750") == (1740, 1760)
@@ -131,24 +130,50 @@ def test_bool_year_coerceitakse_int_ks():
 # Need testid fikseerivad PRAEGUSE käitumise regressioonikaitsena. Kui neid
 # parandada (vt all), tuleb ka vastav test uuendada.
 
-def test_peatatud_reverse_vahemik_on_sortimata():
-    """Tagurpidi vahemik "1690-1670" annab (1690, 1670) — year_start > year_end.
+def test_reverse_vahemik_normaliseeritakse():
+    """Tagurpidi vahemik "1690-1670" normaliseeritakse (1670, 1690). (issue #31)
 
-    POTENTSIAALNE VIGA: _YEAR4_RE.findall tagastab [1690, 1670] ja kood võtab
-    (years[0], years[-1]) sortimata. See võib jätta year_start > year_end,
-    mis rikkub aastavahemiku filtrite loogikat. Reaalses andmes ebatõenäoline
-    (sisend on harva tagurpidi), aga väärt follow-up-i.
+    Varasemalt tagastas _YEAR4_RE.findall + (years[0], years[-1]) sortimata tulemi
+    (1690, 1670) → year_start > year_end, mis rikkus aastavahemiku filtrit.
+    Nüüd aastad sorteeritakse, nii et year_start <= year_end alati.
     """
-    assert parse_year_range(None, "1690-1670") == (1690, 1670)
+    assert parse_year_range(None, "1690-1670") == (1670, 1690)
 
 
-def test_peatatud_sajandite_vahemik_tagastab_none():
-    """"Sajandite vahemik "17.-19. saj" tagastab None.
+def test_reverse_vahemik_en_dash():
+    """Tagurpidi vahemik en-dashi'ga samuti normaliseeritakse."""
+    assert parse_year_range(None, "1690–1670") == (1670, 1690)
 
-    POTENTSIAALNE VIGA: _CENTURY_RE (ankerdatud ^) tabab ainult esimest sajandit
-    ja eeldab kohe 'saj' järel; "17.-19. saj" ei klapi, _YEAR4_RE ei leia
-    4-kohalisi (19 on 2-kohaline) → kogu display langeb läbi → tulem None.
-    Tulemuseks year_start=year_end=0 (rippub kutsujast), mis rikkub filtrit.
-    Väärt follow-up-i, kui selliseid teoseid serveris esineb.
+
+def test_sajandite_vahemik():
+    """Sajandite vahemik "17.-19. saj" → (1601, 1900) (issue #31).
+
+    Varasemalt tagastas None: _CENTURY_RE ei taba vahemikku (nõuab 'saj' kohe
+    pärast numbrit), _YEAR4_RE ei leia 4-kohalisi (19 on 2-kohaline). Nüüd eraldi
+    _CENTURY_RANGE_RE muster: 17. saj algusest (1601) kuni 19. saj lõpuni (1900).
     """
-    assert parse_year_range(None, "17.-19. saj") is None
+    assert parse_year_range(None, "17.-19. saj") == (1601, 1900)
+
+
+def test_sajandite_vahemik_ilma_punktita():
+    assert parse_year_range(None, "17-19. saj") == (1601, 1900)
+
+
+def test_sajandite_vahemik_tuhikutega():
+    assert parse_year_range(None, "17. - 19. saj") == (1601, 1900)
+
+
+def test_sajandite_vahemik_sorteeritakse():
+    # Tagurpidi sajandite vahemik normaliseeritakse (c_lo, c_hi)
+    assert parse_year_range(None, "19.-17. saj") == (1601, 1900)
+
+
+def test_sajandite_vahemik_voidab_aastat():
+    # year_display domineerib year parametri üle
+    assert parse_year_range(1850, "17.-19. saj") == (1601, 1900)
+
+
+def test_uksik_sajand_ikka_tooab():
+    # Regressioon: vahemiku lisamine ei tohi muuta üksik-sajandi käitumist
+    assert parse_year_range(None, "19. saj") == (1801, 1900)
+    assert parse_year_range(None, "9. saj") == (801, 900)


### PR DESCRIPTION
Sulgeb issue #31 — parandab kaks `parse_year_range` varjatud viga, mis leiti PR #30 testide kirjutamisel. Mõlemad parandused rakendatud ka frontend peegelloogikale (`src/utils/yearDisplayUtils.ts`), vastavalt `parse_year_range` docstring-i sünkrooninõudele.

## Leid 1 — tagurpidi aastavahemik
```python
parse_year_range(None, "1690-1670")
# enne: (1690, 1670)  ← year_start > year_end, rikkus aastafiltrit
# nüüd: (1670, 1690)
```
`_YEAR4_RE.findall` tagastas järjestuse ja kood võttis `(years[0], years[-1])` sortimata. **Parandus:** aastad sorteeritakse.

## Leid 2 — sajandite vahemik
```python
parse_year_range(None, "17.-19. saj")
# enne: None  ← _CENTURY_RE ei taba (nõuab 'saj' kohe pärast numbrit), _YEAR4_RE ei leia 2-kohalisi
# nüüd: (1601, 1900)
```
Uus `_CENTURY_RANGE_RE` muster (kontrollitakse enne üksikut sajandit): 17. saj algusest (1601) kuni 19. saj lõpuni (1900). Toetab variante: "17.-19. saj", "17-19. saj", "17. – 19. saj"; reverse "19.-17." normaliseeritakse.

## Serveri andmekontroll (blokeeriv eeltingimus täidetud)
1301 teost serveris, kontrollitud kõik `_metadata.json`:
- sajandi-mustreid `year_display`-s: **0**
- reverse aastavahemikke: **0**

→ Tootmises praegu mõju puudub; **robustsuse-parandus tulevikku** silmas pidades (kui selline sisend kunagi sisestatakse, ei jää teos filtritest kättesaamatuks ega aasta 0-na).

## Muudatused
- `server/utils.py`: `_CENTURY_RANGE_RE` + `sorted()` + uuendatud docstring
- `src/utils/yearDisplayUtils.ts`: peegelfix (sama loogika)
- `tests/test_year_range.py`: kaks `test_peatatud_*` asendatud õige käitumisega + lisavariandid (reverse, sajandi vahemik punkta/ilmata, tühikud, reverse sajandid, üksik sajand ikka töötab)
- `src/utils/__tests__/yearDisplayUtils.test.ts`: +7 sajandi-vahemiku ja reverse testi

## Testid
- Backend: `570 passed` (+6 uut year_range)
- Frontend: `459 passed` (+7 uut yearDisplayUtils)

Closes #31
