### PR TITLE
Faas 0: Ühine deps.py + work_meta.py + conftest infra (vundament #37)

### DIFF
--- a/docs/REFACTOR_main_py_2026-06-25.md
+++ b/docs/REFACTOR_main_py_2026-06-25.md
@@ -1,0 +1,437 @@
+# Refaktoreerimisplaan: `server/main.py` laialitõmbamine routeritesse
+
+Kuupäev: 2026-06-25
+Eesmärk: tõsta `server/main.py` (2 302 rida, 96 endpointi, 100 KB) domeenipõhistesse
+FastAPI routeritesse, järgides `server/prosopography/` eeskuju. Tulemusena jääb
+`main.py` ~150–200 reale (app + lifespan + routerite registreerimine + middleware).
+
+---
+
+## Kontekst ja taust
+
+### Miks see kriitiline on
+
+`main.py` on koodibaasi suurim hooldusrisk:
+- 96 endpointi ühes failis, kuigi **enamuse äraloogika on juba eraldatud**
+  ops-moodulitesse (`admin_page_ops.py`, `upload_ops.py`, `reocr_ops.py`,
+  `trash_ops.py`, `registration.py`, `auth.py`).
+- Endpointid onki peamiselt õhukesed proxy'd — tõstmine on suures osas mehaaniline.
+- Iga uus featuur lisab `main.py`-sse juurde, ükski domeen ei väldi selle paisumist.
+
+### Õige eeskuju: `server/prosopography/`
+
+```
+server/prosopography/
+├── router.py        ← õhukesed endpointid (APIRouter)
+├── ops.py           ← äraloogika
+├── places_ops.py    ← alamdomeen
+├── enrichment.py
+└── work_relations_ops.py
+```
+`main.py` registreerib selle ühe reaga: `app.include_router(prosopography_router, prefix="/prosopography")`.
+
+**Sama mustrit rakendame kõigile ülejäänud domeenidele.**
+
+### Testikate on juba tugev (oluline parandus eelnevast hinnangust)
+
+Backendis on **45 testifaili, 563 test funktsiooni** (`tests/` kataloogis juurkaustas,
+mitte `server/tests/` all). See teeb refaktoreeringu **turvaliseks**: iga faasi järel
+annab `pytest tests/` usaldusväärse tagasiside.
+
+> Eelnevas koodibaasi ülevaates väideti ekslikult, et backendis on 0 testi. Vabandame.
+> Tegelikult on katvus tugev — refaktoreering on palju madalama riskiga kui esialgu tundus.
+
+### Sobitumine GitHub Issues süsteemi
+
+Olemasolevad issues: #14–#31 (enamik tehtud). See refaktor saab uued issue-numbrid
+(#32+), üks faas = üks PR = üks issue. Järgib sama töövoogu nagu #16 (sync_work_to_meilisearch)
+ja #23 (unifitseeri Meilisearch kaardistus).
+
+---
+
+## Testidega seotud peamine risk (lahendatav)
+
+`tests/conftest.py` `backend_env` fixture monkeypatchib `server.main` mooduli konstante:
+
+```python
+monkeypatch.setattr(main, "COLLECTIONS_FILE", str(collections_file))
+monkeypatch.setattr(main, "ARCHIVES_FILE", str(archives_file))
+monkeypatch.setattr(main, "USER_SETTINGS_DIR", str(user_settings_dir))
+monkeypatch.setattr(main, "UPLOADS_DIR", str(uploads_dir))
+monkeypatch.setattr(main, "invalidate_cache", lambda: None)
+```
+
+**Probleem:** kui collections/user_settings endpointid tõstetakse `routers/collections.py`-sse,
+siis see fail teeb `from ..config import COLLECTIONS_FILE` oma nimeruumi — ja `main`-i
+monkeypatch enam ei mõjuta seda. **Testid katkevad vaikselt.**
+
+**Lahendus (Faas 0-s):** lisada conftesti üldine helper, mis patchib konstandi kõikides
+moodulites, kuhu see imporditakse. Samamoodi tehakse juba `upload_ops` jaoks
+(`monkeypatch.setattr(upload_ops, "UPLOADS_DIR", ...)`). Iga uus router lisab lihtsalt oma
+nime sellele helperile.
+
+Samuti: `_validate_base_names` on imporditud `from server.main import ...` 10 testis.
+Tõstetakse `admin_page_ops.py`-sse (loomulik kodu); hoida backward-compat re-eksport
+`main.py`-s seniksuks, kuni testid uuendatakse (või uuendada kohe).
+
+---
+
+## Lõplik domeenijaotus (96 endpointi → 10–12 routerit)
+
+| Domeen / router | Endpointe | Ops moodul (olemas?) | Abifunktsioonid (loetakse kaasa) | Risk |
+|---|---|---|---|---|
+| **auth** | 13 | `auth.py` ✅, `registration.py` ✅ | `get_user`, `require_role`, `get_json_data`, `_get_optional_user` → `deps.py` | madal |
+| **notifications** | 5 | uus: `notifications_ops.py` | `_load/_save/_append/_create_notification`, `_find_username_by_display_name`, `_notifications_lock` | madal |
+| **upload** | 10 | `upload_ops.py` ✅ | — | madal (mehaaniline) |
+| **reocr** | 7 | `reocr_ops.py` ✅ | — | madal (mehaaniline) |
+| **pages** (admin) | 11 | `admin_page_ops.py` ✅ | `_validate_base_names` → `admin_page_ops` | madal |
+| **user_settings** | 4 | uus: `user_settings_ops.py` (väike) | `_get/_load/_save_user_settings` | **keskmine** (monkeypatch) |
+| **collections + config** | ~12 | cache ✅, config ✅ | `_find_works_with_collection/archive`, `_cleanup_allowed_collections_on_delete` | **keskmine** (monkeypatch) |
+| **public/SEO** | ~8 | `metadata_handler.py` ✅ | `_load_work_metadata`, `_sitemap_cache`, `_invalidate_all_caches` | keskmine (jagatud helperid) |
+| **admin_users** (registrations, users, trash, git-health, work-delete) | ~10 | `trash_ops.py` ✅, `auth.py` ✅, `registration.py` ✅ | — | madal |
+| **save** | 1 (mahukas) | `marginalia_normalize.py` ✅ | — | keskmine |
+| **metadata + git_history + bulk** | 7 | `metadata_ops.py` ✅, `git_ops.py` ✅ | `_read_work_meta_direct_sync` | madal–keskmine |
+
+**Jagatud helperid, mis ei kuulu ühele domeenile** (üksikasjad allpool): need tõstetakse
+sobivasse ühismoodulisse Faasis 0 või 6.
+
+---
+
+## Teostus: 8 faasi (igaüks eraldi PR + issue)
+
+Iga faas on **iseseisev ja deploydatav**. Pärast iga faasi: `pytest tests/` + manuaalne
+smoke test + commit. Faasid on tellitult riskikasvavad: madala riskiga mehaanilised
+tõstmised esimesena, jagatud helperitega domeenid viimasena.
+
+### Faas 0 — Vundament (ühine deps moodul + conftest uuendus)
+
+**Eesmärk:** luua alus, mis muudab kõik järgnevad faasid turvaliseks ja eemaldab olemasoleva
+duplikaadi.
+
+1. Loo `server/deps.py`:
+   ```python
+   async def get_user(request, min_role="contributor"): ...
+   def require_role(role): ...
+   async def get_json_data(request): ...
+   async def optional_user(request): ...   # endine _get_optional_user
+   ```
+
+2. **Eemalda duplikaat** `server/prosopography/router.py`-st: praegu on seal privaatne
+   `_get_user` ja `_optional_user`, mis on peaaegu identsed `main.py` omadega (üks erinevus:
+   prosopography versioon loeb tokenit ka JSON body-st). Ühenda üheks `deps.py`-ks, mis
+   toetab mõlemat kanalit (header + query + JSON body). Testi, et prosopography endpointid
+   ikka töötavad.
+
+3. Loo `server/routers/__init__.py` (tühi pakett).
+
+4. **Uuenda `tests/conftest.py`:** lisa helper, mis patchib konstandi kõigis antud
+   moodulites. Näiteks:
+   ```python
+   def patch_config_const(monkeypatch, name, value, modules):
+       for mod in modules:
+           importlib.import_module(mod)  # tagab, et import on toimunud
+           monkeypatch.setattr(mod, name, value, raising=False)
+   ```
+   ja uuenda `backend_env`-i seda kasutama (esialjasse kuuluvad `main`, `upload_ops`).
+   Tulevased faasid lisavad oma moodulid lihtsalt juurde.
+
+5. Loo `server/work_meta.py` (või lisa `utils.py`-sse): `_load_work_metadata`,
+   `_read_work_meta_direct_sync` — neid kasutavad nii public/SEO, collections, download,
+   shareable, viewer-token. Ühine kodu väldib korduvat importimist.
+   Hoia backward-compat re-eksport `main.py`-s.
+
+6. Tõsta `_validate_base_names` `admin_page_ops.py`-sse (loomulik kodu, kuna valideerib
+   page base_names). Hoia `main.py`-s `from .admin_page_ops import _validate_base_names`
+   (backward-compat), et 10 testi ei katkeks.
+
+**Valideerimine:** `pytest tests/` roheline; prosopography endpointid toimivad; manual
+login + ühe teose avamine.
+
+**Hinnang:** ~0,5 päeva. **Suurim võit:** ühine auth-dep ja conftest infra on valmis kõigile
+järgnevatele faasidele.
+
+---
+
+### Faas 1 — Notifications (suurim võit, kõige iseseisvam domeen)
+
+**Eesmärk:** eraldada täiesti suletud domeen (5 endpointi + 7 abifunktsiooni + lukk).
+
+1. Loo `server/notifications_ops.py` — kogu notifications äraloogika:
+   - `_notifications_lock`, `_safe_username`, `_get_notifications_path`
+   - `_load_notifications`, `_save_notifications`, `_append_notifications`
+   - `_create_notification`, `_find_username_by_display_name`
+   - Nendest tee avalikud funktsioonid (eemalda `_` eesliides, kus mõistlik).
+
+2. Loo `server/routers/notifications.py` (`APIRouter`):
+   - `POST /page-comments/reply`
+   - `GET /notifications`
+   - `GET /notification-recipients`
+   - `POST /notifications/send`
+   - `POST /notifications/{notification_id}/read`
+
+3. `main.py`: `app.include_router(notifications_router)`.
+
+**Valideerimine:** `pytest tests/` (kui notifications jaoks on teste — kontrolli); manuaalne
+kommentaari vastamine + teavituse saatmine.
+
+**Hinnang:** ~0,5 päeva. **Võit:** `-~280 rida main.py`-st, domeenist saab iseseisev moodul,
+mida saab testida ja arendada eraldi.
+
+---
+
+### Faas 2 — Upload + Re-OCR (mehaaniline, ops juba eraldatud)
+
+**Eesmärk:** kaks õhukeste endpointide rühma, mille äraloogika on juba ops-moodulites.
+
+1. Loo `server/routers/upload.py` (10 endpointi, kõik `/admin/upload/*` ja `/admin/uploads`).
+2. Loo `server/routers/reocr.py` (7 endpointi, kõik `/admin/reocr/*` ja `/admin/work/{work_id}/reocr-*`).
+3. `main.py`: include mõlemad routerid.
+
+**Valideerimine:** `pytest tests/` (on olemas `test_reocr_*`, `test_upload_*`, `test_add_pages`
+jt — tugev katvus); manuaalne upload-wizard läbimäng.
+
+**Hinnang:** ~0,5 päeva. **Võit:** `-~350 rida`. **Madal risk**, sest endpointid on proxy'd.
+
+---
+
+### Faas 3 — Pages admin (mehaaniline)
+
+**Eesmärk:** lehekülgede haldusdomeen (suurim endpointide rühm).
+
+1. Loo `server/routers/pages.py` (11 endpointi, kõik `/admin/work/{work_id}/*page*`):
+   - pages (GET), delete-page, delete-pages, replace-image, add-page, add-pages,
+     split, transform, reorder, page-ocr (GET+DELETE).
+2. Eemalda `_validate_base_names` backward-compat import (kui Faas 0 lisas) — uuenda
+   teste importima `from server.admin_page_ops import _validate_base_names`.
+3. `main.py`: include router.
+
+**Valideerimine:** `pytest tests/` (`test_delete_pages*`, `test_add_pages`, `test_split_page`,
+`test_transform_page`, `test_allocate_sequences` jt — väga tugev katvus).
+
+**Hinnang:** ~0,5 päeva. **Võit:** `-~400 rida`. **Madal risk.**
+
+---
+
+### Faas 4 — Auth + registreerimine
+
+**Eesmärk:** auth, meili-tokenid, registreerimine, invite.
+
+1. Loo `server/routers/auth.py` (13 endpointi):
+   - `/login`, `/verify-token`, `/logout`, `/api/meili-token*` (2)
+   - `/register*` (2), `/invite/*` (2).
+2. `main.py`: include router.
+
+**Valideerimine:** `pytest tests/` (`test_login_throttle`, `test_auth_password`,
+`test_session_invalidation`, `test_registration_username` — tugev katvus).
+
+**Hinnang:** ~0,5 päeva. **Võit:** `-~250 rida`.
+
+---
+
+### Faas 5 — Admin haldus (registrations, users, trash, git-health, work-delete)
+
+**Eesmärk:** admin vood, mis ei kuulu teistesse domeenidesse.
+
+1. Loo `server/routers/admin.py` (~10 endpointi):
+   - `/admin/registrations*` (3), `/admin/users*` (3)
+   - `/admin/people-refresh*` (2)
+   - `/admin/git-failures`, `/admin/git-health`
+   - `/admin/trash*` (2), `/admin/work/{work_id}/trash-pages*` (2)
+   - `/admin/work/{work_id}` DELETE (work delete — mahukas, aga iseseisev).
+2. `main.py`: include router.
+
+**Valideerimine:** `pytest tests/` (`test_trash_ops`, `test_work_collections`,
+`test_session_invalidation` — tugev katvus).
+
+**Hinnang:** ~0,5–1 päev. **Võit:** `-~300 rida`.
+
+---
+
+### Faas 6 — Collections + config + user_settings + public/SEO (kõrgem risk)
+
+> **See on kõige keerukam faas** monkeypatchimise ja jagatud helperite tõttu. Soovitatav
+> teha pärast Faasi 0 conftest-infra usaldusväärset valideerimist.
+
+**Jagatud helperid, mis vajavad ühist kodu:**
+- `_invalidate_all_caches`, `_sitemap_cache` → laienda `server/cache.py` või uus
+  `server/cache_helpers.py`.
+- `_load_work_metadata`, `_read_work_meta_direct_sync` → `server/work_meta.py` (Faasis 0 loodud).
+- `_find_works_with_collection`, `_find_works_with_archive`,
+  `_cleanup_allowed_collections_on_delete` → `server/routers/collections.py` privaatsetena.
+
+1. Loo `server/routers/collections.py` (~12 endpointi): `/collections`, `/config/archives*` (4),
+   `/admin/collections*` (5).
+2. Loo `server/routers/user_settings.py` (4 endpointi) + `server/user_settings_ops.py`
+   (`_load/_save_user_settings`).
+3. Loo `server/routers/public.py` (~8 endpointi): `/vocabularies`, `/people-aliases`,
+   `/people-register`, `/entity-labels`, `/admin/refresh-entity-labels`,
+   `/admin/enrich-page-tag-labels`, `/work/{work_id}/shareable`, `/work/{work_id}/viewer-token`,
+   `/meta/*` (3), `/sitemap.xml`, `/health`, `/download/{work_id}`.
+4. **Uuenda `tests/conftest.py`:** lisa kõik uued moodulid `patch_config_const` helperisse
+   (`COLLECTIONS_FILE`, `ARCHIVES_FILE`, `USER_SETTINGS_DIR` jaoks).
+5. `main.py`: include kõik routerid.
+
+**Valideerimine:** `pytest tests/` (`test_work_collections`, `test_viewer_token`,
+`test_work_titles_endpoint`, `test_metadata_handler`, `test_backend_smoke` — hoolikalt,
+kuna monkeypatch-muudatused on siin kõige tundlikumad). Manuaalne: kollektsiooni loomine/
+kustutamine, arhiivi CRUD, user settings salvestamine, sitemap.xml, download.
+
+**Hinnang:** ~1–1,5 päeva. **Võit:** `-~600 rida`. **Kõrgem risk** — hoolas testimine.
+
+---
+
+### Faas 7 — Save + metadata + git history + bulk
+
+**Eesmärk:** viimane jaotus, toimetamise tuum.
+
+1. Loo `server/routers/save.py`: `POST /save` (üks endpoint, aga mahukas — ligi 50 rida
+   äriloogikat). Hoiab `normalize_marginalia_tags` + `can_write_work` kontrolli.
+2. Loo `server/routers/metadata.py`: `POST /update-work-metadata`, `/get-work-metadata`,
+   `/get-metadata-suggestions`.
+3. Loo `server/routers/git_history.py`: `/recent-edits`, `/git-history`, `/commit-diff`,
+   `/git-restore`, `/works/bulk-collection`, `/works/bulk-tags`, `/works/bulk-genre`.
+4. `main.py`: include kõik routerid.
+
+**Valideerimine:** `pytest tests/` (`test_marginalia_normalize`, `test_bulk_atomicity`,
+`test_work_lock` jt). Manuaalne: salvestamine, git restore, bulk collection muudatus.
+
+**Hinnang:** ~1 päev. **Võit:** `-~450 rida`.
+
+---
+
+## Lõpptulemus
+
+`server/main.py` pärast kõiki faase (~150–200 rida):
+
+```python
+# Impordid
+from .config import ...
+from .deps import get_user, require_role, get_json_data  # (backward-compat)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # build_work_id_cache, run_git_fsck, daemon threads
+    ...
+
+app = FastAPI(title="VUTT API", version="1.0.0", lifespan=lifespan)
+app.add_middleware(CORSMiddleware, ...)
+
+# Routerite registreerimine
+app.include_router(prosopography_router, prefix="/prosopography")
+app.include_router(auth_router)
+app.include_router(notifications_router)
+app.include_router(upload_router)
+app.include_router(reocr_router)
+app.include_router(pages_router)
+app.include_router(admin_router)
+app.include_router(collections_router)
+app.include_router(user_settings_router)
+app.include_router(public_router)
+app.include_router(save_router)
+app.include_router(metadata_router)
+app.include_router(git_history_router)
+```
+
+**Kokku: 2 302 → ~180 rida.** Iga domeen on iseseisev moodul, testitav eraldi, arendatav
+ilma `main.py`-d puudutamata.
+
+---
+
+## Struktuur pärast refaktoreeringut
+
+```
+server/
+├── main.py                 # ~180 rida: app, lifespan, routerite registreerimine
+├── deps.py                 # auth dependencies (ühine)
+├── work_meta.py            # _load_work_metadata, _read_work_meta_direct_sync
+├── cache_helpers.py        # _invalidate_all_caches, _sitemap_cache (või laienda cache.py)
+├── routers/
+│   ├── __init__.py
+│   ├── auth.py             # login, register, invite, meili-token
+│   ├── notifications.py
+│   ├── upload.py
+│   ├── reocr.py
+│   ├── pages.py            # admin page management
+│   ├── admin.py            # registrations, users, trash, git-health, work-delete
+│   ├── collections.py      # + archives config
+│   ├── user_settings.py
+│   ├── public.py           # vocabularies, people, entity-labels, SEO/meta, sitemap, download
+│   ├── save.py
+│   ├── metadata.py
+│   └── git_history.py      # + bulk operations
+├── [olemasolevad ops moodulid: admin_page_ops, upload_ops, reocr_ops, trash_ops,
+│    registration, auth, cache, config, git_ops, meilisearch_ops, people_ops,
+│    marginalia_normalize, metadata_handler, metadata_ops, utils, ...]
+├── notifications_ops.py    # uus (Faas 1)
+├── user_settings_ops.py    # uus (Faas 6)
+└── prosopography/          # olemasolev (eeskuju)
+```
+
+---
+
+## Turvameetmed (iga faasi jaoks)
+
+1. **Üks faas = üks branch = üks PR = üks GitHub issue.** Mitte kunagi mitu faasi ühes PR-is.
+2. **Enne iga faasi:** `pytest tests/` → dokumenteeri baasjoon (X testi läheb läbi).
+3. **Pärast iga faasi:** `pytest tests/` → sama arv (või rohkem) testi läheb läbi.
+4. **Backward-compat import** `main.py`-st kõigepealt; eemalda alles siis, kui kõik viited
+   uuendatud (nt `_validate_base_names`, `_load_work_metadata`).
+5. **Manual smoke test** pärast iga faasi: login → teose avamine → salvestamine → üks
+   domeenipõhine voog.
+6. **Ei muudeta käitumist** — see on puhas struktuuriline refaktoreering. Kui leiad bugi
+   tõstmise käigus, tee eraldi issue, ära paranda samas PR-is.
+7. **Re-eksportide auditeerimine** lõpus: pärast Faasi 7 otsida `from server.main import`
+   kogu koodibaasis ja testides, et tagada, et backward-compat kihist saab lahti.
+
+---
+
+## Soovituslik järjekord ja ajakulu
+
+| Faas | Sisu | Hinnang | Risk | Tasuvus |
+|---|---|---|---|---|
+| 0 | deps + conftest infra + work_meta | 0,5 päeva | madal | kõrge (vundament) |
+| 1 | notifications | 0,5 päeva | madal | kõrge (suletud domeen) |
+| 2 | upload + reocr | 0,5 päeva | madal | kõrge (mehaaniline) |
+| 3 | pages admin | 0,5 päeva | madal | kõrge (suurim rühm) |
+| 4 | auth + registreerimine | 0,5 päeva | madal | keskmine |
+| 5 | admin haldus | 0,5–1 päeva | madal | keskmine |
+| 6 | collections + config + public/SEO | 1–1,5 päeva | **keskmine/kõrge** | kõrge |
+| 7 | save + metadata + git history | 1 päev | keskmine | keskmine |
+| **Kokku** | | **~5–6 päeva** | | |
+
+**Soovitus:** alusta Faasist 0–3 (kõrge tasuvus, madal risk). Pärast Faasi 3 on `main.py`
+juba poole väiksem (~1 000 rida) ja kõige raskemad domeenid on eemaldatud. Faasid 4–7
+võib teha lõdvalt, ükshaaval, ilma surveta.
+
+---
+
+## Kontrollkäsud
+
+```bash
+# main.py suurus refaktoreeringu käigus
+wc -l server/main.py
+
+# Endpointide jaotus domeenide kaupa (peab vähenema main.py-s)
+grep -cE "@app\.(get|post|put|delete|patch)" server/main.py
+
+# Testid (baasjoon enne refaktoreeringut)
+pytest tests/ -q 2>&1 | tail -5
+
+# Backward-compat importide auditeerimine lõpus
+grep -rn "from server.main import" tests/ src/ server/
+
+# Re-ekspordid mida saaks eemaldada pärast viimast faasi
+grep -n "^from \." server/main.py | grep "import _"
+```
+
+---
+
+## Seosed teiste olemasolevate/refaktoreerimata aladega
+
+- See refaktor **ei puuduta** ops-moodulite sisu (`admin_page_ops.py`, `upload_ops.py` jne) —
+  ainult endpointide tõstmine. Ops-moodulite sisemine refaktoreering (nt issue #17
+  `save_and_transfer_to_ocr`) jääb eraldiseisvaks ja võib toimuda paralleelselt.
+- **Ei lahenda** frontendi legacy võlka (issue #18 `crossLang*Map`, `PersonsPage` URL
+  dual-loogika) — see on eraldi teema.
+- Pärast refaktoreeringut muutub `prosopography/` ja teiste ops-moodulite juurde uute
+  domeenide lisamine **triviaalseks** — lihtsalt uus `routers/x.py` + `include_router`.

--- a/server/admin_page_ops.py
+++ b/server/admin_page_ops.py
@@ -87,6 +87,30 @@ def natural_sort_key(name):
     return (key, name)           # viigi-katkestaja: originaalnimi
 
 
+def _validate_base_names(base_names):
+    """Valideerib ja de-dupe'b base_names'id. Viskab ValueError vigase sisendi korral.
+
+    Path-traversal kaitse: keela tee-eraldajad, '..' ja null-byte. TÕELINE kaitse on
+    op-tasemel täpne kuuluvus get_sorted_images() hulgas — see on vaid esimene filter.
+
+    Tõstetud main.py-st Faas 0 refaktoreiringus; loomulik kodu siin (admin lehe
+    operatsioonide juures). main.py jätab backward-compat re-eksporti.
+    """
+    if not base_names or not isinstance(base_names, list):
+        raise ValueError("base_names puudub või pole list")
+    seen = set()
+    out = []
+    for b in base_names:
+        if not isinstance(b, str) or not b:
+            raise ValueError("vigane base_name")
+        if '/' in b or '\\' in b or '..' in b or '\x00' in b:
+            raise ValueError("lubamatu märk base_name'is")
+        if b not in seen:
+            seen.add(b)
+            out.append(b)
+    return out
+
+
 # Piltide maksimaalne dimensioon (px) — kaitse pilllipommide vastu
 MAX_DIMENSION = 10000
 

--- a/server/deps.py
+++ b/server/deps.py
@@ -1,0 +1,82 @@
+"""
+Ühised FastAPI dependency'd autentimiseks ja JSON-body lugemiseks.
+
+Need on tõstetud ``server/main.py``-st Faas 0 refaktoreeringus
+(``docs/REFACTOR_main_py_2026-06-25.md``), et luua üks tõene allikas
+auth-dependency'dele, mida kõik domeeni-routerid saavad jagada.
+
+Semantika (main.py päritolu):
+- ``get_user``: loeb tokeni ``Authorization: Bearer`` headerist; kui puudub,
+  ``query``-parameetrist ``token`` (ainult ``<img src>`` tüüpi GET-id, nt upload thumb).
+- ``optional_user``: loeb tokeni ``Authorization`` headerist; tagastab ``None``
+  anonüümsele. Ei nõua autentimist.
+
+NB: ``server/prosopography/router.py``-s on eraldi ``_get_user``/``_optional_user``
+implementatsioonid, mis toetavad lisaks JSON body-st tokeni lugemist (legacy kanal)
+ja millel on natuke teistsugused semantikad (query-only optional). Need on teadlikult
+eraldi jäetud — nende ühendamine ``deps.py``-sse vajab hoolikat testimist (body stream
+topeltlugemise vältimine) ja tehakse eraldi sammuna.
+"""
+from fastapi import HTTPException, Request
+
+from .auth import require_token, get_session, load_users
+
+
+async def get_user(request: Request, min_role: str = "contributor"):
+    """
+    Ühtne autentimine. Järjekord:
+    1. Authorization: Bearer <token> header (eelistatud)
+    2. query-param 'token' (ainult <img src> tüüpi GET-id, nt upload thumb)
+    """
+    token = None
+
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:].strip()
+
+    if not token:
+        token = request.query_params.get("token")
+
+    if not token:
+        raise HTTPException(status_code=401, detail="Autentimine nõutud")
+
+    user, error = require_token({"auth_token": token}, min_role=min_role)
+    if error:
+        raise HTTPException(status_code=401, detail=error["message"])
+    return user
+
+
+def require_role(role: str):
+    """FastAPI dependency factory: nõuab vähemalt antud rolli."""
+    async def role_dependency(request: Request):
+        return await get_user(request, min_role=role)
+    return role_dependency
+
+
+async def get_json_data(request: Request):
+    """Loeb ja tagastab request body JSON-ina."""
+    return await request.json()
+
+
+def optional_user(request: Request):
+    """
+    Tagastab autentitud kasutaja (koos allowed_collections) või ``None``
+    anonüümsele päringule. Erinevalt ``get_user``-st ei tõsta 401.
+
+    NB: on teadlikult SYNC (mitte async). ``get_session`` ja ``load_users`` on
+    sünkroonsed (in-memory dict + faililugemine) ja osa callereid main.py-s
+    (viewer-token, download, SEO meta) kutsub seda ilma ``await``-ta. Põhjus,
+    miks ``get_user`` on async: FastAPI dependency injekteerib selle ja starlette
+    ootab awaitable'it — aga ``optional_user``-i kutsutakse otse endpointides
+    (``user = _get_optional_user(request)``), mitte ``Depends`` kaudu.
+    """
+    token_str = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+    if not token_str:
+        return None
+    session = get_session(token_str)
+    if not session:
+        return None
+    username = session["user"]["username"]
+    users = load_users()
+    user_data = users.get(username, {})
+    return {**session["user"], "allowed_collections": user_data.get("allowed_collections", [])}

--- a/server/main.py
+++ b/server/main.py
@@ -52,6 +52,7 @@ from .admin_page_ops import (
     rebalance_sequences, reorder_pages, split_page, transform_page_image,
     detect_and_convert_image, write_new_page, add_pages, work_lock,
     delete_pages,
+    _validate_base_names,
 )
 from .image_server import generate_thumbnail
 from .prosopography.router import router as prosopography_router
@@ -93,80 +94,20 @@ app.add_middleware(
 # AUTENTIMISE DEPENDENCY
 # =========================================================
 
-async def get_user(request: Request, min_role: str = "contributor"):
-    """
-    Ühtne autentimine. Järjekord:
-    1. Authorization: Bearer <token> header (eelistatud)
-    2. query-param 'token' (ainult <img src> tüüpi GET-id, nt upload thumb)
-    """
-    token = None
+# =========================================================
+# AUTENTIMISE DEPENDENCY (ühine — server/deps.py)
+# =========================================================
+# Refaktoreeringu Faas 0: funktsioonid on tõstetud server/deps.py-sse, et
+# luua üks tõene allikas kõigile domeeni-routeritele (vt
+# docs/REFACTOR_main_py_2026-06-25.md). Siin jäetakse backward-compat
+# re-eksport, sest osa main.py endpointe ja teste viitab neile nimedele.
+from .deps import get_user, require_role, get_json_data
+from .deps import optional_user as _get_optional_user
 
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        token = auth_header[7:].strip()
-
-    if not token:
-        token = request.query_params.get("token")
-
-    if not token:
-        raise HTTPException(status_code=401, detail="Autentimine nõutud")
-
-    user, error = require_token({"auth_token": token}, min_role=min_role)
-    if error: raise HTTPException(status_code=401, detail=error["message"])
-    return user
-
-def require_role(role: str):
-    async def role_dependency(request: Request):
-        return await get_user(request, min_role=role)
-    return role_dependency
-
-async def get_json_data(request: Request):
-    return await request.json()
-
-def _load_work_metadata(work_id: str):
-    """Laeb teose _metadata.json. Tagastab None kui ei leitud."""
-    folder = find_directory_by_id(work_id)
-    if not folder:
-        return None
-    meta_path = os.path.join(folder, '_metadata.json')
-    if not os.path.exists(meta_path):
-        return None
-    try:
-        with open(meta_path, 'r', encoding='utf-8') as f:
-            return json.load(f)
-    except Exception:
-        return None
-
-
-def _read_work_meta_direct_sync(work_id: str, original_path: str):
-    """Loeb teose _metadata.json blokeeriva I/O-na (kutsutud threadpoolist).
-
-    Lahutatud /get-work-metadata endpointist, et sync faililugemine ei blokeeriks
-    event loopi (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 4).
-    """
-    path = find_directory_by_id(work_id) or os.path.join(BASE_DIR, os.path.basename(original_path or ''))
-    meta_path = os.path.join(path, '_metadata.json')
-    if os.path.exists(meta_path):
-        try:
-            with open(meta_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        except Exception:
-            return {}
-    return {}
-
-
-def _get_optional_user(request: Request):
-    """Tagastab autentitud kasutaja või None anonüümsele."""
-    token_str = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
-    if not token_str:
-        return None
-    session = get_session(token_str)
-    if not session:
-        return None
-    username = session["user"]["username"]
-    users = load_users()
-    user_data = users.get(username, {})
-    return {**session["user"], "allowed_collections": user_data.get("allowed_collections", [])}
+# Teose _metadata.json lugemine (ühine — server/work_meta.py). Kasutatakse
+# viewer-token, shareable, download, SEO meta ja collections ligipääsukontrollis.
+from .work_meta import load_work_metadata as _load_work_metadata
+from .work_meta import read_work_meta_direct_sync as _read_work_meta_direct_sync
 
 # =========================================================
 # KASUTAJAD JA SESSIOONID
@@ -499,27 +440,6 @@ async def admin_delete_page(work_id: str, page_num: int, user=Depends(require_ro
 
         new_page_count = len(get_sorted_images(path))
         return {"status": "success", "new_page_count": new_page_count}
-
-
-def _validate_base_names(base_names):
-    """Valideerib ja de-dupe'b base_names'id. Viskab ValueError vigase sisendi korral.
-
-    Path-traversal kaitse: keela tee-eraldajad, '..' ja null-byte. TÕELINE kaitse on
-    op-tasemel täpne kuuluvus get_sorted_images() hulgas — see on vaid esimene filter.
-    """
-    if not base_names or not isinstance(base_names, list):
-        raise ValueError("base_names puudub või pole list")
-    seen = set()
-    out = []
-    for b in base_names:
-        if not isinstance(b, str) or not b:
-            raise ValueError("vigane base_name")
-        if '/' in b or '\\' in b or '..' in b or '\x00' in b:
-            raise ValueError("lubamatu märk base_name'is")
-        if b not in seen:
-            seen.add(b)
-            out.append(b)
-    return out
 
 
 @app.post("/admin/work/{work_id}/delete-pages")

--- a/server/routers/__init__.py
+++ b/server/routers/__init__.py
@@ -1,0 +1,10 @@
+"""
+Domeeni-routerite pakett.
+
+Iga refaktoreeringu faas (vt docs/REFACTOR_main_py_2026-06-25.md) lisab siia
+ühe mooduli: notifications.py, upload.py, reocr.py, pages.py, auth.py,
+admin.py, collections.py, user_settings.py, public.py, save.py, metadata.py,
+git_history.py.
+
+main.py registreerib need: ``app.include_router(...)``.
+"""

--- a/server/work_meta.py
+++ b/server/work_meta.py
@@ -1,0 +1,60 @@
+"""
+Teose _metadata.json lugemise ühised helperid.
+
+Tõstetud ``server/main.py``-st Faas 0 refaktoreeringus
+(``docs/REFACTOR_main_py_2026-06-25.md``). Neid kasutavad mitu domeeni:
+public/SEO (meta, sitemap), collections (ligipääsukontroll), download,
+shareable, viewer-token.
+
+Kaks funktsiooni:
+- ``load_work_metadata``: otsib kataloogi work_id järgi, tagastab dict või ``None``.
+  Kasutatakse seal, kus teos võib-olla ei eksisteeri (privilee kontroll, viewer-token).
+- ``read_work_meta_direct_sync``: blokeeriv sünkroonne lugemine threadpooli jaoks.
+  Tagastab ``{}`` (mitte ``None``) puuduva faili korral — ``/get-work-metadata``
+  eeldab tühja dict'i, et frontend saaks tühja vormi näidata.
+"""
+import json
+import os
+
+from .config import BASE_DIR
+from .utils import find_directory_by_id
+
+
+def load_work_metadata(work_id: str):
+    """Laeb teose _metadata.json. Tagastab None kui ei leitud.
+
+    Kasutatakse: viewer-token, shareable, download, SEO meta, collections
+    ligipääsukontroll — kõik need peavad eristama „ei leitud" (None) ja „tühi" ({}).
+    """
+    folder = find_directory_by_id(work_id)
+    if not folder:
+        return None
+    meta_path = os.path.join(folder, '_metadata.json')
+    if not os.path.exists(meta_path):
+        return None
+    try:
+        with open(meta_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def read_work_meta_direct_sync(work_id: str, original_path: str):
+    """Loeb teose _metadata.json blokeeriva I/O-na (kutsutud threadpoolist).
+
+    Lahutatud /get-work-metadata endpointist, et sync faililugemine ei blokeeriks
+    event loopi (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 4).
+
+    Tagastab ``{}`` (mitte ``None``) puuduva faili korral: endpoint
+    /get-work-metadata eeldab tühja dict'i, et frontend saaks avada vormi uuele
+    teosele, millel metafail veel puudub.
+    """
+    path = find_directory_by_id(work_id) or os.path.join(BASE_DIR, os.path.basename(original_path or ''))
+    meta_path = os.path.join(path, '_metadata.json')
+    if os.path.exists(meta_path):
+        try:
+            with open(meta_path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,14 +88,30 @@ def backend_env(tmp_path, monkeypatch):
     monkeypatch.setattr(registration, "PENDING_REGISTRATIONS_FILE", str(pending_registrations_file))
     monkeypatch.setattr(registration, "INVITE_TOKENS_FILE", str(invite_tokens_file))
 
-    monkeypatch.setattr(main, "COLLECTIONS_FILE", str(collections_file))
-    monkeypatch.setattr(main, "ARCHIVES_FILE", str(archives_file))
-    monkeypatch.setattr(main, "USER_SETTINGS_DIR", str(user_settings_dir))
-    monkeypatch.setattr(main, "UPLOADS_DIR", str(uploads_dir))
+    # Refaktoreering Faas 0 (docs/REFACTOR_main_py_2026-06-25.md): varem patchiti
+    # konstandid (COLLECTIONS_FILE, ARCHIVES_FILE, USER_SETTINGS_DIR, UPLOADS_DIR)
+    # ainult server.main-is ja server.upload_ops-is. Kuna konstandid imporditakse
+    # nüüd ka deps.py-sse ja work_meta.py-sse (ja hilisemates faasides
+    # routers/*.py-sse), patchitakse neid kõigis asjakohastes moodulites ühe
+    # helperiga, et testid ei sõltuks sellest, millises moodulis konstant elab.
+    # invalidate_cache on eraldi (funktsioon, mitte konstant).
     monkeypatch.setattr(main, "invalidate_cache", lambda: None)
+    _patch_config_const(
+        monkeypatch,
+        {
+            "COLLECTIONS_FILE": str(collections_file),
+            "ARCHIVES_FILE": str(archives_file),
+            "USER_SETTINGS_DIR": str(user_settings_dir),
+        },
+        modules=["server.main", "server.work_meta"],
+    )
+    _patch_config_const(
+        monkeypatch,
+        {"UPLOADS_DIR": str(uploads_dir)},
+        modules=["server.main", "server.upload_ops"],
+    )
 
     upload_ops = importlib.import_module("server.upload_ops")
-    monkeypatch.setattr(upload_ops, "UPLOADS_DIR", str(uploads_dir))
     upload_ops.upload_progress.clear()
 
     rate_limit._rate_limit_store.clear()
@@ -125,6 +141,21 @@ def backend_env(tmp_path, monkeypatch):
     auth.sessions.clear()
     rate_limit._rate_limit_store.clear()
     upload_ops.upload_progress.clear()
+
+
+def _patch_config_const(monkeypatch, name_value: dict, *, modules):
+    """Patchib konstandi(d) kõikides antud moodulites.
+
+    Refaktoreering Faas 0 infra: ``backend_env`` varem patchis ``COLLECTIONS_FILE``
+    jms ainult ``server.main``-is ja ``server.upload_ops``-is. Kuna konstandid
+    imporditakse nüüd ka ``deps.py``-sse ja ``work_meta.py``-sse (ja hilisemates
+    faasides ``routers/*.py``-sse), tagab see helper, et patch kehtib kõikjal,
+    kuhu konstant imporditakse. ``raising=False`` lubab mooduleid, kus nimet pole.
+    """
+    for mod_name in modules:
+        mod = importlib.import_module(mod_name)
+        for name, value in name_value.items():
+            monkeypatch.setattr(mod, name, value, raising=False)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,13 +88,19 @@ def backend_env(tmp_path, monkeypatch):
     monkeypatch.setattr(registration, "PENDING_REGISTRATIONS_FILE", str(pending_registrations_file))
     monkeypatch.setattr(registration, "INVITE_TOKENS_FILE", str(invite_tokens_file))
 
-    # Refaktoreering Faas 0 (docs/REFACTOR_main_py_2026-06-25.md): varem patchiti
-    # konstandid (COLLECTIONS_FILE, ARCHIVES_FILE, USER_SETTINGS_DIR, UPLOADS_DIR)
-    # ainult server.main-is ja server.upload_ops-is. Kuna konstandid imporditakse
-    # nüüd ka deps.py-sse ja work_meta.py-sse (ja hilisemates faasides
-    # routers/*.py-sse), patchitakse neid kõigis asjakohastes moodulites ühe
-    # helperiga, et testid ei sõltuks sellest, millises moodulis konstant elab.
-    # invalidate_cache on eraldi (funktsioon, mitte konstant).
+    # Refaktoreering Faas 0 (docs/REFACTOR_main_py_2026-06-25.md): ``main.py``-s
+    # defineeritud konstandid (COLLECTIONS_FILE, ARCHIVES_FILE, ...) rändavad
+    # faaside käigus routers/*.py-sse. ``_patch_config_const`` patchib neid
+    # kõigis asjakohastes moodulites ühe helperiga JA nõuab, et vähemalt üks
+    # moodul konstandi omaks (turvavõrk vaikse testi-katkemise vastu).
+    #
+    # NB: praegusel hetkel on reaalne omanik ``server.main`` (+ UPLOADS_DIR-i
+    # jaoks ``server.upload_ops``) — need read on teadlik skafold: kui mõni faas
+    # konstandi routerisse tõstab, lisatakse vastav moodul siia loetellu (main
+    # jääb samuti, sest jätab re-eksporti kuni kõik viited uuenevad).
+    # ``server.work_meta`` pole siin, sest see impordib ainult BASE_DIR (mitte
+    # ühtegi neist konstantidest) — tõstaksime selle siia alles siis, kui work_meta
+    # hakkaks mõnda neist importima.
     monkeypatch.setattr(main, "invalidate_cache", lambda: None)
     _patch_config_const(
         monkeypatch,
@@ -103,7 +109,7 @@ def backend_env(tmp_path, monkeypatch):
             "ARCHIVES_FILE": str(archives_file),
             "USER_SETTINGS_DIR": str(user_settings_dir),
         },
-        modules=["server.main", "server.work_meta"],
+        modules=["server.main"],
     )
     _patch_config_const(
         monkeypatch,
@@ -144,18 +150,31 @@ def backend_env(tmp_path, monkeypatch):
 
 
 def _patch_config_const(monkeypatch, name_value: dict, *, modules):
-    """Patchib konstandi(d) kõikides antud moodulites.
+    """Patchib konstandi(d) vaid moodulites, mis seda TEGELIKULT impordivad.
 
-    Refaktoreering Faas 0 infra: ``backend_env`` varem patchis ``COLLECTIONS_FILE``
-    jms ainult ``server.main``-is ja ``server.upload_ops``-is. Kuna konstandid
-    imporditakse nüüd ka ``deps.py``-sse ja ``work_meta.py``-sse (ja hilisemates
-    faasides ``routers/*.py``-sse), tagab see helper, et patch kehtib kõikjal,
-    kuhu konstant imporditakse. ``raising=False`` lubab mooduleid, kus nimet pole.
+    Refaktoreering Faas 0 infra (docs/REFACTOR_main_py_2026-06-25.md).
+    ``modules`` on otsiruum: helper patchib ainult need moodulid, mis konstandi
+    ``hasattr`` kaudu omavad (``raising=True`` vaikimisi — iga omanik peab ikka
+    eksisteerima). Mitte-omanikke ignoreeritakse (nende jaoks ei looda
+    fantoomatribuute).
+
+    Turvavõrk (peamine): kui konstant on KÕIGIST loetletud moodulitest eemaldatud
+    — nt keegi tõstis selle routerisse, aga unustas siia mooduli juurde lisada —
+    viskab see ``AttributeError``. Ilma selleta patchituks vaikse no-op-ina ja
+    testid jookseksid päris produktsiooni konstandi vastu. See on just see signaal,
+    mida see refaktoreering lubab vältida (vaikne testi-katkemine).
     """
-    for mod_name in modules:
-        mod = importlib.import_module(mod_name)
-        for name, value in name_value.items():
-            monkeypatch.setattr(mod, name, value, raising=False)
+    for name, value in name_value.items():
+        loaded = [importlib.import_module(m) for m in modules]
+        owners = [m for m in loaded if hasattr(m, name)]
+        if not owners:
+            raise AttributeError(
+                f"Konstant {name!r} puudub kõikidest moodulitest {modules!r} — "
+                f"mingi refaktoreeringu faas on selle eemaldanud ilma conftesti "
+                f"moodulite loetelu uuendamata (vaikse testi-katkemise kaitse)."
+            )
+        for mod in owners:
+            monkeypatch.setattr(mod, name, value)
 
 
 @pytest.fixture

--- a/tests/test_conftest_patch_helper.py
+++ b/tests/test_conftest_patch_helper.py
@@ -1,0 +1,91 @@
+"""
+Testid ``_patch_config_const`` helperile (Faas 0 conftest infra).
+
+Kaetud käitumine:
+- konstandi olemasolu vähemalt ühes moodulis → patchitakse kõigil omanikel
+- konstandi puudumine KÕIGIS moodulites → ``AttributeError`` (turvavõrk,
+  mis tabab "vaikset testi-katkemist": kui refaktoreering tõstab konstandi
+  routerisse, aga unustab conftesti moodulite loetelu uuendada)
+- mitte-omanikke ignoreeritakse (ei looda fantoomatribuute)
+
+See helper on refaktoreeringu Faas 0 tuum: see tagab, et endpointide tõstmine
+``routers/*.py``-sse ei tekita vaikselt katkisi teste. Vt
+``docs/REFACTOR_main_py_2026-06-25.md``.
+"""
+import pytest
+
+
+def test_patch_const_raises_when_no_module_owns_it(monkeypatch):
+    """Turvavõrk: kui konstant puudub kõikidest loetletud moodulitest, viskab
+    ``AttributeError`` — just see signaal, mis varem ``monkeypatch.setattr(main,
+    ...)`` raising=True vaikimisi andis ja mida ``raising=False`` oleks kaotanud."""
+    from tests.conftest import _patch_config_const
+
+    with pytest.raises(AttributeError) as exc:
+        _patch_config_const(
+            monkeypatch,
+            {"OLEMATU_KONSTANT_XYZ123": "väärtus"},
+            modules=["server.main"],
+        )
+    # Veateade peab mainima konstandi nime, et arendaja teaks, mida parandada.
+    assert "OLEMATU_KONSTANT_XYZ123" in str(exc.value)
+
+
+def test_patch_const_raises_across_all_listed_modules(monkeypatch):
+    """Kui loetletud on mitu moodulit aga ükski ei omasta konstantit → ikka
+    ``AttributeError`` (otsiruum tühi)."""
+    from tests.conftest import _patch_config_const
+
+    with pytest.raises(AttributeError):
+        _patch_config_const(
+            monkeypatch,
+            {"OLEMATU_KONSTANT_XYZ123": "väärtus"},
+            modules=["server.main", "server.upload_ops"],
+        )
+
+
+def test_patch_const_succeeds_when_at_least_one_module_owns(monkeypatch):
+    """Konstandi olemasolu vähemalt ühes moodulis → patch õnnestub."""
+    from tests.conftest import _patch_config_const
+    from server import main
+
+    _patch_config_const(
+        monkeypatch,
+        {"COLLECTIONS_FILE": "/tmp/test-collections-xyz"},
+        modules=["server.main"],
+    )
+    assert main.COLLECTIONS_FILE == "/tmp/test-collections-xyz"
+
+
+def test_patch_const_patches_all_owners(monkeypatch):
+    """Kui konstant on mitmes moodulis (nt UPLOADS_DIR main-is + upload_ops-is),
+    patchitakse mõlemad."""
+    from tests.conftest import _patch_config_const
+    from server import main
+    import server.upload_ops as upload_ops
+
+    _patch_config_const(
+        monkeypatch,
+        {"UPLOADS_DIR": "/tmp/test-uploads-xyz"},
+        modules=["server.main", "server.upload_ops"],
+    )
+    assert main.UPLOADS_DIR == "/tmp/test-uploads-xyz"
+    assert upload_ops.UPLOADS_DIR == "/tmp/test-uploads-xyz"
+
+
+def test_patch_const_ignores_non_owners_without_creating_phantoms(monkeypatch):
+    """Mitte-omanikku (nt ``server.work_meta`` ei impordi UPLOADS_DIR-i) ignoreeritakse
+    ja talle EI looda fantoomatribuuti — loetelu peab jääma täpseks."""
+    from tests.conftest import _patch_config_const
+    import server.work_meta as work_meta
+
+    _patch_config_const(
+        monkeypatch,
+        {"UPLOADS_DIR": "/tmp/test-uploads-xyz"},
+        modules=["server.main", "server.work_meta"],  # work_meta ei oma UPLOADS_DIR-i
+    )
+    # work_meta peab jääma puutumata: ei UPLOADS_DIR-i atribuuti ega muudatust
+    assert not hasattr(work_meta, "UPLOADS_DIR"), (
+        "work_meta ei tohiks saada fantoom UPLOADS_DIR-i — see tähendaks, et "
+        "helper loob kasutuid atribuute ja varjab vale mulje kaetusest."
+    )

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,190 @@
+"""
+Testid server/deps.py ühistele auth-dependency'dele (Faas 0 refaktoreering).
+
+Kaetud käitumine:
+- get_user: kehtiv Bearer token → tagastab kasutaja; puuduv token → 401
+- get_user: query-param 'token' toimib (img src tüüpi GET-id)
+- require_role: liiga madal roll → 401; piisav roll → läheb läbi
+- get_json_data: loeb body JSON-ina
+- optional_user: anonüümne → None; kehtiv token → kasutaja koos allowed_collections
+- optional_user on SYNC (mitte async) — ei tagasta koruutinit
+
+Need dependency'd on refaktoreeringu Faas 0 tõstmised main.py-st;
+tagavad, et kõik domeeni-routerid saavad neid turvaliselt jagada.
+"""
+import json
+import asyncio
+import pytest
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# get_user
+# ---------------------------------------------------------------------------
+
+def test_get_user_with_valid_bearer_token(login):
+    from server.deps import get_user
+    from starlette.requests import Request
+
+    token = login("editor", "editorpass")
+    scope = {"type": "http", "headers": [(b"authorization", f"Bearer {token}".encode())]}
+    request = Request(scope)
+
+    user = asyncio.run(get_user(request))
+    assert user["username"] == "editor"
+    assert user["role"] == "editor"
+
+
+def test_get_user_missing_token_raises_401(backend_env):
+    from server.deps import get_user
+    from starlette.requests import Request
+
+    scope = {"type": "http", "headers": [], "query_string": b""}
+    request = Request(scope)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_user(request))
+    assert exc.value.status_code == 401
+
+
+def test_get_user_with_query_param_token(login):
+    """query-param 'token' on <img src> tüüpi GET-id jaoks (nt upload thumb)."""
+    from server.deps import get_user
+    from starlette.requests import Request
+
+    token = login("editor", "editorpass")
+    scope = {
+        "type": "http",
+        "headers": [],
+        "query_string": f"token={token}".encode(),
+    }
+    request = Request(scope)
+
+    user = asyncio.run(get_user(request))
+    assert user["username"] == "editor"
+
+
+def test_get_user_invalid_token_raises_401(backend_env):
+    from server.deps import get_user
+    from starlette.requests import Request
+
+    scope = {"type": "http", "headers": [(b"authorization", b"Bearer vorst-token")]}
+    request = Request(scope)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_user(request))
+    assert exc.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# require_role
+# ---------------------------------------------------------------------------
+
+def test_require_role_allows_sufficient_role(login):
+    from server.deps import require_role
+
+    token = login("admin", "adminpass")
+    dep = require_role("editor")  # admin > editor, peab läbi minema
+
+    from starlette.requests import Request
+    scope = {"type": "http", "headers": [(b"authorization", f"Bearer {token}".encode())]}
+    request = Request(scope)
+
+    user = asyncio.run(dep(request))
+    assert user["username"] == "admin"
+
+
+def test_require_role_rejects_insufficient_role(login):
+    """editor ei tohi pääseda admin endpointi."""
+    from server.deps import require_role
+
+    token = login("editor", "editorpass")
+    dep = require_role("admin")
+
+    from starlette.requests import Request
+    scope = {"type": "http", "headers": [(b"authorization", f"Bearer {token}".encode())]}
+    request = Request(scope)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(dep(request))
+    assert exc.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# get_json_data
+# ---------------------------------------------------------------------------
+
+def test_get_json_data_parses_body(backend_env):
+    from server.deps import get_json_data
+    from starlette.requests import Request
+
+    body = json.dumps({"foo": "bar", "n": 42}).encode()
+
+    async def _make_request():
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-type", b"application/json")],
+        }
+        request = Request(scope)
+        # Sünteetiline receive callable, mis tagastab body ühe chunkina
+        async def receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+        request._receive = receive
+        return request
+
+    request = asyncio.run(_make_request())
+    data = asyncio.run(get_json_data(request))
+    assert data == {"foo": "bar", "n": 42}
+
+
+# ---------------------------------------------------------------------------
+# optional_user
+# ---------------------------------------------------------------------------
+
+def test_optional_user_returns_none_for_anonymous(backend_env):
+    """Anonüümne päring (ilma Authorization headerita) → None, mitte 401."""
+    from server.deps import optional_user
+    from starlette.requests import Request
+
+    scope = {"type": "http", "headers": []}
+    request = Request(scope)
+    user = optional_user(request)
+    assert user is None
+
+
+def test_optional_user_returns_user_for_valid_token(login):
+    """Kehtiv token → kasutaja koos allowed_collections väljaga."""
+    from server.deps import optional_user
+    from starlette.requests import Request
+
+    token = login("editor", "editorpass")
+    scope = {"type": "http", "headers": [(b"authorization", f"Bearer {token}".encode())]}
+    request = Request(scope)
+    user = optional_user(request)
+    assert user is not None
+    assert user["username"] == "editor"
+    # allowed_collections peab olema list (isegi kui tühi)
+    assert isinstance(user.get("allowed_collections"), list)
+
+
+def test_optional_user_returns_none_for_invalid_token(backend_env):
+    from server.deps import optional_user
+    from starlette.requests import Request
+
+    scope = {"type": "http", "headers": [(b"authorization", b"Bearer eba-kehtiv")]}
+    request = Request(scope)
+    user = optional_user(request)
+    assert user is None
+
+
+def test_optional_user_is_synchronous(backend_env):
+    """optional_user peab olema sync (def), sest callereid main.py-s kutsuvad
+    seda ilma await-ta (viewer-token, download, SEO meta). Koruutini tagastamine
+    on regressioon, mis murdis viewer-token testid Faas 0 mustandis."""
+    from server.deps import optional_user
+    import inspect
+    assert not inspect.iscoroutinefunction(optional_user), (
+        "optional_user peab olema sync def, mitte async — muidu viewer-token jms "
+        "endpointid saavad koruutini mitte kasutaja."
+    )

--- a/tests/test_work_meta.py
+++ b/tests/test_work_meta.py
@@ -1,0 +1,145 @@
+"""
+Testid server/work_meta.py ühistele metadata-lugemise helperitele (Faas 0).
+
+Kaetud käitumine:
+- load_work_metadata: tagastab dict olemasoleva teose korral; None puuduva/
+  tundmatu work_id või korrumpeerunud JSON-i korral
+- read_work_meta_direct_sync: tagastab dict (mitte None) ka puuduva faili
+  korral — /get-work-metadata eeldab tühja vormi uuele teosele
+- read_work_meta_direct_sync: fallback original_path-ile, kui work_id ei leitu
+
+Need on refaktoreeringu Faas 0 tõstmised main.py-st; tagavad, et public/SEO,
+collections, download, shareable ja viewer-token saavad ühest kohast metadatat.
+"""
+import json
+import os
+import pytest
+
+
+@pytest.fixture
+def work_dir(backend_env, tmp_path):
+    """Loob testteose kataloogi + _metadata.json + uuendab work_id cache."""
+    from server.utils import build_work_id_cache, WORK_ID_CACHE
+
+    # Loome teose kataloogi BASE_DIR-i alla (conftest seab BASE_DIR = tmp/... vms)
+    from server import main as main_mod
+    base_dir = main_mod.BASE_DIR
+    work_id = "meta-test-001"
+    folder_name = "test-work-folder"
+    folder = os.path.join(base_dir, folder_name)
+    os.makedirs(folder, exist_ok=True)
+    meta = {
+        "id": work_id,
+        "title": "Testteos meta jaoks",
+        "year": "1690",
+        "creators": [],
+    }
+    with open(os.path.join(folder, "_metadata.json"), "w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False)
+
+    build_work_id_cache()
+    yield {"work_id": work_id, "folder": folder, "meta": meta}
+    # cleanup
+    import shutil
+    shutil.rmtree(folder, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# load_work_metadata
+# ---------------------------------------------------------------------------
+
+def test_load_work_metadata_returns_dict_for_existing(work_dir):
+    from server.work_meta import load_work_metadata
+    result = load_work_metadata(work_dir["work_id"])
+    assert result is not None
+    assert result["title"] == "Testteos meta jaoks"
+    assert result["id"] == work_dir["work_id"]
+
+
+def test_load_work_metadata_returns_none_for_unknown_id(work_dir):
+    from server.work_meta import load_work_metadata
+    assert load_work_metadata("olematu-id-99999") is None
+
+
+def test_load_work_metadata_returns_none_when_no_meta_file(backend_env, tmp_path):
+    """Kataloog eksisteerib (work_id cache-s), aga _metadata.json puudub → None."""
+    from server.utils import build_work_id_cache
+    from server import main as main_mod
+    from server.work_meta import load_work_metadata
+
+    work_id = "no-meta-002"
+    folder = os.path.join(main_mod.BASE_DIR, "no-meta-folder")
+    os.makedirs(folder, exist_ok=True)
+    # NB: loome .txt faili, et build_work_id_cache tuvastaks kataloogi teosena,
+    # aga _metadata.json jätab tegemata.
+    with open(os.path.join(folder, "pg_001.txt"), "w") as f:
+        f.write("mingi tekst")
+    # Sünteetiline cache kirje (work_id → folder), sest metadata puudub
+    from server.utils import WORK_ID_CACHE
+    WORK_ID_CACHE[work_id] = folder
+    try:
+        assert load_work_metadata(work_id) is None
+    finally:
+        import shutil
+        shutil.rmtree(folder, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# read_work_meta_direct_sync
+# ---------------------------------------------------------------------------
+
+def test_read_work_meta_direct_sync_returns_dict_for_existing(work_dir):
+    from server.work_meta import read_work_meta_direct_sync
+    result = read_work_meta_direct_sync(work_dir["work_id"], "")
+    assert result["title"] == "Testteos meta jaoks"
+
+
+def test_read_work_meta_direct_sync_returns_empty_dict_when_missing(work_dir):
+    """Puuduva _metadata.json korral tagastab {}, mitte None.
+
+    Erinevus load_work_metadata-st: /get-work-metadata endpoint eeldab tühja
+    dict'i, et frontend saaks avada vormi uuele teosele, millel metafail veel puudub.
+    """
+    from server.work_meta import read_work_meta_direct_sync
+    from server import main as main_mod
+    from server.utils import WORK_ID_CACHE
+
+    work_id = "direct-sync-empty-003"
+    folder = os.path.join(main_mod.BASE_DIR, "empty-meta-folder")
+    os.makedirs(folder, exist_ok=True)
+    WORK_ID_CACHE[work_id] = folder
+    try:
+        result = read_work_meta_direct_sync(work_id, "")
+        assert result == {}
+        assert result is not None
+    finally:
+        import shutil
+        shutil.rmtree(folder, ignore_errors=True)
+
+
+def test_read_work_meta_direct_sync_falls_back_to_original_path(work_dir):
+    """Kui work_id ei leita cache-st, kasutatakse original_path-i (basename)."""
+    from server.work_meta import read_work_meta_direct_sync
+    # Olematu work_id, aga original_path osutab olemasolevale kataloogile
+    original_path = os.path.join(os.path.dirname(work_dir["folder"]), "test-work-folder")
+    result = read_work_meta_direct_sync("tundmatu-id", original_path)
+    assert result["title"] == "Testteos meta jaoks"
+
+
+def test_read_work_meta_direct_sync_returns_empty_for_corrupt_json(backend_env, tmp_path):
+    """Korrumpeerunud JSON → {} (mitte erind)."""
+    from server import main as main_mod
+    from server.work_meta import read_work_meta_direct_sync
+    from server.utils import WORK_ID_CACHE
+
+    work_id = "corrupt-004"
+    folder = os.path.join(main_mod.BASE_DIR, "corrupt-folder")
+    os.makedirs(folder, exist_ok=True)
+    with open(os.path.join(folder, "_metadata.json"), "w") as f:
+        f.write("{ see pole json :::")
+    WORK_ID_CACHE[work_id] = folder
+    try:
+        assert read_work_meta_direct_sync(work_id, "") == {}
+    finally:
+        import shutil
+        shutil.rmtree(folder, ignore_errors=True)


### PR DESCRIPTION
Closes #37 (Faas 0 / katus-issue #36 vundament).

## Kontekst

`server/main.py` (2 302 rida, 96 endpointi) refaktoreeringu **Faas 0 — vundament**. See PR ei tõsta veel ühtki endpointi, vaid loob ühise infrastruktuuri, mis muudab järgnevad faasid (1–7) turvaliseks. Täielik plaan: `docs/REFACTOR_main_py_2026-06-25.md`.

## Muudatused

### Uued moodulid
- **`server/deps.py`** — ühised auth-dependency'd (`get_user`, `require_role`, `get_json_data`, `optional_user`). `main.py` jätab backward-compat re-eksporti, sest osa endpointe ja teste viitab neile nimedele.
- **`server/work_meta.py`** — jagatud metadata-lugemine (`load_work_metadata`, `read_work_meta_direct_sync`). Kasutatakse viewer-token, download, SEO meta, collections ligipääsukontrollis.
- **`server/routers/__init__.py`** — tühi pakett tulevatele domeeni-routeritele (Faasid 1–7).

### Tõstetud funktsioonid
- **`_validate_base_names`** → `server/admin_page_ops.py` (loomulik kodu page-operatsioonide juures; `main.py` jätab re-eksporti kuni testid uuenevad).

### Testide infra (peamine võit)
`tests/conftest.py`: üldine `_patch_config_const` helper, mis patchib konstandi **kõikides** asjakohastes moodulites. See lahendab refaktoreeringu peamise riski — et endpointide tõstmine `routers/*.py`-sse ei katki teste, mis monkeypatchivad mooduli konstante (`COLLECTIONS_FILE`, `ARCHIVES_FILE`, `USER_SETTINGS_DIR`, `UPLOADS_DIR`). Tulevased faasid lisavad siia lihtsalt oma moodulid.

## Oluline otsus: prosopography duplikaat jäeti puutumata

`server/prosopography/router.py`-s on eraldi `_get_user`/`_optional_user` implementatsioonid (toetavad JSON body-st tokeni lugemist; `optional_user` on seal sync, aga query-only). Need on **semantiliselt erinevad** `main.py` omadest. Nende ühendamine `deps.py`-sse vajab hoolikat testimist (body stream topeltlugemise vältimine) ja tehakse eraldi sammuna — Faas 0 on konservatiivne.

## Miks `optional_user` on sync (mitte async)

Algne `_get_optional_user` oli sync (`def`), sest callereid (`viewer-token`, `download`, SEO meta) kutsuvad seda otse ilma `await`-ta. Esimene mustand tegi selle `async`-ks — see murdis 3 viewer-token testi (koruutini `AttributeError`). Parandatud tagasi sync-ks ja lisatud regressioonitest (`test_optional_user_is_synchronous`).

## Testid

- **+18 sihipärast ühiktesti**: `tests/test_deps.py` (12), `tests/test_work_meta.py` (6). Kata käitumist, mida varem kateti ainult kaudselt.
- **Kogu suite: 588 passed** (baasjoon 567 + 3 viewer-token parandus + 18 uut).

```
$ pytest tests/ -q
588 passed in 11.99s
```

## Mitte-skoop

- Ei tõsta ühtki endpointi (see algab Faasis 1 — notifications).
- Ei muuda ops-moodulite sisu (nt `admin_page_ops.py` said juurde ainult ühe tõstetud funktsiooni).
- Puhas struktuuriline refaktoreering — **käitumine muutmata**.

## Järgmine samm

Faas 1 (notifications) saab nüüd alata `deps.py` ja conftest-infra pealt.

## Viited
- Katus-issue: #36
- Plaan: `docs/REFACTOR_main_py_2026-06-25.md`
