### PR TITLE
fix(metadata): aasta-väli poole laiusega

### DIFF
--- a/src/components/MetadataModal.tsx
+++ b/src/components/MetadataModal.tsx
@@ -577,19 +577,22 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
           {/* Grupp 2: Kolofoon */}
           <div className="border border-gray-200 rounded-lg p-3 space-y-3 bg-gray-50/50">
             <h4 className="text-xs font-bold text-gray-600 uppercase -mt-1">{t('metadata.colophon', 'Kolofoon')}</h4>
-            {/* Aasta — üks tekstilahter (aasta-välja ühendamine, vt deriveYearFields) */}
-            <div>
-              <label className="block text-xs font-medium text-gray-500 mb-1">{t('metadata.year')}</label>
-              <input
-                type="text"
-                inputMode="text"
-                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
-                placeholder={t('metadata.yearInputPlaceholder', '1680, ca. 1680, 1670–1690, 17. saj')}
-                value={metaForm.yearInput}
-                onChange={e => setMetaForm({ ...metaForm, yearInput: e.target.value })}
-              />
-              {/* Live-eelvaade / pehme validatsioon (EI blokeeri salvestamist) */}
-              <YearInputPreview value={metaForm.yearInput} existing={existingYearRef.current} />
+            {/* Aasta — üks tekstilahter (aasta-välja ühendamine, vt deriveYearFields).
+                Poole laiusega (grid'i vasak veerg), joondatud Koht/Trükkal reaga all. */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">{t('metadata.year')}</label>
+                <input
+                  type="text"
+                  inputMode="text"
+                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:ring-2 focus:ring-primary-500 outline-none bg-white"
+                  placeholder={t('metadata.yearInputPlaceholder', '1680, ca. 1680, 1670–1690, 17. saj')}
+                  value={metaForm.yearInput}
+                  onChange={e => setMetaForm({ ...metaForm, yearInput: e.target.value })}
+                />
+                {/* Live-eelvaade / pehme validatsioon (EI blokeeri salvestamist) */}
+                <YearInputPreview value={metaForm.yearInput} existing={existingYearRef.current} />
+              </div>
             </div>
             {/* Rida 2: Koht ja trükkal */}
             <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
Üks aasta-tekstilahter mõjus täislaiusel liiasena. Mähitud `grid grid-cols-2` vasakusse veergu, joondatud Koht/Trükkal reaga all. Ainult MetadataModal, frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)