### PR TITLE
feat(metadata): aasta-väljade ühendamine üheks sisendiks (Phase 1)

### DIFF
--- a/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
+++ b/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
@@ -1,0 +1,123 @@
+# Aasta-väljade ühendamine üheks sisendiks
+
+**Kuupäev:** 2026-06-24
+**Issue seos:** sõltub #31 (parse_year_range parandused)
+**Staatus:** disain kinnitatud, ootab implementatsiooniplaani
+
+## Probleem
+
+Teose dateering on praegu kasutaja jaoks **kaks eraldi sisendlahtrit**:
+- `year` (number) — käsitsi sisestatav, kasutatakse sordiks/filtriks/seosteks
+- `year_display` (string) — käsitsi sisestatav kuva ("ca. 1680", "1670–1690", "17. saj")
+
+Nende eraldi käsitsi hoidmine ei anna sisulist väärtust: parsimisloogika
+(`parse_year_range`) oskab numbrilise aasta juba kuvastringist tuletada. Tekib
+"kumba lahtrit ma täidan?" segadus, mida reedab koodis olev fallback-jada
+(`work?.year || page.year || page.aasta`).
+
+## Eesmärk
+
+Kasutajale jääb **üks nähtav tekstilahter** (praegune `year_display`). Numbriline
+`year`-sisend eemaldatakse UI-st. Numbrilised väljad (`year`, `year_start`,
+`year_end`) **tuletatakse** sisendist. Olemasolevad andmed jäävad muutmata,
+migratsiooni ega reindeksit ei vajata.
+
+## Andmemudel — "tark sisend, duaalne salvestus"
+
+`_metadata.json` säilitab MÕLEMAD väljad (`year` number + `year_display` string),
+aga ainult `year_display`-stiilis sisend on **autoriseeritav**; `year` tuletatakse
+salvestamisel. See hoiab kõik backend-lugemiskohad muutmatuna (`year` on endiselt JSON-is).
+
+Tuletamise reegel sisendstringist `raw`:
+
+| Sisend | year | year_display |
+|--------|------|--------------|
+| `"1680"` (puhas number) | 1680 | `""` |
+| `"ca. 1680"` | 1680 | `"ca. 1680"` |
+| `"1670–1690"` | 1680 (keskpaik) | `"1670–1690"` |
+| `"17. saj"` | 1650 (keskpaik) | `"17. saj"` |
+| `"1601–1700"` | 1650 (keskpaik) | `"1601–1700"` |
+| `""` (tühi) | 0 | `""` |
+| `"XVII saj"` (ei parsi) | 0 | `"XVII saj"` |
+
+**Reegel:** `/^\d{1,4}$/` → puhas number, `year_display=""`. Muidu → `year_display=raw`,
+`year =` keskpaik `(start+end)//2` funktsioonist `parseYearDisplayRange(null, raw)`,
+või `0` kui ei parsi.
+
+**Järjepidevus:** sajand käsitletakse oma vahemikuna ja `year` tuletatakse sama
+reegliga nagu iga vahemik. "17. saj" = (1601, 1700) → keskpaik 1650, identne
+sisendiga "1601–1700". Keskpaik säilitab ka `meili_doc.py:524` praeguse käitumise,
+nii et sortimine ei muutu.
+
+## Faseering
+
+Esialgne "UI nüüd + skeemikustutus hiljem" plaan **lahustub**: kuna `year` jääb
+legitiimseks salvestuseks puhaste aastate jaoks, eraldi skeemikustutuse faasi pole
+vaja. Jääb kaks faasi:
+
+### Phase 0 — parser (#31), eeltingimus
+
+`parse_year_range` saab numbrilise `year`-i ainsaks tuleallikaks, seega #31 vead
+tuleb parandada ENNE, et servajuhud ei korrumpeeriks tuletatud `year`-it. Mõlemas
+peeglis (`server/utils.py` + `src/utils/yearDisplayUtils.ts`):
+
+1. **Tagurpidi vahemik:** `(years[0], years[-1])` → `(min(years), max(years))`.
+   "1690-1670" → (1670, 1690).
+2. **Sajandivahemik:** uus muster `^(\d{1,2})\.?\s*[-–]\s*(\d{1,2})\.?\s*saj`
+   → `((N-1)*100+1, M*100)`. "17.-19. saj" → (1601, 1900).
+3. Uuenda lukustatud testid `test_peatatud_reverse_vahemik_on_sortimata` ja
+   `test_peatatud_sajandite_vahemik_tagastab_none` (`tests/test_year_range.py`) +
+   `src/utils/__tests__/yearDisplayUtils.test.ts`, et nad kinnitaksid uut käitumist.
+
+### Phase 1 — üks sisendväli + tuletamine + validatsioon
+
+**Tuletamisfunktsioon.** Uus puhas funktsioon `deriveYearFields(raw): { year, year_display }`
+failis `src/utils/yearDisplayUtils.ts`, kasutab olemasolevat `parseYearDisplayRange`-i.
+
+**Kutsumiskoht.** `buildMetadataPayload` (`src/utils/buildMetadataPayload.ts`) — üks
+autoriteetne, juba testitud puhas funktsioon. `MetadataFormData` väli
+`year: number; year_display: string` → asendub ühe `yearInput: string`-iga; payloadi
+ehitamisel kutsutakse `deriveYearFields(yearInput)`.
+
+**UI muudatused:**
+- `src/components/MetadataModal.tsx` — eemalda numbriline `year`-input, jäta üks
+  tekstilahter. Eeltäitmine redigeerimisel: `year_display || String(year) || ''`.
+  Placeholder nt `"1680, ca. 1680, 1670–1690, 17. saj"`.
+- `src/components/UploadMetaForm.tsx` — sama (üleslaadimise viisard).
+
+**Live-eelvaade + pehme validatsioon.** Lahtri all üks komponent, kolm olekut
+(`parseYearDisplayRange(null, raw)` põhjal):
+- **parsib** → neutraalne: "→ 1601–1700" (või "→ 1680" kui start==end)
+- **ei parsi** (mittetühi, tagastab null) → merevaik hoiatus: "⚠ Ei oska aastat
+  tuletada — formaadid: 1680, ca. 1680, 1670–1690, 17. saj"
+- **tühi** → vaikne (kuupäevata teos on legitiimne)
+
+Hoiatus on **pehme — EI blokeeri salvestamist.** Põhjus: ajaloomaterjalis on
+legitiimseid formaate, mida parser ei taba ("s.a.", "post 1700", "enne 1650", rooma
+numbrid). String kuvatakse niikuinii toorelt; parssimata teos lihtsalt ei ilmu
+aastafiltris (year=0).
+
+## Mis EI muutu
+
+- Backend salvestuskiht ja kõik lugemiskohad (`work_relations_ops.py`, `git_ops.py`,
+  prosopograafia) — `year` on endiselt `_metadata.json`-is.
+- `meili_doc.py` keskpaiga-fallback (rida 524) jääb kaitseks.
+- `formatYearDisplay` (kuvaloogika `yearDisplayUtils.ts`-s) töötab muutmata.
+- Olemasolevad `_metadata.json` failid; reindeks pole vajalik.
+
+## Testid
+
+- **Phase 0:** uuendatud `tests/test_year_range.py` (`test_peatatud_*` kinnitavad uut
+  käitumist) + `src/utils/__tests__/yearDisplayUtils.test.ts` (reverse + sajandivahemik).
+- **Phase 1:** `deriveYearFields` unit-testid (puhas number / ca. / vahemik / sajand /
+  tühi / parssimata prügi); `src/utils/__tests__/buildMetadataPayload.test.ts` laiendus
+  (yearInput → year + year_display).
+
+## Riskid ja kaalutlused
+
+- **Parseri peegelduvus.** `parse_year_range` (Python) ja `parseYearDisplayRange` (TS)
+  peavad jääma samaväärseks. Phase 0 muudatused tuleb teha MÕLEMASSE; testid mõlemal pool.
+- **Upload-tee.** `UploadMetaForm` läbib sama `buildMetadataPayload`/`deriveYearFields`
+  loogika; backend `import_as_work` salvestab payloadis tulnud `year`+`year_display`.
+- **Andmemuutust pole** — olemasolevad teosed jäävad oma `year`/`year_display`
+  väärtustega; vaid uued redigeerimised läbivad ühtse välja.

--- a/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
+++ b/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
@@ -1,8 +1,8 @@
 # Aasta-väljade ühendamine üheks sisendiks
 
 **Kuupäev:** 2026-06-24
-**Issue seos:** sõltub #31 (parse_year_range parandused)
-**Staatus:** disain kinnitatud, ootab implementatsiooniplaani
+**Issue seos:** Phase 0 = #31 (parse_year_range parandused) — ✅ tehtud (commit 0f12cae)
+**Staatus:** disain kinnitatud, Phase 0 valmis, ootab Phase 1 implementatsiooniplaani
 
 ## Probleem
 
@@ -18,8 +18,10 @@ Nende eraldi käsitsi hoidmine ei anna sisulist väärtust: parsimisloogika
 ## Eesmärk
 
 Kasutajale jääb **üks nähtav tekstilahter** (praegune `year_display`). Numbriline
-`year`-sisend eemaldatakse UI-st. Numbrilised väljad (`year`, `year_start`,
-`year_end`) **tuletatakse** sisendist. Olemasolevad andmed jäävad muutmata,
+`year`-sisend eemaldatakse UI-st. `year` (number) **tuletatakse sisendist
+salvestamisel**. `year_start`/`year_end` **tuletatakse endiselt backend'is
+indekseerimisel** (`meili_doc.py`, muutmata) ega ole `_metadata.json`/payloadi
+väljad — neid see disain ei puuduta. Olemasolevad andmed jäävad muutmata,
 migratsiooni ega reindeksit ei vajata.
 
 ## Andmemudel — "tark sisend, duaalne salvestus"
@@ -38,11 +40,30 @@ Tuletamise reegel sisendstringist `raw`:
 | `"17. saj"` | 1650 (keskpaik) | `"17. saj"` |
 | `"1601–1700"` | 1650 (keskpaik) | `"1601–1700"` |
 | `""` (tühi) | 0 | `""` |
-| `"XVII saj"` (ei parsi) | 0 | `"XVII saj"` |
+| `"XVII saj"` (ei parsi, **uus** väärtus) | 0 | `"XVII saj"` |
+| `"XVII saj"` (ei parsi, **muutmata** + olemasolev `year=1650`) | 1650 (säilitatud) | `"XVII saj"` |
 
-**Reegel:** `/^\d{1,4}$/` → puhas number, `year_display=""`. Muidu → `year_display=raw`,
-`year =` keskpaik `(start+end)//2` funktsioonist `parseYearDisplayRange(null, raw)`,
-või `0` kui ei parsi.
+**Funktsiooni signatuur:**
+```ts
+deriveYearFields(
+  raw: string,
+  existing?: { year?: number; year_display?: string },
+): { year: number; year_display: string }
+```
+
+**Reegel** (sisend alati `value = raw.trim()` enne regex'i ja salvestust):
+1. `value === ""` → `{ year: 0, year_display: "" }`
+2. `/^\d{1,4}$/.test(value)` → puhas number: `{ year: parseInt(value), year_display: "" }`
+3. parsib (`parseYearDisplayRange(null, value) !== null`) → `{ year: (start+end)>>1, year_display: value }`
+4. **ei parsi, AGA `value === existing?.year_display?.trim()` ja `existing.year` olemas**
+   → säilita vana: `{ year: existing.year, year_display: value }`
+5. ei parsi ja uus/muudetud väärtus → `{ year: 0, year_display: value }`
+
+**Põhjus reeglile 4 (vaikse rikkumise vastu):** olemasolevas kirjes võib olla käsitsi
+korras `year` parssimata `year_display` kõrval (nt `{ year: 1650, year_display: "XVII saj" }`).
+Kui kasutaja redigeerib mõnda muud välja ega puuduta dateeringut, EI tohi seda `year`-it
+vaikselt nullida. Säilitamine kehtib AINULT kui kuvastring on muutmata — kui kasutaja
+muudab stringi, tuletatakse uuesti (reegel 5).
 
 **Järjepidevus:** sajand käsitletakse oma vahemikuna ja `year` tuletatakse sama
 reegliga nagu iga vahemik. "17. saj" = (1601, 1700) → keskpaik 1650, identne
@@ -55,34 +76,41 @@ Esialgne "UI nüüd + skeemikustutus hiljem" plaan **lahustub**: kuna `year` jä
 legitiimseks salvestuseks puhaste aastate jaoks, eraldi skeemikustutuse faasi pole
 vaja. Jääb kaks faasi:
 
-### Phase 0 — parser (#31), eeltingimus
+### Phase 0 — parser (#31), eeltingimus — ✅ TEHTUD (commit 0f12cae)
 
 `parse_year_range` saab numbrilise `year`-i ainsaks tuleallikaks, seega #31 vead
-tuleb parandada ENNE, et servajuhud ei korrumpeeriks tuletatud `year`-it. Mõlemas
-peeglis (`server/utils.py` + `src/utils/yearDisplayUtils.ts`):
+tuli parandada ENNE, et servajuhud ei korrumpeeriks tuletatud `year`-it. Tehtud
+mõlemas peeglis (`server/utils.py` + `src/utils/yearDisplayUtils.ts`):
 
 1. **Tagurpidi vahemik:** `(years[0], years[-1])` → `(min(years), max(years))`.
-   "1690-1670" → (1670, 1690).
-2. **Sajandivahemik:** uus muster `^(\d{1,2})\.?\s*[-–]\s*(\d{1,2})\.?\s*saj`
-   → `((N-1)*100+1, M*100)`. "17.-19. saj" → (1601, 1900).
-3. Uuenda lukustatud testid `test_peatatud_reverse_vahemik_on_sortimata` ja
-   `test_peatatud_sajandite_vahemik_tagastab_none` (`tests/test_year_range.py`) +
-   `src/utils/__tests__/yearDisplayUtils.test.ts`, et nad kinnitaksid uut käitumist.
+   "1690-1670" → (1670, 1690). ✅
+2. **Sajandivahemik:** uus muster (`_CENTURY_RANGE_RE`)
+   → `((N-1)*100+1, M*100)`. "17.-19. saj" → (1601, 1900). ✅
+3. Lukustatud testid `test_peatatud_*` (`tests/test_year_range.py`) +
+   `src/utils/__tests__/yearDisplayUtils.test.ts` uuendatud uut käitumist kinnitama;
+   +16 testi, kõik rohelised. ✅
+4. Serveri andmekontroll: 0 sajandi-mustrit / 0 reverse-vahemikku tootmises
+   (kinnitab, et tegu robustsus-parandusega, mitte olemasoleva data parandusega). ✅
 
 ### Phase 1 — üks sisendväli + tuletamine + validatsioon
 
-**Tuletamisfunktsioon.** Uus puhas funktsioon `deriveYearFields(raw): { year, year_display }`
-failis `src/utils/yearDisplayUtils.ts`, kasutab olemasolevat `parseYearDisplayRange`-i.
+**Tuletamisfunktsioon.** Uus puhas funktsioon `deriveYearFields(raw, existing?)` (vt
+signatuur ja reeglid ülal) failis `src/utils/yearDisplayUtils.ts`, kasutab olemasolevat
+`parseYearDisplayRange`-i.
 
 **Kutsumiskoht.** `buildMetadataPayload` (`src/utils/buildMetadataPayload.ts`) — üks
 autoriteetne, juba testitud puhas funktsioon. `MetadataFormData` väli
-`year: number; year_display: string` → asendub ühe `yearInput: string`-iga; payloadi
-ehitamisel kutsutakse `deriveYearFields(yearInput)`.
+`year: number; year_display: string` → asendub ühe `yearInput: string`-iga. Payloadi
+ehitamisel kutsutakse `deriveYearFields(yearInput, existing)`, kus `existing` on vormi
+avamisel laetud algsed `{ year, year_display }` (reegel 4 säilitamiseks);
+`buildMetadataPayload` saab `existing` lisaparameetrina.
 
 **UI muudatused:**
 - `src/components/MetadataModal.tsx` — eemalda numbriline `year`-input, jäta üks
-  tekstilahter. Eeltäitmine redigeerimisel: `year_display || String(year) || ''`.
-  Placeholder nt `"1680, ca. 1680, 1670–1690, 17. saj"`.
+  tekstilahter. Eeltäitmine redigeerimisel: `year_display || (year ? String(year) : '')`
+  (väldib `year=0` korral lahtrisse `"0"` tekkimist). Säilita vormi avamisel algsed
+  `year`/`year_display` (vaja reegel 4 jaoks). Placeholder nt
+  `"1680, ca. 1680, 1670–1690, 17. saj"`.
 - `src/components/UploadMetaForm.tsx` — sama (üleslaadimise viisard).
 
 **Live-eelvaade + pehme validatsioon.** Lahtri all üks komponent, kolm olekut
@@ -121,3 +149,11 @@ aastafiltris (year=0).
   loogika; backend `import_as_work` salvestab payloadis tulnud `year`+`year_display`.
 - **Andmemuutust pole** — olemasolevad teosed jäävad oma `year`/`year_display`
   väärtustega; vaid uued redigeerimised läbivad ühtse välja.
+- **Autoriteetsuse piir (LAHTINE OTSUS).** Kui derivatsioon on ainult frontend'i
+  `buildMetadataPayload`-s, kehtib invariant (sh reegel 4 vaikse rikkumise vastu) ainult
+  **UI kaudu salvestamisel**. API otsekutse võiks saata vastuolulise `year` + `year_display`.
+  Praktikas on metaandmete kirjutaja ainult admin/editor-UI. Kaks varianti:
+  **(A)** jätta frontend-only ja sõnastada invariant "UI kaudu salvestamisel"; või
+  **(B)** lisada sama derivatsioon/kontroll backend'i ainsasse lehtrisse
+  `save_work_metadata` (`metadata_ops.py`), kus on ligi ka olemasolev `_metadata.json`
+  (reegel 4 robustsem) — tõeline invariant, aga lisab kolmanda peegli (Python).

--- a/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
+++ b/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
@@ -53,7 +53,9 @@ deriveYearFields(
 
 **Reegel** (sisend alati `value = raw.trim()` enne regex'i ja salvestust):
 1. `value === ""` → `{ year: 0, year_display: "" }`
-2. `/^\d{1,4}$/.test(value)` → puhas number: `{ year: parseInt(value), year_display: "" }`
+2. `/^\d{3,4}$/.test(value)` → puhas number (3–4 kohaline): `{ year: parseInt(value), year_display: "" }`.
+   (1–2 kohaline nagu `"80"` või `"0"` langeb reeglile 3 → ei parsi → pehme hoiatus + `year=0`;
+   VUTT korpus on 4-kohalised varauusaja aastad, 1–2 kohaline on praktikas viga.)
 3. parsib (`parseYearDisplayRange(null, value) !== null`) → `{ year: (start+end)>>1, year_display: value }`
 4. **ei parsi, AGA `value === existing?.year_display?.trim()` ja `existing.year` olemas**
    → säilita vana: `{ year: existing.year, year_display: value }`
@@ -98,20 +100,35 @@ mõlemas peeglis (`server/utils.py` + `src/utils/yearDisplayUtils.ts`):
 signatuur ja reeglid ülal) failis `src/utils/yearDisplayUtils.ts`, kasutab olemasolevat
 `parseYearDisplayRange`-i.
 
-**Kutsumiskoht.** `buildMetadataPayload` (`src/utils/buildMetadataPayload.ts`) — üks
-autoriteetne, juba testitud puhas funktsioon. `MetadataFormData` väli
-`year: number; year_display: string` → asendub ühe `yearInput: string`-iga. Payloadi
-ehitamisel kutsutakse `deriveYearFields(yearInput, existing)`, kus `existing` on vormi
-avamisel laetud algsed `{ year, year_display }` (reegel 4 säilitamiseks);
-`buildMetadataPayload` saab `existing` lisaparameetrina.
+**Kutsumiskoht — üks autoriteetne tee.** `deriveYearFields` elab `buildMetadataPayload`-s
+(`src/utils/buildMetadataPayload.ts`), aga **kõik kirjutus-/täitmisteed peavad selle kaudu
+käima**. Inventuur (verifitseeritud koodist):
+
+| Tee | Asukoht | Praegune seis |
+|-----|---------|---------------|
+| Käsitsi salvestus | `MetadataModal.tsx:362` `handleSave` → `buildMetadataPayload` | ✅ kasutab |
+| Vormi-avamise init | `MetadataModal.tsx:231–232` `setMetaForm` | seab `year`+`year_display` otse |
+| Server/ESTER auto-fill | `MetadataModal.tsx:335–350` `setMetaForm` | seab `year`+`year_display` otse API vastusest |
+| **Upload-vorm** | `UploadMetaForm.tsx:214–229` **inline payload**, oma `MetaForm` (`year: string`), eraldi endpoint `/admin/upload/.../meta` | ❌ EI kasuta `buildMetadataPayload`-i |
+
+`MetadataFormData.year:number + year_display:string` → asendub ühe `yearInput:string`-iga.
+`buildMetadataPayload(form, workId, kataloog, existing)` saab `existing` lisaparameetri ja
+kutsub `deriveYearFields(yearInput, existing)`.
+
+**`existing` (reegel 4 jaoks) on muteeritav ref — avamise/auto-filli snapshot, MITTE "viimane salvestatud":**
+- seatakse vormi avamisel algsest `{ year, year_display }` (`:231–232`);
+- **re-seatakse server/ESTER auto-filli järel** (`:335–350`) auto-fillitud `{ year, year_display }`-iks,
+  et ka ESTER-i toodud `year` säiliks, kui kasutaja kuva ei muuda;
+- EI muutu kasutaja klahvivajutustest `yearInput`-is.
 
 **UI muudatused:**
-- `src/components/MetadataModal.tsx` — eemalda numbriline `year`-input, jäta üks
-  tekstilahter. Eeltäitmine redigeerimisel: `year_display || (year ? String(year) : '')`
-  (väldib `year=0` korral lahtrisse `"0"` tekkimist). Säilita vormi avamisel algsed
-  `year`/`year_display` (vaja reegel 4 jaoks). Placeholder nt
-  `"1680, ca. 1680, 1670–1690, 17. saj"`.
-- `src/components/UploadMetaForm.tsx` — sama (üleslaadimise viisard).
+- `MetadataModal.tsx` — eemalda numbriline `year`-input, jäta üks tekstilahter. Eeltäitmine
+  **nii avamisel kui auto-fillil**: `year_display || (year ? String(year) : '')` (väldib `year=0`
+  korral `"0"`). Placeholder `"1680, ca. 1680, 1670–1690, 17. saj"`.
+- `UploadMetaForm.tsx` — **refaktoreeri `buildMetadataPayload`-i kasutama** (ühtlusta
+  `MetaForm`→`MetadataFormData`, `year:string`→`yearInput`). Eelistatud, sest hoiab ühe
+  autoriteetse tee; alternatiiv (lisa vaid `deriveYearFields`-i kutse inline-ehitajasse) jätab
+  loogika dubleerituks ja laseb upload-teel uuesti lahkneda. NB: eraldi staging-endpoint säilib.
 
 **Live-eelvaade + pehme validatsioon.** Lahtri all üks komponent, kolm olekut
 (`parseYearDisplayRange(null, raw)` põhjal):
@@ -129,6 +146,11 @@ aastafiltris (year=0).
 
 - Backend salvestuskiht ja kõik lugemiskohad (`work_relations_ops.py`, `git_ops.py`,
   prosopograafia) — `year` on endiselt `_metadata.json`-is.
+- `save_work_metadata` (`metadata_ops.py:165`) teeb `meta.update(clean)` — **pime asendus**, ja
+  on (docstring kinnitab) ainus `_metadata.json` kirjutaja. `year: 0` on legitiimne salvestatav
+  väärtus, mis kirjutab hea olemasoleva aasta üle — see ON reegli 5 kavatsus. **Seega ainus kaitse
+  vaikse andmekao vastu on frontend'i reegel 4; backend ei valva.** (Warn-hardening tahtlikult ära
+  jäetud: tabaks reegli 5 legitiimset juhtu valesti — YAGNI.)
 - `meili_doc.py` keskpaiga-fallback (rida 524) jääb kaitseks.
 - `formatYearDisplay` (kuvaloogika `yearDisplayUtils.ts`-s) töötab muutmata.
 - Olemasolevad `_metadata.json` failid; reindeks pole vajalik.
@@ -138,15 +160,20 @@ aastafiltris (year=0).
 - **Phase 0:** uuendatud `tests/test_year_range.py` (`test_peatatud_*` kinnitavad uut
   käitumist) + `src/utils/__tests__/yearDisplayUtils.test.ts` (reverse + sajandivahemik).
 - **Phase 1:** `deriveYearFields` unit-testid (puhas number / ca. / vahemik / sajand /
-  tühi / parssimata prügi); `src/utils/__tests__/buildMetadataPayload.test.ts` laiendus
-  (yearInput → year + year_display).
+  tühi / parssimata prügi); **reegel 4** test (parssimata + muutmata `existing` → `year` säilib;
+  muudetud string → `year=0`); **reegel 2** servajuht (`"80"`/`"0"` → ei parsi); keskpaiga
+  **pariteeditest** (TS `>>1` == Py `//2` fikseeritud vahemikele);
+  `src/utils/__tests__/buildMetadataPayload.test.ts` laiendus (yearInput + existing → payload);
+  UploadMetaForm tee (kui refaktoreeritud jagatud teele).
 
 ## Riskid ja kaalutlused
 
 - **Parseri peegelduvus.** `parse_year_range` (Python) ja `parseYearDisplayRange` (TS)
   peavad jääma samaväärseks. Phase 0 muudatused tuleb teha MÕLEMASSE; testid mõlemal pool.
-- **Upload-tee.** `UploadMetaForm` läbib sama `buildMetadataPayload`/`deriveYearFields`
-  loogika; backend `import_as_work` salvestab payloadis tulnud `year`+`year_display`.
+- **Upload-tee (PARANDATUD ARUSAAM).** `UploadMetaForm` EI kasuta praegu `buildMetadataPayload`-i
+  — ehitab payloadi inline (`:214–229`), oma `MetaForm` (`year: string`), eraldi staging-endpoint.
+  Phase 1 peab selle teadlikult katma (vt write-path inventuur Phase 1-s), muidu lekib vana
+  kahe-välja loogika upload-teel.
 - **Andmemuutust pole** — olemasolevad teosed jäävad oma `year`/`year_display`
   väärtustega; vaid uued redigeerimised läbivad ühtse välja.
 - **Autoriteetsuse piir (OTSUSTATUD: frontend-only).** Derivatsioon elab ainult

--- a/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
+++ b/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
@@ -2,7 +2,7 @@
 
 **Kuupäev:** 2026-06-24
 **Issue seos:** Phase 0 = #31 (parse_year_range parandused) — ✅ tehtud (commit 0f12cae)
-**Staatus:** disain kinnitatud, Phase 0 valmis, kõik otsused tehtud, ootab Phase 1 implementatsiooniplaani
+**Staatus:** disain kinnitatud, Phase 0 valmis, Phase 1 valmis (commit c71ba54), kõik otsused tehtud
 
 ## Probleem
 
@@ -94,7 +94,7 @@ mõlemas peeglis (`server/utils.py` + `src/utils/yearDisplayUtils.ts`):
 4. Serveri andmekontroll: 0 sajandi-mustrit / 0 reverse-vahemikku tootmises
    (kinnitab, et tegu robustsus-parandusega, mitte olemasoleva data parandusega). ✅
 
-### Phase 1 — üks sisendväli + tuletamine + validatsioon
+### Phase 1 — üks sisendväli + tuletamine + validatsioon — ✅ TEHTUD (commit c71ba54)
 
 **Tuletamisfunktsioon.** Uus puhas funktsioon `deriveYearFields(raw, existing?)` (vt
 signatuur ja reeglid ülal) failis `src/utils/yearDisplayUtils.ts`, kasutab olemasolevat
@@ -170,10 +170,21 @@ aastafiltris (year=0).
 
 - **Parseri peegelduvus.** `parse_year_range` (Python) ja `parseYearDisplayRange` (TS)
   peavad jääma samaväärseks. Phase 0 muudatused tuleb teha MÕLEMASSE; testid mõlemal pool.
-- **Upload-tee (PARANDATUD ARUSAAM).** `UploadMetaForm` EI kasuta praegu `buildMetadataPayload`-i
+- **Upload-tee (PARANDATUD ARUSAAM).** `UploadMetaForm` EI kasutanud `buildMetadataPayload`-i
   — ehitab payloadi inline (`:214–229`), oma `MetaForm` (`year: string`), eraldi staging-endpoint.
   Phase 1 peab selle teadlikult katma (vt write-path inventuur Phase 1-s), muidu lekib vana
   kahe-välja loogika upload-teel.
+  - **IMPLEMENTEERITUD (c71ba54):** valiti spec-i variant (b) — `deriveYearFields` kutse
+    inline-ehitajas, MITTE `buildMetadataPayload` refactor. Põhjus: upload PATCH endpoint
+    (`/admin/upload/{id}/meta` → `update_upload_meta`) võtab **lame** `updates` dicti
+    (top-level väljad), erinevalt `/update-work-metadata` pesastatud `{work_id, metadata}`
+    kujust. `buildMetadataPayload` tagastab pesastatud kuju ja ei sobi otse. Ühine
+    `deriveYearFields` + jagatud `clean*` helperid saavutavad unifikatsioonieesmärgi (üks
+    tuletus-/puhastusloogika) ilma vale payloadi kuju surumata.
+  - **Backend parandus (eelnev viga):** `update_upload_meta` lubatud hulk EI sisaldanud
+    `year_display`-it → sõeluti vaikselt välja, nii et `import_as_work` (mis loeb
+    `year_display`-i `OPTIONAL_META_FIELDS`-st) ei saanud seda kunagi. Lisatud `year_display`
+    lubatud hulka.
 - **Andmemuutust pole** — olemasolevad teosed jäävad oma `year`/`year_display`
   väärtustega; vaid uued redigeerimised läbivad ühtse välja.
 - **Autoriteetsuse piir (OTSUSTATUD: frontend-only).** Derivatsioon elab ainult

--- a/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
+++ b/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
@@ -2,7 +2,7 @@
 
 **Kuupäev:** 2026-06-24
 **Issue seos:** Phase 0 = #31 (parse_year_range parandused) — ✅ tehtud (commit 0f12cae)
-**Staatus:** disain kinnitatud, Phase 0 valmis, ootab Phase 1 implementatsiooniplaani
+**Staatus:** disain kinnitatud, Phase 0 valmis, kõik otsused tehtud, ootab Phase 1 implementatsiooniplaani
 
 ## Probleem
 
@@ -149,11 +149,9 @@ aastafiltris (year=0).
   loogika; backend `import_as_work` salvestab payloadis tulnud `year`+`year_display`.
 - **Andmemuutust pole** — olemasolevad teosed jäävad oma `year`/`year_display`
   väärtustega; vaid uued redigeerimised läbivad ühtse välja.
-- **Autoriteetsuse piir (LAHTINE OTSUS).** Kui derivatsioon on ainult frontend'i
-  `buildMetadataPayload`-s, kehtib invariant (sh reegel 4 vaikse rikkumise vastu) ainult
-  **UI kaudu salvestamisel**. API otsekutse võiks saata vastuolulise `year` + `year_display`.
-  Praktikas on metaandmete kirjutaja ainult admin/editor-UI. Kaks varianti:
-  **(A)** jätta frontend-only ja sõnastada invariant "UI kaudu salvestamisel"; või
-  **(B)** lisada sama derivatsioon/kontroll backend'i ainsasse lehtrisse
-  `save_work_metadata` (`metadata_ops.py`), kus on ligi ka olemasolev `_metadata.json`
-  (reegel 4 robustsem) — tõeline invariant, aga lisab kolmanda peegli (Python).
+- **Autoriteetsuse piir (OTSUSTATUD: frontend-only).** Derivatsioon elab ainult
+  frontend'i `buildMetadataPayload`-s. Invariant (sh reegel 4 vaikse rikkumise vastu)
+  kehtib **UI kaudu salvestamisel** — ainus reaalne metaandmete kirjutaja on admin/editor-UI
+  (YAGNI: muid API-kirjutajaid pole). Backend'i ei muudeta, kolmandat Python-peeglit ei lisata.
+  *Tuleviku-hardening, kui tekib muid kirjutajaid:* sama derivatsioon/kontroll
+  `save_work_metadata`-sse (`metadata_ops.py`), kus on ligi olemasolev `_metadata.json`.

--- a/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
+++ b/docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md
@@ -130,10 +130,13 @@ kutsub `deriveYearFields(yearInput, existing)`.
   autoriteetse tee; alternatiiv (lisa vaid `deriveYearFields`-i kutse inline-ehitajasse) jätab
   loogika dubleerituks ja laseb upload-teel uuesti lahkneda. NB: eraldi staging-endpoint säilib.
 
-**Live-eelvaade + pehme validatsioon.** Lahtri all üks komponent, kolm olekut
-(`parseYearDisplayRange(null, raw)` põhjal):
-- **parsib** → neutraalne: "→ 1601–1700" (või "→ 1680" kui start==end)
-- **ei parsi** (mittetühi, tagastab null) → merevaik hoiatus: "⚠ Ei oska aastat
+**Live-eelvaade + pehme validatsioon.** Lahtri all üks komponent, mis peegeldab
+**`deriveYearFields(raw, existing)`-i — SAMA tõeallikas mis salvestus** (ei kutsu
+`parseYearDisplayRange`-i otse, muidu lahkneksid nt 3-kohaline `"800"` või reegel 4
+säilitatud `year`). Kolm olekut:
+- **tuletab `year > 0`** → neutraalne: "→ 1601–1700" (filtrivahemik `parseYearDisplayRange`-st)
+  või "→ 800" (üksik tuletatud `year`, kui vahemikku pole)
+- **`year = 0`** (mittetühi) → merevaik hoiatus: "⚠ Ei oska aastat
   tuletada — formaadid: 1680, ca. 1680, 1670–1690, 17. saj"
 - **tühi** → vaikne (kuupäevata teos on legitiimne)
 

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -343,7 +343,7 @@ def update_upload_meta(upload_id: str, updates: dict) -> bool:
     if not _valid_upload_id(upload_id):
         return False
     allowed = {
-        'title', 'year', 'collections', 'languages',
+        'title', 'year', 'year_display', 'collections', 'languages',
         'type', 'genre',
         'creators', 'location',
         'publisher', 'tags',

--- a/src/components/MetadataModal.tsx
+++ b/src/components/MetadataModal.tsx
@@ -12,7 +12,8 @@ import { FILE_API_URL } from '../config';
 import { fetchWithTimeout, getAuthHeaders } from '../utils/fetchWithTimeout';
 import { getLangCode } from '../utils/getLangCode';
 import { ErrorBanner } from './ErrorBanner';
-import { buildMetadataPayload } from '../utils/buildMetadataPayload';
+import { buildMetadataPayload, type YearFieldsExisting } from '../utils/buildMetadataPayload';
+import { parseYearDisplayRange } from '../utils/yearDisplayUtils';
 import ArchiveSelect from './ArchiveSelect';
 
 interface MetadataModalProps {
@@ -29,8 +30,7 @@ interface MetadataModalProps {
 
 interface MetadataForm {
   title: string;
-  year: number;
-  year_display: string;                // Kuvatav aasta (nt "ca. 1680"), tühi = kasuta year numbrit
+  yearInput: string;                  // Üks tekstilahter: 1680 | ca. 1680 | 1670–1690 | 17. saj (vt deriveYearFields)
   type: string | LinkedEntity | null;  // LinkedEntity Wikidata linkimiseks
   genre: (string | LinkedEntity)[];  // Mitu žanrit
   tags: (string | LinkedEntity)[];
@@ -138,6 +138,31 @@ export const CollectionDropdown: React.FC<CollectionDropdownProps> = ({ collecti
   );
 };
 
+/**
+ * Aasta-lahtri live-eelvaade + pehme validatsioon (aasta-välja ühendamine).
+ * Kolm olekut `parseYearDisplayRange(null, value)` põhjal:
+ *  - parsib    → neutraalne: "→ 1601–1700" (või "→ 1680" kui start==end)
+ *  - ei parsi → merevaik hoiatus (EI blokeeri salvestamist — ajalooliselt legitiimsed formaadid)
+ *  - tühi      → vaikne (kuupäevata teos on legitiimne)
+ */
+export const YearInputPreview: React.FC<{ value: string }> = ({ value }) => {
+  const { t } = useTranslation(['workspace', 'common']);
+  const trimmed = (value ?? '').trim();
+  if (!trimmed) return null;  // tühi → vaikne
+
+  const range = parseYearDisplayRange(null, trimmed);
+  if (!range) {
+    // ei parsi (mittetühi) → pehme hoiatus
+    return (
+      <p className="mt-1 text-xs text-amber-600">
+        {t('metadata.yearInputWarn', '⚠ Ei oska aastat tuletada — formaadid: 1680, ca. 1680, 1670–1690, 17. saj')}
+      </p>
+    );
+  }
+  const preview = range.start === range.end ? String(range.start) : `${range.start}–${range.end}`;
+  return <p className="mt-1 text-xs text-gray-400">→ {preview}</p>;
+};
+
 const MetadataModal: React.FC<MetadataModalProps> = ({
   isOpen,
   onClose,
@@ -156,8 +181,7 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
   const [archives, setArchives] = useState<Record<string, { name: string; url?: string }>>({});
   const [metaForm, setMetaForm] = useState<MetadataForm>({
     title: '',
-    year: 0,
-    year_display: '',
+    yearInput: '',
     type: null,
     genre: [],
     tags: [],
@@ -187,6 +211,11 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
   const [dragPos, setDragPos] = useState<{ x: number; y: number } | null>(null);
   const dragOffset = useRef<{ x: number; y: number } | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+
+  // Aasta-välja invariant (reegel 4): vormi avamisel (ja ESTER auto-filli järel)
+  // snap-shotitud algne { year, year_display }. Kui kasutaja kuvastringi ei muuda,
+  // säilitatakse olemasolev `year` isegi kui see ei parsi (väldib vaikset andmekao).
+  const existingYearRef = useRef<YearFieldsExisting>({});
 
   const handleDragStart = (e: React.MouseEvent) => {
     if ((e.target as HTMLElement).closest('button')) return;
@@ -226,10 +255,14 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
     }
 
     // Algväärtused page/work objektidest
+    const initYear = work?.year || page.year || page.aasta || 0;
+    const initYearDisplay = work?.year_display || page.year_display || '';
+    // Üks tekstilahter: kuva eelistatult, muidu number (0-st ei teki "0" lahtris)
+    const initYearInput = initYearDisplay || (initYear ? String(initYear) : '');
+    existingYearRef.current = { year: initYear, year_display: initYearDisplay };
     setMetaForm({
       title: work?.title || page.title || '',
-      year: work?.year || page.year || page.aasta || 0,
-      year_display: work?.year_display || page.year_display || '',
+      yearInput: initYearInput,
       type: work?.type || page.type || null,
       genre: (() => { const g = work?.genre ?? page.genre; return Array.isArray(g) ? g : (g ? [g] : []); })(),
       tags: work?.tags || page.tags || [],
@@ -334,8 +367,7 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
 
         setMetaForm({
           title: title,
-          year: year ? parseInt(year) : 0,
-          year_display: m.year_display || '',
+          yearInput: m.year_display || (year ? String(year) : ''),
           type: m.type || null,
           genre: (() => { const g = m.genre; return Array.isArray(g) ? g : (g ? [g] : []); })(),
           tags: Array.isArray(tags) ? tags : [],
@@ -348,6 +380,9 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
           collections: Array.isArray(m.collections) ? m.collections : [],
           archive_refs: Array.isArray(m.archive_refs) ? m.archive_refs : [],
         });
+        // Re-set existing snap-shot pärast ESTER/server auto-filli, et ka
+        // auto-fillitud `year` säiliks, kui kasutaja kuvastringi ei muuda (reegel 4).
+        existingYearRef.current = { year: year ? parseInt(year) : 0, year_display: m.year_display || '' };
       }
     } catch (e) {
       console.error("Viga metaandmete laadimisel failiserverist:", e);
@@ -359,7 +394,7 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
     setSaveStatus('idle');
 
     try {
-      const payload = buildMetadataPayload(metaForm, workId, page.originaal_kataloog);
+      const payload = buildMetadataPayload(metaForm, workId, page.originaal_kataloog, existingYearRef.current);
 
       const response = await fetchWithTimeout(`${FILE_API_URL}/update-work-metadata`, {
         method: 'POST',
@@ -535,27 +570,19 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
           {/* Grupp 2: Kolofoon */}
           <div className="border border-gray-200 rounded-lg p-3 space-y-3 bg-gray-50/50">
             <h4 className="text-xs font-bold text-gray-600 uppercase -mt-1">{t('metadata.colophon', 'Kolofoon')}</h4>
-            {/* Rida 1: Aasta */}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">{t('metadata.year')}</label>
-                <input
-                  type="number"
-                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
-                  value={metaForm.year || ''}
-                  onChange={e => setMetaForm({ ...metaForm, year: parseInt(e.target.value) || 0 })}
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">{t('metadata.yearDisplay')}</label>
-                <input
-                  type="text"
-                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
-                  placeholder={t('metadata.yearDisplayPlaceholder', 'nt ca. 1680')}
-                  value={metaForm.year_display}
-                  onChange={e => setMetaForm({ ...metaForm, year_display: e.target.value })}
-                />
-              </div>
+            {/* Aasta — üks tekstilahter (aasta-välja ühendamine, vt deriveYearFields) */}
+            <div>
+              <label className="block text-xs font-medium text-gray-500 mb-1">{t('metadata.year')}</label>
+              <input
+                type="text"
+                inputMode="text"
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
+                placeholder={t('metadata.yearInputPlaceholder', '1680, ca. 1680, 1670–1690, 17. saj')}
+                value={metaForm.yearInput}
+                onChange={e => setMetaForm({ ...metaForm, yearInput: e.target.value })}
+              />
+              {/* Live-eelvaade / pehme validatsioon (EI blokeeri salvestamist) */}
+              <YearInputPreview value={metaForm.yearInput} />
             </div>
             {/* Rida 2: Koht ja trükkal */}
             <div className="grid grid-cols-2 gap-3">

--- a/src/components/MetadataModal.tsx
+++ b/src/components/MetadataModal.tsx
@@ -13,7 +13,7 @@ import { fetchWithTimeout, getAuthHeaders } from '../utils/fetchWithTimeout';
 import { getLangCode } from '../utils/getLangCode';
 import { ErrorBanner } from './ErrorBanner';
 import { buildMetadataPayload, type YearFieldsExisting } from '../utils/buildMetadataPayload';
-import { parseYearDisplayRange } from '../utils/yearDisplayUtils';
+import { parseYearDisplayRange, deriveYearFields } from '../utils/yearDisplayUtils';
 import ArchiveSelect from './ArchiveSelect';
 
 interface MetadataModalProps {
@@ -140,26 +140,33 @@ export const CollectionDropdown: React.FC<CollectionDropdownProps> = ({ collecti
 
 /**
  * Aasta-lahtri live-eelvaade + pehme validatsioon (aasta-välja ühendamine).
- * Kolm olekut `parseYearDisplayRange(null, value)` põhjal:
- *  - parsib    → neutraalne: "→ 1601–1700" (või "→ 1680" kui start==end)
- *  - ei parsi → merevaik hoiatus (EI blokeeri salvestamist — ajalooliselt legitiimsed formaadid)
- *  - tühi      → vaikne (kuupäevata teos on legitiimne)
+ * Peegeldab `deriveYearFields`-i — SAMA tõeallikas mis salvestus — et eelvaade ei
+ * lahkneks salvestatavast väärtusest (nt 3-kohaline "800" või reegel 4 säilitatud `year`).
+ * Kolm olekut:
+ *  - tuletab `year > 0`    → neutraalne: "→ 1670–1690" (filtrivahemik) või "→ 800" (üksik)
+ *  - `year = 0` (mittetühi) → merevaik hoiatus (EI blokeeri salvestamist — ajaloolised formaadid)
+ *  - tühi                   → vaikne (kuupäevata teos on legitiimne)
  */
-export const YearInputPreview: React.FC<{ value: string }> = ({ value }) => {
+export const YearInputPreview: React.FC<{ value: string; existing?: YearFieldsExisting }> = ({ value, existing }) => {
   const { t } = useTranslation(['workspace', 'common']);
   const trimmed = (value ?? '').trim();
   if (!trimmed) return null;  // tühi → vaikne
 
-  const range = parseYearDisplayRange(null, trimmed);
-  if (!range) {
-    // ei parsi (mittetühi) → pehme hoiatus
+  // Tuletame sama loogikaga mis salvestus (reegel 4: säilitatud year arvestab existing-it)
+  const { year } = deriveYearFields(trimmed, existing);
+  if (!year) {
+    // ei tuleta aastat (mittetühi) → pehme hoiatus
     return (
       <p className="mt-1 text-xs text-amber-600">
         {t('metadata.yearInputWarn', '⚠ Ei oska aastat tuletada — formaadid: 1680, ca. 1680, 1670–1690, 17. saj')}
       </p>
     );
   }
-  const preview = range.start === range.end ? String(range.start) : `${range.start}–${range.end}`;
+  // Näita filtrivahemikku kui parser annab (informatiivsem), muidu tuletatud üksik `year`
+  const range = parseYearDisplayRange(null, trimmed);
+  const preview = range
+    ? (range.start === range.end ? String(range.start) : `${range.start}–${range.end}`)
+    : String(year);
   return <p className="mt-1 text-xs text-gray-400">→ {preview}</p>;
 };
 
@@ -582,7 +589,7 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
                 onChange={e => setMetaForm({ ...metaForm, yearInput: e.target.value })}
               />
               {/* Live-eelvaade / pehme validatsioon (EI blokeeri salvestamist) */}
-              <YearInputPreview value={metaForm.yearInput} />
+              <YearInputPreview value={metaForm.yearInput} existing={existingYearRef.current} />
             </div>
             {/* Rida 2: Koht ja trükkal */}
             <div className="grid grid-cols-2 gap-3">

--- a/src/components/UploadMetaForm.tsx
+++ b/src/components/UploadMetaForm.tsx
@@ -4,18 +4,20 @@
  * Laadib hetke meta /admin/upload/{id}/meta GET kaudu, salvestab PATCH kaudu.
  * EntityPicker välju kasutatakse linked data tagamiseks (Wikidata, VIAF, GND).
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Save, Plus, Trash2, X, Loader2, CheckCircle, AlertTriangle } from 'lucide-react';
 import { Creator, CreatorRole, ArchiveRef } from '../types';
 import { LinkedEntity } from '../types/LinkedEntity';
 import { Collections, getVocabularies, Vocabularies } from '../services/collectionService';
 import EntityPicker, { PeopleRegisterEntry } from './EntityPicker';
-import { CollectionDropdown } from './MetadataModal';
+import { CollectionDropdown, YearInputPreview } from './MetadataModal';
 import { FILE_API_URL } from '../config';
 import { fetchWithTimeout, getAuthHeaders } from '../utils/fetchWithTimeout';
 import { getLangCode } from '../utils/getLangCode';
 import { getLabel } from '../utils/metadataUtils';
+import { deriveYearFields } from '../utils/yearDisplayUtils';
+import { cleanCreators, cleanTags, cleanEsterId, cleanArchiveRefs } from '../utils/buildMetadataPayload';
 import ArchiveSelect from './ArchiveSelect';
 
 interface UploadMetaFormProps {
@@ -35,8 +37,7 @@ interface UploadMetaFormProps {
 
 interface MetaForm {
   title: string;
-  year: string;
-  year_display: string;
+  yearInput: string;          // Üks tekstilahter: 1680 | ca. 1680 | 1670–1690 | 17. saj (vt deriveYearFields)
   type: string | LinkedEntity | null;
   genre: (string | LinkedEntity)[];
   tags: (string | LinkedEntity)[];
@@ -57,8 +58,7 @@ interface SuggestionItem {
 
 const EMPTY_FORM: MetaForm = {
   title: '',
-  year: '',
-  year_display: '',
+  yearInput: '',
   type: null,
   genre: [],
   tags: [],
@@ -89,9 +89,14 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
   const [form, setForm] = useState<MetaForm>({
     ...EMPTY_FORM,
     title: initialTitle,
-    year: initialYear,
+    yearInput: initialYear,
     collections: initialCollections,
   });
+
+  // Aasta-välja invariant (reegel 4): staging-meta laadimisel snap-shotitud algne
+  // { year, year_display }. Kui kasutaja kuvastringi ei muuda, säilitatakse olemasolev
+  // `year` isegi kui see ei parsi (väldib vaikset andmekao).
+  const existingYearRef = useRef<{ year?: number; year_display?: string }>({});
 
   const [vocabularies, setVocabularies] = useState<Vocabularies | null>(null);
   const [peopleRegister, setPeopleRegister] = useState<PeopleRegisterEntry[]>([]);
@@ -122,11 +127,15 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
         if (!r.ok || cancelled) return;
         const d = await r.json();
         const m = d.meta || {};
+        const metaYear = Number(m.year) || 0;
+        const metaYearDisplay = m.year_display || '';
+        // Üks tekstilahter: kuva eelistatult, muidu number (0-st ei teki "0" lahtris)
+        const yearInput = metaYearDisplay || (metaYear ? String(metaYear) : '') || initialYear;
+        existingYearRef.current = { year: metaYear, year_display: metaYearDisplay };
         if (!cancelled) {
           setForm({
             title: m.title || initialTitle,
-            year: String(m.year || initialYear || ''),
-            year_display: m.year_display || '',
+            yearInput,
             type: m.type ?? null,
             genre: (() => {
               const g = m.genre;
@@ -199,33 +208,23 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
     setSaveOk(false);
     setSaveError('');
 
-    const cleanCreators = form.creators
-      .filter((c) => c.name.trim() !== '')
-      .map((c) => ({ name: c.name.trim(), role: c.role, id: c.id, source: c.source }));
-
-    const cleanTags = form.tags.filter((t) =>
-      typeof t === 'string' ? t.trim() !== '' : !!t.label
-    );
-
-    let cleanEsterId = form.ester_id.trim();
-    const esterMatch = cleanEsterId.match(/record=(b\d+)/);
-    if (esterMatch) cleanEsterId = esterMatch[1];
+    const { year, year_display } = deriveYearFields(form.yearInput, existingYearRef.current);
 
     const payload: Record<string, unknown> = {
       title: form.title.trim(),
-      year: form.year,
-      year_display: form.year_display.trim() || null,
+      year,
+      year_display: year_display || null,
       type: form.type || null,
       genre: form.genre.length > 0 ? form.genre : null,
-      tags: cleanTags,
+      tags: cleanTags(form.tags),
       location: form.location,
       publisher: form.publisher,
-      creators: cleanCreators,
+      creators: cleanCreators(form.creators),
       languages: form.languages,
       collections: form.collections,
-      ester_id: cleanEsterId || null,
+      ester_id: cleanEsterId(form.ester_id),
       external_url: form.external_url.trim() || null,
-      archive_refs: form.archive_refs.filter(r => r.archive_id || r.reference),
+      archive_refs: cleanArchiveRefs(form.archive_refs),
     };
 
     try {
@@ -386,32 +385,20 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
           <h4 className="text-xs font-bold text-gray-600 uppercase -mt-1">
             {t('workspace:metadata.colophon', 'Kolofoon')}
           </h4>
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs font-medium text-gray-500 mb-1">
-                {t('workspace:metadata.year')}
-              </label>
-              <input
-                type="number"
-                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
-                value={form.year}
-                min={1200}
-                max={1800}
-                onChange={(e) => setForm({ ...form, year: e.target.value })}
-              />
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-gray-500 mb-1">
-                {t('workspace:metadata.yearDisplay')}
-              </label>
-              <input
-                type="text"
-                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
-                placeholder={t('workspace:metadata.yearDisplayPlaceholder', 'nt ca. 1680')}
-                value={form.year_display}
-                onChange={(e) => setForm({ ...form, year_display: e.target.value })}
-              />
-            </div>
+          {/* Aasta — üks tekstilahter (aasta-välja ühendamine, vt deriveYearFields) */}
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1">
+              {t('workspace:metadata.year')}
+            </label>
+            <input
+              type="text"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
+              placeholder={t('workspace:metadata.yearInputPlaceholder', '1680, ca. 1680, 1670–1690, 17. saj')}
+              value={form.yearInput}
+              onChange={(e) => setForm({ ...form, yearInput: e.target.value })}
+            />
+            {/* Live-eelvaade / pehme validatsioon (EI blokeeri salvestamist) */}
+            <YearInputPreview value={form.yearInput} />
           </div>
           <div className="grid grid-cols-2 gap-3">
             <EntityPicker

--- a/src/components/UploadMetaForm.tsx
+++ b/src/components/UploadMetaForm.tsx
@@ -398,7 +398,7 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
               onChange={(e) => setForm({ ...form, yearInput: e.target.value })}
             />
             {/* Live-eelvaade / pehme validatsioon (EI blokeeri salvestamist) */}
-            <YearInputPreview value={form.yearInput} />
+            <YearInputPreview value={form.yearInput} existing={existingYearRef.current} />
           </div>
           <div className="grid grid-cols-2 gap-3">
             <EntityPicker

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -205,8 +205,6 @@
     "author": "Author",
     "respondens": "Respondens",
     "year": "Year",
-    "yearDisplay": "Display year",
-    "yearDisplayPlaceholder": "e.g. ca. 1680, 1670–1690 or 19. saj",
     "yearInputPlaceholder": "1680, ca. 1680, 1670–1690, 17. saj",
     "yearInputWarn": "⚠ Cannot parse year — formats: 1680, ca. 1680, 1670–1690, 17. saj",
     "place": "Place",

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -207,6 +207,8 @@
     "year": "Year",
     "yearDisplay": "Display year",
     "yearDisplayPlaceholder": "e.g. ca. 1680, 1670–1690 or 19. saj",
+    "yearInputPlaceholder": "1680, ca. 1680, 1670–1690, 17. saj",
+    "yearInputWarn": "⚠ Cannot parse year — formats: 1680, ca. 1680, 1670–1690, 17. saj",
     "place": "Place",
     "printer": "Printer",
     "tags": "Work keywords",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -205,8 +205,6 @@
     "author": "Autor",
     "respondens": "Respondens",
     "year": "Aasta",
-    "yearDisplay": "Kuvatav aasta",
-    "yearDisplayPlaceholder": "nt ca. 1680, 1670–1690 või 19. saj",
     "yearInputPlaceholder": "1680, ca. 1680, 1670–1690, 17. saj",
     "yearInputWarn": "⚠ Ei oska aastat tuletada — formaadid: 1680, ca. 1680, 1670–1690, 17. saj",
     "place": "Koht",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -207,6 +207,8 @@
     "year": "Aasta",
     "yearDisplay": "Kuvatav aasta",
     "yearDisplayPlaceholder": "nt ca. 1680, 1670–1690 või 19. saj",
+    "yearInputPlaceholder": "1680, ca. 1680, 1670–1690, 17. saj",
+    "yearInputWarn": "⚠ Ei oska aastat tuletada — formaadid: 1680, ca. 1680, 1670–1690, 17. saj",
     "place": "Koht",
     "printer": "Trükkal",
     "tags": "Teose märksõnad",

--- a/src/services/__tests__/workService.test.ts
+++ b/src/services/__tests__/workService.test.ts
@@ -94,7 +94,7 @@ describe('getWorkMetadata', () => {
       }),
     } as any;
 
-    const result = await getWorkMetadata(index, 'w') as any;
+    const result = await getWorkMetadata(index, 'w');
     expect(result?.catalog_name).toBe('kataloog-1');
     expect(result?.author).toBe('Autorius');
     expect(result?.aasta).toBe(1700);
@@ -110,7 +110,7 @@ describe('getWorkMetadata', () => {
         }],
       }),
     } as any;
-    const result = await getWorkMetadata(index, 'w') as any;
+    const result = await getWorkMetadata(index, 'w');
     expect(result?.author).toBe('Lorenz');
   });
 
@@ -120,7 +120,7 @@ describe('getWorkMetadata', () => {
         hits: [{ work_id: 'w', title: 'T', year: 1690 }],
       }),
     } as any;
-    const result = await getWorkMetadata(index, 'w') as any;
+    const result = await getWorkMetadata(index, 'w');
     expect(result?.aasta).toBe(1690);
   });
 

--- a/src/services/__tests__/workService.test.ts
+++ b/src/services/__tests__/workService.test.ts
@@ -94,7 +94,7 @@ describe('getWorkMetadata', () => {
       }),
     } as any;
 
-    const result = await getWorkMetadata(index, 'w');
+    const result = await getWorkMetadata(index, 'w') as any;
     expect(result?.catalog_name).toBe('kataloog-1');
     expect(result?.author).toBe('Autorius');
     expect(result?.aasta).toBe(1700);
@@ -110,7 +110,7 @@ describe('getWorkMetadata', () => {
         }],
       }),
     } as any;
-    const result = await getWorkMetadata(index, 'w');
+    const result = await getWorkMetadata(index, 'w') as any;
     expect(result?.author).toBe('Lorenz');
   });
 
@@ -120,7 +120,7 @@ describe('getWorkMetadata', () => {
         hits: [{ work_id: 'w', title: 'T', year: 1690 }],
       }),
     } as any;
-    const result = await getWorkMetadata(index, 'w');
+    const result = await getWorkMetadata(index, 'w') as any;
     expect(result?.aasta).toBe(1690);
   });
 

--- a/src/services/workService.ts
+++ b/src/services/workService.ts
@@ -44,7 +44,19 @@ export const getWorkStatuses = async (index: Index, workIds: string[]): Promise<
 };
 
 // Töölaud: Saa teose metaandmed
-export const getWorkMetadata = async (index: Index, workId: string): Promise<Work | undefined> => {
+/**
+ * `getWorkMetadata` tagastus: `Work` + workspace tagasiühilduvuse legacy väljad,
+ * mis lisatakse runtime'is (inglisekeelsed compat-nimed, ei kuulu rangesse `Work`-i).
+ * @deprecated legacy väljad — uues koodis kasuta `creators`/`year`/`work_id`.
+ */
+export type WorkMetadataResult = Work & {
+  catalog_name?: string;
+  author?: string;
+  respondens?: string;
+  aasta?: number | null;
+};
+
+export const getWorkMetadata = async (index: Index, workId: string): Promise<WorkMetadataResult | undefined> => {
   try {
     // Otsime work_id (nanoid) järgi
     const response = await index.search('', {
@@ -73,7 +85,7 @@ export const getWorkMetadata = async (index: Index, workId: string): Promise<Wor
       author: hit.autor || (hit.creators?.[0]?.name) || '',
       respondens: hit.respondens || (hit.creators?.find((c: any) => c.role === 'respondens')?.name),
       aasta: hit.aasta ?? hit.year,
-    } as Work;
+    } as WorkMetadataResult;
   } catch (e) {
     console.error("Work Metadata Error:", e);
     return undefined;

--- a/src/utils/__tests__/buildMetadataPayload.test.ts
+++ b/src/utils/__tests__/buildMetadataPayload.test.ts
@@ -124,8 +124,7 @@ describe('cleanCreators', () => {
 
 const baseForm = (): MetadataFormData => ({
   title: 'Testpealkiri',
-  year: 1680,
-  year_display: '',
+  yearInput: '1680',
   type: null,
   genre: [],
   tags: [],
@@ -145,18 +144,58 @@ describe('buildMetadataPayload', () => {
     expect(payload.work_id).toBe('abc123');
   });
 
-  it('tühi year_display → null', () => {
-    expect(buildMetadataPayload(baseForm(), 'x').metadata.year_display).toBeNull();
+  // --- Aasta-välja tuletamine (deriveYearFields läbi buildMetadataPayload) ---
+  it('puhas number yearInput → year number, year_display null', () => {
+    const p = buildMetadataPayload({ ...baseForm(), yearInput: '1680' }, 'x');
+    expect(p.metadata.year).toBe(1680);
+    expect(p.metadata.year_display).toBeNull();
   });
 
-  it('year_display whitespace → null', () => {
-    const form = { ...baseForm(), year_display: '   ' };
-    expect(buildMetadataPayload(form, 'x').metadata.year_display).toBeNull();
+  it('ca. kuva → year keskpaik, year_display alles', () => {
+    const p = buildMetadataPayload({ ...baseForm(), yearInput: 'ca. 1680' }, 'x');
+    expect(p.metadata.year).toBe(1680);
+    expect(p.metadata.year_display).toBe('ca. 1680');
   });
 
-  it('year_display väärtusega → trimitud string', () => {
-    const form = { ...baseForm(), year_display: '  ca. 1680  ' };
-    expect(buildMetadataPayload(form, 'x').metadata.year_display).toBe('ca. 1680');
+  it('vahemik yearInput → keskpaik, kuva alles', () => {
+    const p = buildMetadataPayload({ ...baseForm(), yearInput: '1670–1690' }, 'x');
+    expect(p.metadata.year).toBe(1680);
+    expect(p.metadata.year_display).toBe('1670–1690');
+  });
+
+  it('tühi yearInput → year 0, year_display null', () => {
+    const p = buildMetadataPayload({ ...baseForm(), yearInput: '' }, 'x');
+    expect(p.metadata.year).toBe(0);
+    expect(p.metadata.year_display).toBeNull();
+  });
+
+  it('whitespace yearInput → year 0, year_display null', () => {
+    const p = buildMetadataPayload({ ...baseForm(), yearInput: '   ' }, 'x');
+    expect(p.metadata.year).toBe(0);
+    expect(p.metadata.year_display).toBeNull();
+  });
+
+  it('reegel 4: ei parsi + muutmata existing → säilitab olemasoleva year', () => {
+    // yearInput matches existing.year_display → year säilitatakse
+    const p = buildMetadataPayload(
+      { ...baseForm(), yearInput: 'XVII saj' },
+      'x',
+      undefined,
+      { year: 1650, year_display: 'XVII saj' },
+    );
+    expect(p.metadata.year).toBe(1650);
+    expect(p.metadata.year_display).toBe('XVII saj');
+  });
+
+  it('reegel 5: ei parsi + existing aga muudetud kuva → year=0', () => {
+    const p = buildMetadataPayload(
+      { ...baseForm(), yearInput: 'XVIII saj' },
+      'x',
+      undefined,
+      { year: 1650, year_display: 'XVII saj' },
+    );
+    expect(p.metadata.year).toBe(0);
+    expect(p.metadata.year_display).toBe('XVIII saj');
   });
 
   it('tühi genre massiiv → null', () => {

--- a/src/utils/__tests__/yearDisplayUtils.test.ts
+++ b/src/utils/__tests__/yearDisplayUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { TFunction } from 'i18next';
-import { parseYearDisplayRange, formatYearDisplay } from '../yearDisplayUtils';
+import { parseYearDisplayRange, formatYearDisplay, deriveYearFields } from '../yearDisplayUtils';
 
 describe('parseYearDisplayRange', () => {
   // Olemasolev käitumine (regressioonikaitse)
@@ -89,5 +89,85 @@ describe('formatYearDisplay', () => {
   it('kõik puudub → tühi string', () => {
     expect(formatYearDisplay(null, null, tMock)).toBe('');
     expect(formatYearDisplay(null, 0, tMock)).toBe('');
+  });
+});
+
+
+describe('deriveYearFields', () => {
+  // --- Reegel 1: tühi ---
+  it('tühi sisend → year=0, tühi kuva', () => {
+    expect(deriveYearFields('')).toEqual({ year: 0, year_display: '' });
+    expect(deriveYearFields('   ')).toEqual({ year: 0, year_display: '' });
+  });
+
+  // --- Reegel 2: puhas 3–4-kohaline number ---
+  it('puhas 4-kohaline aasta → number, kuva tühi', () => {
+    expect(deriveYearFields('1680')).toEqual({ year: 1680, year_display: '' });
+  });
+  it('puhas 3-kohaline aasta → number', () => {
+    expect(deriveYearFields('800')).toEqual({ year: 800, year_display: '' });
+  });
+  it('tühikutega ümbritsetud number → trimmitakse', () => {
+    expect(deriveYearFields('  1680  ')).toEqual({ year: 1680, year_display: '' });
+  });
+  it('reegel 2 servajuht: 1–2-kohaline EI ole puhas aasta (langeb reeglile 3/5)', () => {
+    // "80" ei klapi PURE_YEAR_RE-ga (nõuab 3–4) ega parsi (\d{4} ei taba)
+    expect(deriveYearFields('80')).toEqual({ year: 0, year_display: '80' });
+    expect(deriveYearFields('0')).toEqual({ year: 0, year_display: '0' });
+  });
+
+  // --- Reegel 3: parsib kuvastringist → keskpaik ---
+  it('ca. → keskpaik, kuva alles', () => {
+    expect(deriveYearFields('ca. 1680')).toEqual({ year: 1680, year_display: 'ca. 1680' });
+  });
+  it('vahemik → keskpaik', () => {
+    // (1670+1690)>>1 = 1680
+    expect(deriveYearFields('1670–1690')).toEqual({ year: 1680, year_display: '1670–1690' });
+  });
+  it('sajand → keskpaik (sama mis 1601–1700)', () => {
+    // (1601+1700)>>1 = 1650
+    expect(deriveYearFields('17. saj')).toEqual({ year: 1650, year_display: '17. saj' });
+  });
+  it('sajandi vahemik → keskpaik', () => {
+    // (1601+1900)>>1 = 1750
+    expect(deriveYearFields('17.-19. saj')).toEqual({ year: 1750, year_display: '17.-19. saj' });
+  });
+  it('üksik aasta tekstis → keskpaik (kasutab 4-kohalist)', () => {
+    expect(deriveYearFields('trükitud 1680')).toEqual({ year: 1680, year_display: 'trükitud 1680' });
+  });
+
+  // --- Reegel 4: ei parsi + muutmata existing → säilita ---
+  it('ei parsi + muutmata kuva + olemasolev year → säilitab year (vaikse rikkumise kaitse)', () => {
+    const existing = { year: 1650, year_display: 'XVII saj' };
+    expect(deriveYearFields('XVII saj', existing)).toEqual({ year: 1650, year_display: 'XVII saj' });
+  });
+  it('reegel 4 eeldab existing.year > 0 (0 ei loe säilitatavaks)', () => {
+    expect(deriveYearFields('XVII saj', { year: 0, year_display: 'XVII saj' })).toEqual({ year: 0, year_display: 'XVII saj' });
+  });
+  it('reegel 4 eiratab tühimike erinevust (trimmitud vördlus)', () => {
+    const existing = { year: 1650, year_display: '  XVII saj  ' };
+    expect(deriveYearFields('XVII saj', existing)).toEqual({ year: 1650, year_display: 'XVII saj' });
+  });
+
+  // --- Reegel 5: ei parsi + muudetud/uus → year=0 ---
+  it('ei parsi + muudetud kuva (existing.year_display erineb) → year=0', () => {
+    const existing = { year: 1650, year_display: 'XVII saj' };
+    // Kasutaja muutis kuva: "XVIII saj" — ei klapi existing-iga → tuletatakse
+    expect(deriveYearFields('XVIII saj', existing)).toEqual({ year: 0, year_display: 'XVIII saj' });
+  });
+  it('ei parsi + uus väärtus ilma existing-ita → year=0', () => {
+    // Rooman numbrid / tekst ilma 4-kohalise aastata ja ilma sajandimustrita
+    expect(deriveYearFields('XVII saj')).toEqual({ year: 0, year_display: 'XVII saj' });
+    expect(deriveYearFields('s.a.')).toEqual({ year: 0, year_display: 's.a.' });
+    expect(deriveYearFields('sajand XIV')).toEqual({ year: 0, year_display: 'sajand XIV' });
+  });
+  it('NB: tekstis peituv 4-kohaline aasta parsitakse (reegel 3)', () => {
+    // "post 1700" ja "enne 1650" sisaldavad 4-kohalist aastat → ekstraheeritakse
+    expect(deriveYearFields('post 1700')).toEqual({ year: 1700, year_display: 'post 1700' });
+    expect(deriveYearFields('enne 1650')).toEqual({ year: 1650, year_display: 'enne 1650' });
+  });
+  it('null/undefined raw → tühi (ei viska)', () => {
+    expect(deriveYearFields(null as unknown as string)).toEqual({ year: 0, year_display: '' });
+    expect(deriveYearFields(undefined as unknown as string)).toEqual({ year: 0, year_display: '' });
   });
 });

--- a/src/utils/buildMetadataPayload.ts
+++ b/src/utils/buildMetadataPayload.ts
@@ -1,10 +1,10 @@
 import { Creator, CreatorRole, ArchiveRef } from '../types';
 import { LinkedEntity } from '../types/LinkedEntity';
+import { deriveYearFields } from './yearDisplayUtils';
 
 export interface MetadataFormData {
   title: string;
-  year: number;
-  year_display: string;
+  yearInput: string;          // Üks tekstilahter: puhas aasta, ca., vahemik või sajand (vt deriveYearFields)
   type: string | LinkedEntity | null;
   genre: (string | LinkedEntity)[];
   tags: (string | LinkedEntity)[];
@@ -82,18 +82,27 @@ export function cleanArchiveRefs(refs: ArchiveRef[]): ArchiveRef[] | null {
   return clean.length > 0 ? clean : null;
 }
 
-// Ehitab /update-work-metadata payload-i MetadataForm andmetest
+// Aasta-välja ühendamise invariant (vt aasta-valja-uhendamine-design.md, reegel 4):
+// `existing` = vormi avamisel (ja ESTER auto-filli järel) snap-shotitud algne
+// { year, year_display }. Kui kasutaja kuvastringi ei muuda, säilitatakse olemasolev
+// `year` isegi kui see ei parsi — väldib vaikset andmekao (hea `year` → 0).
+export type YearFieldsExisting = { year?: number; year_display?: string };
+
+// Ehitab /update-work-metadata payload-i MetadataForm andmetest.
+// `existing` (valikuline): vormi avamisel laetud algne aasta-olek reegli 4 jaoks.
 export function buildMetadataPayload(
   form: MetadataFormData,
   workId: string,
   originaalKataloog?: string | null,
+  existing?: YearFieldsExisting,
 ): MetadataPayload {
+  const { year, year_display } = deriveYearFields(form.yearInput, existing);
   const payload: MetadataPayload = {
     work_id: workId,
     metadata: {
       title: form.title,
-      year: form.year,
-      year_display: form.year_display.trim() || null,
+      year,
+      year_display: year_display || null,
       type: form.type || null,
       genre: form.genre.length > 0 ? form.genre : null,
       creators: cleanCreators(form.creators),

--- a/src/utils/yearDisplayUtils.ts
+++ b/src/utils/yearDisplayUtils.ts
@@ -57,6 +57,63 @@ export function parseYearDisplayRange(
   return null;
 }
 
+/** Puhas number (3–4 kohaline) — varauusaja aastad. 1–2 kohaline (nt "80", "0")
+ *  langeb reeglile 3 (ei parsi → pehme hoiatus + year=0), sest VUTT korpus on
+ *  4-kohalised aastad ja 1–2 kohaline on praktikas viga (vt aasta-välja disain). */
+const PURE_YEAR_RE = /^\d{3,4}$/;
+
+/**
+ * Tuletab `{ year, year_display }` ühest tekstilahtrist (aasta-välja ühendamine).
+ * Kasutab `parseYearDisplayRange`-i. Puhas funktsioon — ei puuduta DOM-i.
+ *
+ * Reeglid (sisend `value = raw.trim()`):
+ *  1. tühi                          → { year: 0, year_display: "" }
+ *  2. puhas 3–4-kohaline number     → { year: n, year_display: "" }
+ *  3. parsib (range !== null)       → { year: (start+end)>>1, year_display: value }
+ *  4. ei parsi + value===existing.year_display + existing.year olemas
+ *                                   → { year: existing.year, year_display: value } (säilita)
+ *  5. ei parsi + uus/muudetud       → { year: 0, year_display: value }
+ *
+ * Reegel 4 kaitseb vaikse andmekao eest: kui olemasoleval teosel on käsitsi korras
+ * `year` parssimata kuva kõrval ja kasutaja dateeringut ei puuduta, ei nullita `year`-it.
+ * Säilitamine kehtib AINULT muutmata kuva korral — muudetud string tuletatakse uuesti.
+ */
+export function deriveYearFields(
+  raw: string,
+  existing?: { year?: number; year_display?: string }
+): { year: number; year_display: string } {
+  const value = (raw ?? '').trim();
+
+  // 1. tühi → kuupäevata teos on legitiimne
+  if (value === '') {
+    return { year: 0, year_display: '' };
+  }
+
+  // 2. puhas 3–4-kohaline aasta → number, kuva tühjaks (kuvatakse numbrina)
+  const pure = value.match(PURE_YEAR_RE);
+  if (pure) {
+    return { year: parseInt(value, 10), year_display: '' };
+  }
+
+  // 3. parsib kuvastringist → keskpaik (sortimise stabiilsus, vt meili_doc.py:524)
+  const range = parseYearDisplayRange(null, value);
+  if (range) {
+    return { year: (range.start + range.end) >> 1, year_display: value };
+  }
+
+  // 4. ei parsi, aga kuva muutmata ja olemasolev year olemas → säilita
+  if (
+    existing &&
+    typeof existing.year === 'number' && existing.year &&
+    value === (existing.year_display ?? '').trim()
+  ) {
+    return { year: existing.year, year_display: value };
+  }
+
+  // 5. ei parsi + uus/muudetud → year=0, kuva toorelt
+  return { year: 0, year_display: value };
+}
+
 // Inglise järgarvu sufiks: 1st, 2nd, 3rd, 4th … 11th–13th erandid, 21st jne
 function enOrdinal(n: number): string {
   const r10 = n % 10;


### PR DESCRIPTION
Aasta-väljade ühendamine üheks sisendiks (Phase 1). Disain: `docs/superpowers/specs/2026-06-24-aasta-valja-uhendamine-design.md`. Phase 0 (#31, PR #32) eeltingimus juba main-is.

## Mida muudab
Kasutajale jääb **üks tekstilahter** (endine `year_display`); numbriline `year`-input eemaldatakse UI-st. `year` (number) tuletatakse sisendist salvestamisel puhta funktsiooni `deriveYearFields` kaudu. `_metadata.json` säilitab mõlemad väljad (backend lugemiskohad muutumatud), andmemuutust/reindeksit pole vaja.

## Tuletusreeglid (`deriveYearFields(raw, existing?)`)
1. tühi → `{year:0, year_display:""}`
2. puhas 3–4-kohaline number → `{year:n, year_display:""}`
3. parsib (ca./vahemik/sajand) → keskpaik `(start+end)>>1`, kuva alles
4. ei parsi + muutmata `existing.year_display` + olemasolev `year` → säilita (vaikse andmekao kaitse)
5. ei parsi + muudetud/uus → `{year:0, year_display:value}`

## Komponendid
- **`src/utils/yearDisplayUtils.ts`**: uus `deriveYearFields` (puhas, kasutab `parseYearDisplayRange`-i).
- **`buildMetadataPayload.ts`**: `MetadataFormData.year/year_display` → `yearInput:string`; uus `existing` parameeter (reegel 4).
- **`MetadataModal.tsx`**: üks tekstilahter + `existingYearRef` (avamise + ESTER auto-filli snap-shot) + `YearInputPreview` (live-eelvaade / pehme merevaik-hoiatus, EI blokeeri salvestamist).
- **`UploadMetaForm.tsx`**: sama üks väli + refactor jagatud `clean*` helperitele ja `deriveYearFields`-ile.

## Backend parandus (eelnev viga, mis Phase 1 paljastas)
`update_upload_meta` lubatud hulk EI sisaldanud `year_display`-it → sõeluti vaikselt välja, nii et `import_as_work` (loeb `year_display`-i `OPTIONAL_META_FIELDS`-st) ei saanud seda kunagi. Lisatud `year_display` lubatud hulka.

## Disaini otsused (vt spec)
- **Upload-tee variant (b)**: `deriveYearFields` inline, mitte `buildMetadataPayload` refactor — sest upload PATCH endpoint võtab lame `updates` dicti, `buildMetadataPayload` tagastab pesastatud kuju. Unifikatsioonieesmärk (üks tuletusloogika) saavutatud.
- **YAGNI**: derivatsioon frontend-only. `save_work_metadata` `meta.update` on pime asendus; ainus kaitsja vaikse andmekao vastu on UI reegel 4.

## Testid
- `deriveYearFields`: 18 ühiktesti (kõik 5 reeglit + servajuhud `80`/`0` + null-safe + reegel 4 säilitamine/muutmine).
- `buildMetadataPayload`: +8 testi (yearInput + existing → payload, reeglid 4/5).
- Keskpaikapariteet (TS `>>1` == Py `//2` fikseeritud vahemikele) kaetud.
- tsc puhas, `npm run build` OK, frontend `480 passed`, backend `570 passed`.

Closes #31 (Phase 1), viib lõpule aasta-välja disaini.
