### PR TITLE
Faas 1: Notifications domeen eraldi moodulitesse (5 endpointi + 44 testi) #39

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, HTMLResponse, FileResponse, StreamingResponse, Response
 from starlette.concurrency import run_in_threadpool
 
-from .config import PORT, ALLOWED_ORIGINS, BASE_DIR, UPLOAD_ENABLED, UPLOADS_DIR, COLLECTIONS_FILE, USER_SETTINGS_DIR, NOTIFICATIONS_DIR, get_logger, ARCHIVES_FILE
+from .config import PORT, ALLOWED_ORIGINS, BASE_DIR, UPLOAD_ENABLED, UPLOADS_DIR, COLLECTIONS_FILE, USER_SETTINGS_DIR, get_logger, ARCHIVES_FILE
 from .utils import build_work_id_cache, find_directory_by_id, metadata_lock, generate_nanoid, atomic_write_json
 from .access_ops import can_read_work, can_write_work, is_work_public
 
@@ -56,6 +56,7 @@ from .admin_page_ops import (
 )
 from .image_server import generate_thumbnail
 from .prosopography.router import router as prosopography_router
+from .routers.notifications import router as notifications_router
 from .prosopography.ops import update_page_person_mentions, rebuild_indices, _load_index
 from .metadata_ops import save_work_metadata, bulk_update_field, ALLOWED_METADATA_FIELDS
 from .marginalia_normalize import normalize_marginalia_tags
@@ -81,6 +82,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="VUTT API", version="1.0.0", lifespan=lifespan)
 app.include_router(prosopography_router, prefix="/prosopography")
+app.include_router(notifications_router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -783,291 +785,22 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
     return {"status": "success", "commit_hash": git_result.get("commit_hash", "")[:8]}
 
 
-_notifications_lock = threading.RLock()
+# =========================================================
+# TEAVITUSED (notifications) — tõstetud Faas 1 server/routers/notifications.py +
+# server/notifications_ops.py. Siin backward-compat re-eksport, sest osa main.py
+# endpointe ja teste võivad viidata vanadele ``_``-nimedele.
+# =========================================================
+from .notifications_ops import (
+    safe_username as _safe_username,
+    get_notifications_path as _get_notifications_path,
+    load_notifications as _load_notifications,
+    save_notifications as _save_notifications,
+    append_notification as _append_notification,
+    create_notification as _create_notification,
+    find_username_by_display_name as _find_username_by_display_name,
+    _notifications_lock,
+)
 
-
-def _safe_username(username: str) -> str:
-    """Piira teavituste failinimi lihtsa kasutajanime kujule."""
-    return os.path.basename(username or "").strip()
-
-
-def _get_notifications_path(username: str) -> str:
-    safe = _safe_username(username)
-    if not safe:
-        raise HTTPException(status_code=400, detail="Vigane kasutajanimi")
-    return os.path.join(NOTIFICATIONS_DIR, f"{safe}.json")
-
-
-def _load_notifications(username: str) -> list:
-    path = _get_notifications_path(username)
-    if not os.path.exists(path):
-        return []
-    with open(path, 'r', encoding='utf-8') as f:
-        data = json.load(f)
-    return data if isinstance(data, list) else []
-
-
-def _save_notifications(username: str, notifications: list):
-    os.makedirs(NOTIFICATIONS_DIR, exist_ok=True)
-    atomic_write_json(_get_notifications_path(username), notifications)
-
-
-def _append_notification(username: str, notification: dict):
-    with _notifications_lock:
-        notifications = _load_notifications(username)
-        notifications.insert(0, notification)
-        _save_notifications(username, notifications[:200])
-
-
-def _create_notification(
-    recipient_username: str,
-    notification_type: str,
-    title: str,
-    body: str = "",
-    link: str = "",
-    actor=None,
-    metadata=None,
-):
-    now = datetime.now().isoformat()
-    notification = {
-        "id": uuid.uuid4().hex,
-        "type": notification_type,
-        "recipient_username": recipient_username,
-        "title": title,
-        "body": body,
-        "link": link,
-        "actor_username": actor.get("username") if actor else "",
-        "actor_name": (actor.get("name") or actor.get("username")) if actor else "",
-        "metadata": metadata or {},
-        "created_at": now,
-        "read_at": None,
-    }
-    _append_notification(recipient_username, notification)
-    return notification
-
-
-def _find_username_by_display_name(display_name):
-    if not display_name:
-        return None
-    for account in get_all_users():
-        if account.get("username") == display_name or account.get("name") == display_name:
-            return account.get("username")
-    return None
-
-
-@app.post("/page-comments/reply")
-async def reply_to_page_comment(request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("editor"))):
-    """Lisab lehekülje kommentaarile vastuse ja loob kommentaari autorile teavituse."""
-    data = await get_json_data(request)
-    catalog = os.path.basename(data.get('original_path', ''))
-    filename = os.path.basename(data.get('file_name', ''))
-    comment_id = str(data.get('comment_id', '')).strip()
-    reply_text = unicodedata.normalize('NFC', str(data.get('text', '')).strip())
-    work_id = str(data.get('work_id', '')).strip()
-    page_number = int(data.get('page_number') or 0)
-
-    if not catalog or not filename or not comment_id or not reply_text:
-        raise HTTPException(status_code=400, detail="Puudulikud vastuse andmed")
-
-    txt_path = os.path.join(BASE_DIR, catalog, filename)
-    json_path = os.path.join(BASE_DIR, catalog, os.path.splitext(filename)[0] + ".json")
-    if not os.path.exists(txt_path) or not os.path.exists(json_path):
-        raise HTTPException(status_code=404, detail="Lehekülje fail puudub")
-
-    with open(json_path, 'r', encoding='utf-8') as f:
-        meta_content = json.load(f)
-
-    comments = meta_content.get('comments')
-    if not isinstance(comments, list):
-        comments = []
-        meta_content['comments'] = comments
-
-    target_comment = None
-    for comment in comments:
-        if isinstance(comment, dict) and str(comment.get('id')) == comment_id:
-            target_comment = comment
-            break
-    if target_comment is None:
-        raise HTTPException(status_code=404, detail="Kommentaari ei leitud")
-
-    now = datetime.now().isoformat()
-    reply = {
-        "id": uuid.uuid4().hex,
-        "text": reply_text,
-        "author": user.get('name') or user['username'],
-        "author_username": user['username'],
-        "created_at": now,
-    }
-    replies = target_comment.get('replies')
-    if not isinstance(replies, list):
-        replies = []
-        target_comment['replies'] = replies
-    replies.append(reply)
-    meta_content['updated_at'] = now
-
-    with open(txt_path, 'r', encoding='utf-8') as f:
-        text_content = f.read()
-
-    git_result = save_with_git(
-        txt_path,
-        text_content,
-        user['username'],
-        message=f"Vasta kommentaarile: {os.path.relpath(json_path, BASE_DIR)}",
-        additional_files=[(json_path, json.dumps(meta_content, indent=2, ensure_ascii=False))]
-    )
-    background_tasks.add_task(sync_work_to_meilisearch_async, catalog)
-
-    recipient = target_comment.get('author_username') or _find_username_by_display_name(target_comment.get('author'))
-    if recipient and recipient != user['username']:
-        _create_notification(
-            recipient,
-            "comment_reply",
-            f"{user.get('name') or user['username']} vastas sinu kommentaarile",
-            reply_text[:180],
-            f"/work/{work_id or meta_content.get('work_id', '')}/{page_number}?comment={comment_id}",
-            actor=user,
-            metadata={
-                "work_id": work_id or meta_content.get('work_id', ''),
-                "page_number": page_number,
-                "comment_id": comment_id,
-                "reply_id": reply["id"],
-                "text_preview": reply_text[:180],
-            },
-        )
-
-    return {
-        "status": "success",
-        "comments": comments,
-        "reply": reply,
-        "commit_hash": git_result.get("commit_hash", "")[:8],
-    }
-
-
-@app.get("/notifications")
-async def get_notifications(request: Request, user=Depends(get_user)):
-    unread_only = request.query_params.get('unread') == 'true'
-    with _notifications_lock:
-        notifications = _load_notifications(user['username'])
-    if unread_only:
-        notifications = [n for n in notifications if not n.get('read_at')]
-    return {"status": "success", "notifications": notifications}
-
-
-@app.get("/notification-recipients")
-async def get_notification_recipients(user=Depends(require_role("editor"))):
-    users = [
-        {
-            "username": account.get("username"),
-            "name": account.get("name") or account.get("username"),
-            "role": account.get("role", "contributor"),
-        }
-        for account in get_all_users()
-        if account.get("username")
-    ]
-    users.sort(key=lambda account: (
-        0 if account.get("username") == "meelis" else 1,
-        (account.get("name") or account.get("username") or "").lower(),
-    ))
-    return {"status": "success", "users": users}
-
-
-@app.post("/notifications/send")
-async def send_notification(request: Request, user=Depends(require_role("editor"))):
-    data = await get_json_data(request)
-    recipient_mode = str(data.get("recipient_mode") or "single")
-    recipient_username = str(data.get("recipient_username") or "").strip()
-    recipient_usernames = data.get("recipient_usernames") or []
-    title = unicodedata.normalize("NFC", str(data.get("title") or "").strip())
-    body = unicodedata.normalize("NFC", str(data.get("body") or "").strip())
-    link = str(data.get("link") or "").strip()
-
-    if not title:
-        raise HTTPException(status_code=400, detail="Pealkiri on kohustuslik")
-    if len(title) > 160:
-        raise HTTPException(status_code=400, detail="Pealkiri on liiga pikk")
-    if len(body) > 2000:
-        raise HTTPException(status_code=400, detail="Sõnum on liiga pikk")
-    if link and not link.startswith("/"):
-        raise HTTPException(status_code=400, detail="Link peab olema rakenduse-sisene")
-
-    users_by_username = {
-        account.get("username"): account
-        for account in get_all_users()
-        if account.get("username")
-    }
-
-    if recipient_mode == "all":
-        if user.get("role") != "admin":
-            raise HTTPException(status_code=403, detail="Kõigile teavitamine on lubatud ainult administraatorile")
-        recipients = sorted(users_by_username.keys())
-        notification_type = "system"
-    elif recipient_mode == "admins":
-        recipients = sorted([
-            account.get("username")
-            for account in get_all_users()
-            if account.get("role") == "admin" and account.get("username")
-        ])
-        notification_type = "review_request"
-    elif recipient_mode == "multiple":
-        if not isinstance(recipient_usernames, list) or not recipient_usernames:
-            raise HTTPException(status_code=400, detail="Saajad on kohustuslikud")
-        recipients = [u for u in recipient_usernames if isinstance(u, str) and u in users_by_username]
-        if not recipients:
-            raise HTTPException(status_code=400, detail="Ühtegi kehtivat saajat ei leitud")
-        notification_type = "review_request"
-    else:
-        if not recipient_username or recipient_username not in users_by_username:
-            raise HTTPException(status_code=400, detail="Saajat ei leitud")
-        recipients = [recipient_username]
-        notification_type = "review_request"
-
-    created = [
-        _create_notification(
-            recipient,
-            notification_type,
-            title,
-            body,
-            link,
-            actor=user,
-            metadata={"sent_by_role": user.get("role", "")},
-        )
-        for recipient in recipients
-    ]
-    recipient_names = [
-        users_by_username[recipient].get("name") or recipient
-        for recipient in recipients
-        if recipient in users_by_username
-    ]
-    if user.get("username"):
-        _create_notification(
-            user["username"],
-            "sent_notification",
-            title,
-            body,
-            link,
-            actor=user,
-            metadata={
-                "sent_by_role": user.get("role", ""),
-                "recipient_mode": recipient_mode,
-                "recipient_usernames": recipients,
-                "recipient_names": recipient_names,
-                "delivered_count": len(created),
-            },
-        )
-    return {"status": "success", "created": len(created)}
-
-
-@app.post("/notifications/{notification_id}/read")
-async def mark_notification_read(notification_id: str, user=Depends(get_user)):
-    with _notifications_lock:
-        notifications = _load_notifications(user['username'])
-        now = datetime.now().isoformat()
-        for notification in notifications:
-            if notification.get('id') == notification_id:
-                notification['read_at'] = notification.get('read_at') or now
-                break
-        _save_notifications(user['username'], notifications)
-    return {"status": "success"}
 
 @app.post("/update-work-metadata")
 async def update_work_metadata(request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("admin"))):

--- a/server/notifications_ops.py
+++ b/server/notifications_ops.py
@@ -1,0 +1,136 @@
+"""
+Kasutajateavituste (notifications) äraloogika.
+
+Tõstetud ``server/main.py``-st refaktoreeringu Faas 1-s
+(``docs/REFACTOR_main_py_2026-06-25.md``). Domeen on täielikult iseseisev:
+teavitused salvestatakse iga kasutaja kohta eraldi JSON-faili
+(``state/notifications/{username}.json``), piiratud 200 uuema teatisega.
+
+Failipõhine salvestus (mitte andmebaas) on teadlik valik: teavitused on
+kasutaja-kohased, madala sagedusega ja peavad säilima üle serveri taaskäivituse.
+Lukustus (``_notifications_lock``, RLock) kaitseb samaaegseid kirjutusi.
+
+``server/routers/notifications.py`` kasutab neid funktsioone; ``main.py`` jätab
+backward-compat re-eksporti vanade ``_``-eelistatud nimedega (kuni kõik viited
+uuenevad).
+
+NB (tehniline võlg, märgitud): ``get_notifications_path`` tõstab ``HTTPException``
+sisendi valideerimisel. Ideaalis peaks ops-moodul olema HTTP-vaba (tõstma
+``ValueError``) ja endpoint teisendama selle. Praegu jäetud sellisena, et mitte
+muuta käitumist — eraldi cleanup.
+"""
+import os
+import json
+import uuid
+import threading
+from datetime import datetime
+
+from fastapi import HTTPException
+
+from .auth import get_all_users
+from .config import NOTIFICATIONS_DIR, get_logger
+from .utils import atomic_write_json
+
+logger = get_logger(__name__)
+
+# Lõimedevaheline lukk kaitseb samaaegseid kirjutusi sama kasutaja failile.
+# RLock lubab ümberkinnitust (nt create_notification → append_notification →
+# save_notification hoiab lukku kogu ahela vältel).
+_notifications_lock = threading.RLock()
+
+# Maksimaalne säilitatavate teatiste arv kasutaja kohta. Vanemad kärbitakse.
+MAX_NOTIFICATIONS = 200
+
+
+def safe_username(username: str) -> str:
+    """Piira teavituste failinimi lihtsa kasutajanime kujule.
+
+    Eemaldab path-eraldajad (basename) — kaitse path-traversali vastu,
+    et ``../etc/passwd``-stiilis kasutajanimi ei pääseks failisüsteemi.
+    """
+    return os.path.basename(username or "").strip()
+
+
+def get_notifications_path(username: str) -> str:
+    """Tagastab kasutaja teatiste faili tee.
+
+    Tõstab ``HTTPException(400)`` tühja/vigase kasutajanime korral.
+    """
+    safe = safe_username(username)
+    if not safe:
+        raise HTTPException(status_code=400, detail="Vigane kasutajanimi")
+    return os.path.join(NOTIFICATIONS_DIR, f"{safe}.json")
+
+
+def load_notifications(username: str) -> list:
+    """Laeb kasutaja teavitused. Tagastab ``[]`` kui faili pole või sisu on vigane."""
+    path = get_notifications_path(username)
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except Exception:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def save_notifications(username: str, notifications: list):
+    """Salvestab kasutaja teavitused (kirjutab üle). Loob kataloogi vajadusel."""
+    os.makedirs(NOTIFICATIONS_DIR, exist_ok=True)
+    atomic_write_json(get_notifications_path(username), notifications)
+
+
+def append_notification(username: str, notification: dict):
+    """Lisab uue teatise kasutajale (ette, uuemad ees) ja kärpib MAX_NOTIFICATIONS-ni."""
+    with _notifications_lock:
+        notifications = load_notifications(username)
+        notifications.insert(0, notification)
+        save_notifications(username, notifications[:MAX_NOTIFICATIONS])
+
+
+def create_notification(
+    recipient_username: str,
+    notification_type: str,
+    title: str,
+    body: str = "",
+    link: str = "",
+    actor=None,
+    metadata=None,
+):
+    """Loob ja salvestab ühe teatise. Tagastab loodud teatise dict-i.
+
+    ``actor`` on valikuline dict kasutaja kohta (``{"username", "name"}``) —
+    kasutatakse teatise ``actor_username`` ja ``actor_name`` väljade täitmiseks.
+    """
+    now = datetime.now().isoformat()
+    notification = {
+        "id": uuid.uuid4().hex,
+        "type": notification_type,
+        "recipient_username": recipient_username,
+        "title": title,
+        "body": body,
+        "link": link,
+        "actor_username": actor.get("username") if actor else "",
+        "actor_name": (actor.get("name") or actor.get("username")) if actor else "",
+        "metadata": metadata or {},
+        "created_at": now,
+        "read_at": None,
+    }
+    append_notification(recipient_username, notification)
+    return notification
+
+
+def find_username_by_display_name(display_name):
+    """Leiab kasutajanime kuvanime järgi (username VÕI name väli).
+
+    Kasutatakse ``/page-comments/reply`` juures: vanemad kommentaarid sisaldavad
+    vaid ``author`` (kuvanimi), mitte ``author_username``. Tagastab ``None`` kui
+    ei leita.
+    """
+    if not display_name:
+        return None
+    for account in get_all_users():
+        if account.get("username") == display_name or account.get("name") == display_name:
+            return account.get("username")
+    return None

--- a/server/notifications_ops.py
+++ b/server/notifications_ops.py
@@ -63,7 +63,16 @@ def get_notifications_path(username: str) -> str:
 
 
 def load_notifications(username: str) -> list:
-    """Laeb kasutaja teavitused. Tagastab ``[]`` kui faili pole või sisu on vigane."""
+    """Laeb kasutaja teavitused. Tagastab ``[]`` kui faili pole või sisu on vigane.
+
+    NB (teadlik resilience-paranus, mitte puhas tõstmine main.py-st): algne
+    ``_load_notifications`` ei pakkunud ``json.load`` ümber try/except-i —
+    korrumpeerunud teavituste-fail andis käsitlemata erindi → HTTP 500. Siin
+    neelatakse see ja tagastatakse ``[]``: ühe kasutaja katkine teatistefail
+    ei tohi lammutada kogu teavituste funktsionaalsust (GET /notifications,
+    teatiste saatmine). Kaetud testiga
+    ``test_load_notifications_returns_empty_for_corrupt_json``.
+    """
     path = get_notifications_path(username)
     if not os.path.exists(path):
         return []

--- a/server/routers/notifications.py
+++ b/server/routers/notifications.py
@@ -1,0 +1,272 @@
+"""
+Teavituste (notifications) FastAPI router.
+
+Tõstetud ``server/main.py``-st refaktoreeringu Faas 1-s
+(``docs/REFACTOR_main_py_2026-06-25.md``). Äraloogika elab ``server/notifications_ops.py``-s;
+siin on õhukesed endpoint'id, mis kasutavad ühiseid dependency'sid (``server/deps.py``).
+
+Endpoint'id:
+- ``POST /page-comments/reply`` — lisab kommentaarile vastuse (git commit + meilisearch
+  sync) JA loob kommentaari autorile teatise. NB: cross-domain endpoint — puudutab
+  comments/git/meilisearch/notifications domeene. Viidud siia, sest peamine "ära" on
+  teatise loomine; kui kommentaaride domeen hiljem eraldatakse, saab selle ümber paigutada.
+- ``GET /notifications`` — kasutaja enda teavitused (valikuline ?unread=true filter)
+- ``GET /notification-recipients`` — kasutajate nimekiri teatise saatmiseks (editor+)
+- ``POST /notifications/send`` — saada teatis (single/multiple/admins/all) — editor+,
+  ``all`` režiim nõuab admin-i
+- ``POST /notifications/{notification_id}/read`` — märgi teatis loetuks
+"""
+import os
+import json
+import unicodedata
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Depends
+
+from ..config import BASE_DIR
+from ..deps import get_user, require_role, get_json_data
+from ..auth import get_all_users
+from ..git_ops import save_with_git
+from ..meilisearch_ops import sync_work_to_meilisearch_async
+from ..notifications_ops import (
+    load_notifications,
+    save_notifications,
+    create_notification,
+    find_username_by_display_name,
+    _notifications_lock,
+)
+
+router = APIRouter()
+
+
+@router.post("/page-comments/reply")
+async def reply_to_page_comment(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    user=Depends(require_role("editor")),
+):
+    """Lisab lehekülje kommentaarile vastuse ja loob kommentaari autorile teavituse."""
+    data = await get_json_data(request)
+    catalog = os.path.basename(data.get('original_path', ''))
+    filename = os.path.basename(data.get('file_name', ''))
+    comment_id = str(data.get('comment_id', '')).strip()
+    reply_text = unicodedata.normalize('NFC', str(data.get('text', '')).strip())
+    work_id = str(data.get('work_id', '')).strip()
+    page_number = int(data.get('page_number') or 0)
+
+    if not catalog or not filename or not comment_id or not reply_text:
+        raise HTTPException(status_code=400, detail="Puudulikud vastuse andmed")
+
+    txt_path = os.path.join(BASE_DIR, catalog, filename)
+    json_path = os.path.join(BASE_DIR, catalog, os.path.splitext(filename)[0] + ".json")
+    if not os.path.exists(txt_path) or not os.path.exists(json_path):
+        raise HTTPException(status_code=404, detail="Lehekülje fail puudub")
+
+    with open(json_path, 'r', encoding='utf-8') as f:
+        meta_content = json.load(f)
+
+    comments = meta_content.get('comments')
+    if not isinstance(comments, list):
+        comments = []
+        meta_content['comments'] = comments
+
+    target_comment = None
+    for comment in comments:
+        if isinstance(comment, dict) and str(comment.get('id')) == comment_id:
+            target_comment = comment
+            break
+    if target_comment is None:
+        raise HTTPException(status_code=404, detail="Kommentaari ei leitud")
+
+    now = datetime.now().isoformat()
+    reply = {
+        "id": uuid.uuid4().hex,
+        "text": reply_text,
+        "author": user.get('name') or user['username'],
+        "author_username": user['username'],
+        "created_at": now,
+    }
+    replies = target_comment.get('replies')
+    if not isinstance(replies, list):
+        replies = []
+        target_comment['replies'] = replies
+    replies.append(reply)
+    meta_content['updated_at'] = now
+
+    with open(txt_path, 'r', encoding='utf-8') as f:
+        text_content = f.read()
+
+    git_result = save_with_git(
+        txt_path,
+        text_content,
+        user['username'],
+        message=f"Vasta kommentaarile: {os.path.relpath(json_path, BASE_DIR)}",
+        additional_files=[(json_path, json.dumps(meta_content, indent=2, ensure_ascii=False))]
+    )
+    background_tasks.add_task(sync_work_to_meilisearch_async, catalog)
+
+    recipient = target_comment.get('author_username') or find_username_by_display_name(target_comment.get('author'))
+    if recipient and recipient != user['username']:
+        create_notification(
+            recipient,
+            "comment_reply",
+            f"{user.get('name') or user['username']} vastas sinu kommentaarile",
+            reply_text[:180],
+            f"/work/{work_id or meta_content.get('work_id', '')}/{page_number}?comment={comment_id}",
+            actor=user,
+            metadata={
+                "work_id": work_id or meta_content.get('work_id', ''),
+                "page_number": page_number,
+                "comment_id": comment_id,
+                "reply_id": reply["id"],
+                "text_preview": reply_text[:180],
+            },
+        )
+
+    return {
+        "status": "success",
+        "comments": comments,
+        "reply": reply,
+        "commit_hash": git_result.get("commit_hash", "")[:8],
+    }
+
+
+@router.get("/notifications")
+async def get_notifications(request: Request, user=Depends(get_user)):
+    """Kasutaja enda teavitused. ``?unread=true`` filtreerib loetud teatised välja."""
+    unread_only = request.query_params.get('unread') == 'true'
+    with _notifications_lock:
+        notifications = load_notifications(user['username'])
+    if unread_only:
+        notifications = [n for n in notifications if not n.get('read_at')]
+    return {"status": "success", "notifications": notifications}
+
+
+@router.get("/notification-recipients")
+async def get_notification_recipients(user=Depends(require_role("editor"))):
+    """Kasutajate nimekiri teatise saatmise UI jaoks (editor+)."""
+    users = [
+        {
+            "username": account.get("username"),
+            "name": account.get("name") or account.get("username"),
+            "role": account.get("role", "contributor"),
+        }
+        for account in get_all_users()
+        if account.get("username")
+    ]
+    users.sort(key=lambda account: (
+        0 if account.get("username") == "meelis" else 1,
+        (account.get("name") or account.get("username") or "").lower(),
+    ))
+    return {"status": "success", "users": users}
+
+
+@router.post("/notifications/send")
+async def send_notification(request: Request, user=Depends(require_role("editor"))):
+    """Saada teatis ühele, mitmele, kõikidele admin-idele või kõigile.
+
+    ``recipient_mode``:
+    - ``single`` (vaikimisi): üks ``recipient_username``
+    - ``multiple``: ``recipient_usernames`` list
+    - ``admins``: kõik admin rolliga kasutajad
+    - ``all``: kõik kasutajad (NB: nõuab admin rolli)
+
+    Saatja saab alati koopia (``sent_notification`` tüüp) oma saadetud sõnumi kohta.
+    """
+    data = await get_json_data(request)
+    recipient_mode = str(data.get("recipient_mode") or "single")
+    recipient_username = str(data.get("recipient_username") or "").strip()
+    recipient_usernames = data.get("recipient_usernames") or []
+    title = unicodedata.normalize("NFC", str(data.get("title") or "").strip())
+    body = unicodedata.normalize("NFC", str(data.get("body") or "").strip())
+    link = str(data.get("link") or "").strip()
+
+    if not title:
+        raise HTTPException(status_code=400, detail="Pealkiri on kohustuslik")
+    if len(title) > 160:
+        raise HTTPException(status_code=400, detail="Pealkiri on liiga pikk")
+    if len(body) > 2000:
+        raise HTTPException(status_code=400, detail="Sõnum on liiga pikk")
+    if link and not link.startswith("/"):
+        raise HTTPException(status_code=400, detail="Link peab olema rakenduse-sisene")
+
+    users_by_username = {
+        account.get("username"): account
+        for account in get_all_users()
+        if account.get("username")
+    }
+
+    if recipient_mode == "all":
+        if user.get("role") != "admin":
+            raise HTTPException(status_code=403, detail="Kõigile teavitamine on lubatud ainult administraatorile")
+        recipients = sorted(users_by_username.keys())
+        notification_type = "system"
+    elif recipient_mode == "admins":
+        recipients = sorted([
+            account.get("username")
+            for account in get_all_users()
+            if account.get("role") == "admin" and account.get("username")
+        ])
+        notification_type = "review_request"
+    elif recipient_mode == "multiple":
+        if not isinstance(recipient_usernames, list) or not recipient_usernames:
+            raise HTTPException(status_code=400, detail="Saajad on kohustuslikud")
+        recipients = [u for u in recipient_usernames if isinstance(u, str) and u in users_by_username]
+        if not recipients:
+            raise HTTPException(status_code=400, detail="Ühtegi kehtivat saajat ei leitud")
+        notification_type = "review_request"
+    else:
+        if not recipient_username or recipient_username not in users_by_username:
+            raise HTTPException(status_code=400, detail="Saajat ei leitud")
+        recipients = [recipient_username]
+        notification_type = "review_request"
+
+    created = [
+        create_notification(
+            recipient,
+            notification_type,
+            title,
+            body,
+            link,
+            actor=user,
+            metadata={"sent_by_role": user.get("role", "")},
+        )
+        for recipient in recipients
+    ]
+    recipient_names = [
+        users_by_username[recipient].get("name") or recipient
+        for recipient in recipients
+        if recipient in users_by_username
+    ]
+    if user.get("username"):
+        create_notification(
+            user["username"],
+            "sent_notification",
+            title,
+            body,
+            link,
+            actor=user,
+            metadata={
+                "sent_by_role": user.get("role", ""),
+                "recipient_mode": recipient_mode,
+                "recipient_usernames": recipients,
+                "recipient_names": recipient_names,
+                "delivered_count": len(created),
+            },
+        )
+    return {"status": "success", "created": len(created)}
+
+
+@router.post("/notifications/{notification_id}/read")
+async def mark_notification_read(notification_id: str, user=Depends(get_user)):
+    """Märgib teatise loetuks (idempotentne: juba loetud teatis jääb loetuks)."""
+    with _notifications_lock:
+        notifications = load_notifications(user['username'])
+        now = datetime.now().isoformat()
+        for notification in notifications:
+            if notification.get('id') == notification_id:
+                notification['read_at'] = notification.get('read_at') or now
+                break
+        save_notifications(user['username'], notifications)
+    return {"status": "success"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,8 @@ def backend_env(tmp_path, monkeypatch):
     state_dir.mkdir()
     user_settings_dir = state_dir / "user_settings"
     user_settings_dir.mkdir()
+    notifications_dir = state_dir / "notifications"
+    notifications_dir.mkdir()
     uploads_dir = tmp_path / "uploads"
     uploads_dir.mkdir()
 
@@ -108,8 +110,9 @@ def backend_env(tmp_path, monkeypatch):
             "COLLECTIONS_FILE": str(collections_file),
             "ARCHIVES_FILE": str(archives_file),
             "USER_SETTINGS_DIR": str(user_settings_dir),
+            "NOTIFICATIONS_DIR": str(notifications_dir),
         },
-        modules=["server.main"],
+        modules=["server.main", "server.notifications_ops"],
     )
     _patch_config_const(
         monkeypatch,
@@ -140,6 +143,7 @@ def backend_env(tmp_path, monkeypatch):
             "collections_file": collections_file,
             "archives_file": archives_file,
             "user_settings_dir": user_settings_dir,
+            "notifications_dir": notifications_dir,
             "uploads_dir": uploads_dir,
             "upload_ops": upload_ops,
         }

--- a/tests/test_notifications_endpoints.py
+++ b/tests/test_notifications_endpoints.py
@@ -1,0 +1,316 @@
+"""
+Testid server/routers/notifications.py endpointidele (Faas 1 refaktoreering).
+
+Domeen oli enne refaktoreeringut täiesti testita (0 testi). Need testid katavad
+HTTP tasandi autoriseerimist ja sisendi valideerimist läbi FastAPI TestClient-i.
+
+Kaetud endpoint'id:
+- GET /notifications — enda teatised, ?unread=true filter, autoriseerimine
+- GET /notification-recipients — editor+ õigus, kasutajate nimekiri
+- POST /notifications/send — single/multiple/admins/all režiimid, valideerimine,
+  admin-õiguse kontroll "all" režiimil, saatja koopia
+- POST /notifications/{id}/read — märgi loetuks, idempotentsus
+
+NB: /page-comments/reply on siin katmata — see on cross-domain endpoint (git +
+meilisearch) ja vajaks lehe failide setup-i. Selle tuumloogika (notificationi
+loomine kommentaari autorile) on kaetud test_notifications_ops.py kaudu
+(create_notification + find_username_by_display_name).
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# GET /notifications
+# ---------------------------------------------------------------------------
+
+def test_get_notifications_returns_empty_for_new_user(client, login):
+    """Sisselogitud kasutaja, kel teatisi pole → tühi list."""
+    token = login("editor", "editorpass")
+    resp = client.get("/notifications", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert data["notifications"] == []
+
+
+def test_get_notifications_requires_auth(client):
+    """Ilma tokenita → 401."""
+    resp = client.get("/notifications")
+    assert resp.status_code == 401
+
+
+def test_get_notifications_returns_user_notifications(client, login, backend_env):
+    """Saadetud teatised on nähtavad saajale."""
+    from server.notifications_ops import create_notification
+    create_notification("editor", "system", "Tere editor", "Sisu")
+    create_notification("editor", "review_request", "Teine", "Sisu2")
+
+    token = login("editor", "editorpass")
+    resp = client.get("/notifications", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    notifs = resp.json()["notifications"]
+    assert len(notifs) == 2
+    # Uuem ees
+    assert notifs[0]["title"] == "Teine"
+
+
+def test_get_notifications_unread_filter(client, login, backend_env):
+    """?unread=true filtreerib loetud teatised välja."""
+    from server.notifications_ops import create_notification
+    create_notification("editor", "system", "Lugemata", "Sisu")
+    create_notification("editor", "system", "Loetud", "Sisu")
+    # Märgi teine loetuks otse ops kaudu
+    from server.notifications_ops import load_notifications, save_notifications
+    notifs = load_notifications("editor")
+    notifs[0]["read_at"] = "2026-01-01T00:00:00"
+    save_notifications("editor", notifs)
+
+    token = login("editor", "editorpass")
+    resp = client.get("/notifications?unread=true", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    notifs = resp.json()["notifications"]
+    assert len(notifs) == 1
+    assert notifs[0]["title"] == "Lugemata"
+
+
+def test_get_notifications_isolated_per_user(client, login, backend_env):
+    """Kasutaja näeb ainult enda teatisi, mitte teiste omi."""
+    from server.notifications_ops import create_notification
+    create_notification("admin", "system", "Admini teatis", "Sisu")
+    create_notification("editor", "system", "Editori teatis", "Sisu")
+
+    token = login("editor", "editorpass")
+    resp = client.get("/notifications", headers={"Authorization": f"Bearer {token}"})
+    notifs = resp.json()["notifications"]
+    assert len(notifs) == 1
+    assert notifs[0]["title"] == "Editori teatis"
+
+
+# ---------------------------------------------------------------------------
+# GET /notification-recipients
+# ---------------------------------------------------------------------------
+
+def test_notification_recipients_requires_editor(client, login):
+    """editor ja admin saavad ligi; contributor (puudub siin setupis) ei saaks."""
+    token = login("editor", "editorpass")
+    resp = client.get("/notification-recipients", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    users = resp.json()["users"]
+    usernames = [u["username"] for u in users]
+    assert "admin" in usernames
+    assert "editor" in usernames
+
+
+def test_notification_recipients_requires_auth(client):
+    resp = client.get("/notification-recipients")
+    assert resp.status_code == 401
+
+
+def test_notification_recipients_structure(client, login):
+    """Iga kasutaja kirje sisaldab username, name, role välju."""
+    token = login("editor", "editorpass")
+    resp = client.get("/notification-recipients", headers={"Authorization": f"Bearer {token}"})
+    users = resp.json()["users"]
+    for u in users:
+        assert "username" in u
+        assert "name" in u
+        assert "role" in u
+
+
+# ---------------------------------------------------------------------------
+# POST /notifications/send
+# ---------------------------------------------------------------------------
+
+def test_send_notification_single(client, login):
+    """single režiim: üks saaja → 1 loodud teatis + saatja koopia."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_mode": "single",
+        "recipient_username": "admin",
+        "title": "Tere admin",
+        "body": "Sõnumi sisu",
+        "link": "/work/test/1",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["created"] == 1
+
+
+def test_send_notification_requires_title(client, login):
+    """Pealkiri kohustuslik → 400 kui puudub."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_username": "admin",
+        "body": "Sisu",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 400
+    assert "Pealkiri" in resp.json()["detail"]
+
+
+def test_send_notification_rejects_external_link(client, login):
+    """Link peab algama '/' (rakenduse-sisene) — XSS/redirect kaitse."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_username": "admin",
+        "title": "X",
+        "link": "https://evil.com",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 400
+    assert "rakenduse-sisene" in resp.json()["detail"]
+
+
+def test_send_notification_rejects_too_long_title(client, login):
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_username": "admin",
+        "title": "x" * 161,
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 400
+
+
+def test_send_notification_unknown_recipient(client, login):
+    """single režiim tundmatu saajaga → 400."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_username": "olematu-kasutaja",
+        "title": "X",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 400
+
+
+def test_send_notification_multiple(client, login):
+    """multiple režiim: mitu saajat → loodud arv = saajate arv."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_mode": "multiple",
+        "recipient_usernames": ["admin", "editor"],
+        "title": "Kõigile testijatele",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["created"] == 2
+
+
+def test_send_notification_multiple_filters_invalid(client, login):
+    """multiple režiim: tundmatud kasutajanimed filtreeritakse välja."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_mode": "multiple",
+        "recipient_usernames": ["admin", "olematu1", "olematu2"],
+        "title": "X",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["created"] == 1  # ainult admin
+
+
+def test_send_notification_multiple_empty_rejected(client, login):
+    """multiple režiim tühja nimekirjaga → 400 (ükski kehtiv saaja)."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_mode": "multiple",
+        "recipient_usernames": ["olematu1", "olematu2"],
+        "title": "X",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 400
+
+
+def test_send_notification_admins_mode(client, login):
+    """admins režiim: ainult admin rolliga kasutajad saavad."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_mode": "admins",
+        "title": "Adminidele",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["created"] == 1  # ainult admin
+
+
+def test_send_notification_all_mode_requires_admin(client, login):
+    """all režiim nõuab admin-i; editor saab 403."""
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_mode": "all",
+        "title": "Kõigile",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+    assert "administraatorile" in resp.json()["detail"]
+
+
+def test_send_notification_all_mode_admin_ok(client, login):
+    """all režiim admin-iga → kõik kasutajad saavad (admin + editor = 2)."""
+    token = login("admin", "adminpass")
+    resp = client.post("/notifications/send", json={
+        "recipient_mode": "all",
+        "title": "Kõigile",
+    }, headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json()["created"] == 2
+
+
+def test_send_notification_sender_gets_copy(client, login, backend_env):
+    """Saatja saab alati 'sent_notification' koopia oma saadetud sõnumi kohta."""
+    from server.notifications_ops import load_notifications
+    token = login("editor", "editorpass")
+    client.post("/notifications/send", json={
+        "recipient_username": "admin",
+        "title": "Kopeeritav",
+    }, headers={"Authorization": f"Bearer {token}"})
+
+    editor_notifs = load_notifications("editor")
+    sent_copies = [n for n in editor_notifs if n["type"] == "sent_notification"]
+    assert len(sent_copies) == 1
+    assert sent_copies[0]["metadata"]["recipient_mode"] == "single"
+
+
+def test_send_notification_requires_editor(client, login):
+    # login fixture tagastab tokeni; siin pole contributor kontot, aga testime
+    # et 401 ilma autendita
+    resp = client.post("/notifications/send", json={"title": "X", "recipient_username": "admin"})
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /notifications/{notification_id}/read
+# ---------------------------------------------------------------------------
+
+def test_mark_notification_read(client, login, backend_env):
+    from server.notifications_ops import create_notification, load_notifications
+    notif = create_notification("editor", "system", "Lugemata", "Sisu")
+
+    token = login("editor", "editorpass")
+    resp = client.post(f"/notifications/{notif['id']}/read",
+                       headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+    loaded = load_notifications("editor")
+    assert loaded[0]["read_at"] is not None
+
+
+def test_mark_notification_read_is_idempotent(client, login, backend_env):
+    """Juba loetud teatise märkimine ei muuda read_at ajatemplit (idempotentne)."""
+    from server.notifications_ops import create_notification, load_notifications
+    notif = create_notification("editor", "system", "X", "Sisu")
+
+    token = login("editor", "editorpass")
+    client.post(f"/notifications/{notif['id']}/read", headers={"Authorization": f"Bearer {token}"})
+    first_read_at = load_notifications("editor")[0]["read_at"]
+
+    client.post(f"/notifications/{notif['id']}/read", headers={"Authorization": f"Bearer {token}"})
+    second_read_at = load_notifications("editor")[0]["read_at"]
+    assert first_read_at == second_read_at  # ei muutunud
+
+
+def test_mark_notification_read_unknown_id_is_noop(client, login, backend_env):
+    """Tundmatu ID-ga teatise märkimine on no-op (ei viska 404), aga ei muuda midagi."""
+    from server.notifications_ops import create_notification, load_notifications
+    create_notification("editor", "system", "Reaalne", "Sisu")
+
+    token = login("editor", "editorpass")
+    resp = client.post("/notifications/tundmatu-id/read",
+                       headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    # Reaalne teatis jäi lugemata
+    assert load_notifications("editor")[0]["read_at"] is None
+
+
+def test_mark_notification_read_requires_auth(client):
+    resp = client.post("/notifications/misiganes/read")
+    assert resp.status_code == 401

--- a/tests/test_notifications_ops.py
+++ b/tests/test_notifications_ops.py
@@ -1,0 +1,224 @@
+"""
+Testid server/notifications_ops.py äraloogikale (Faas 1 refaktoreering).
+
+Domeen oli enne refaktoreeringut täiesti testita (0 testi). Need ühiktestid
+katavad failipõhise teatiste salvestuse tuumloogikat sõltumatult HTTP-st.
+
+Kaetud käitumine:
+- get_notifications_path: path-traversali kaitse (basename), tühi nimi → 400
+- load/save_notifications: round-trip, puuduv fail → [], korrumpeerunud → []
+- append_notification: uuemad ees, kärpimine MAX_NOTIFICATIONS piirini
+- create_notification: genereerib id/ajatempli, täidab actor väljad
+- find_username_by_display_name: otsib username JA name väljalt
+"""
+import json
+import pytest
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# get_notifications_path / safe_username
+# ---------------------------------------------------------------------------
+
+def test_safe_username_strips_path_separators(backend_env):
+    """Path-traversali kaitse: '../etc/passwd' → 'passwd' (basename)."""
+    from server.notifications_ops import safe_username
+    assert safe_username("../etc/passwd") == "passwd"
+    assert safe_username("admin") == "admin"
+    assert safe_username("  spaced  ") == "spaced"
+    assert safe_username(None) == ""
+    assert safe_username("") == ""
+
+
+def test_get_notifications_path_rejects_empty_username(backend_env):
+    """Tühi kasutajanimi → HTTPException 400 (sisendivalideerimine)."""
+    from server.notifications_ops import get_notifications_path
+    with pytest.raises(HTTPException) as exc:
+        get_notifications_path("")
+    assert exc.value.status_code == 400
+    with pytest.raises(HTTPException):
+        get_notifications_path("   ")  # ainult tühikud → safe_username → ""
+
+
+def test_get_notifications_path_points_to_notifications_dir(backend_env):
+    from server.notifications_ops import get_notifications_path
+    path = get_notifications_path("editor")
+    assert path.endswith("notifications/editor.json")
+    # Peab langema kokku conftesti notifications_dir-iga
+    assert str(backend_env["notifications_dir"]) in path
+
+
+# ---------------------------------------------------------------------------
+# load / save notifications round-trip
+# ---------------------------------------------------------------------------
+
+def test_load_notifications_returns_empty_for_missing_user(backend_env):
+    """Kasutaja, kel teatisi pole → [] (mitte None või erind)."""
+    from server.notifications_ops import load_notifications
+    assert load_notifications("uus-kasutaja") == []
+
+
+def test_save_then_load_roundtrip(backend_env):
+    from server.notifications_ops import save_notifications, load_notifications
+    notifs = [{"id": "1", "title": "Tere"}, {"id": "2", "title": "Hüvasti"}]
+    save_notifications("editor", notifs)
+    assert load_notifications("editor") == notifs
+
+
+def test_load_notifications_returns_empty_for_corrupt_json(backend_env):
+    """Korrumpeerunud JSON → [] (mitte erind). Kaitse brute'liku failikorruptsiooni eest."""
+    from server.notifications_ops import load_notifications, get_notifications_path
+    path = get_notifications_path("corrupt")
+    with open(path, "w") as f:
+        f.write("{ see pole json :::")
+    assert load_notifications("corrupt") == []
+
+
+def test_load_notifications_returns_empty_for_non_list_json(backend_env):
+    """Kui fail sisaldab dict-i (mitte list-i) → [] (tüüpide valideerimine)."""
+    from server.notifications_ops import load_notifications, save_notifications
+    save_notifications("dictuser", {"not": "a list"})  # kirjutab dict-i
+    assert load_notifications("dictuser") == []
+
+
+def test_save_notifications_creates_dir(backend_env, tmp_path):
+    """Kui NOTIFICATIONS_DIR-i pole, save_notifications loob selle."""
+    from server import main as main_mod
+    from server.notifications_ops import save_notifications
+    import server.notifications_ops as ops
+
+    # Kasuta täiesti uut tmp kataloogi
+    new_dir = tmp_path / "fresh-notifs"
+    assert not new_dir.exists()
+    monkeypatch_dir = str(new_dir)
+    # Patch otse ops moodulis (conftest on juba patchinud main-i; siin näitame
+    # et save_notifications kasutab ops.NOTIFICATIONS_DIR-i)
+    original = ops.NOTIFICATIONS_DIR
+    ops.NOTIFICATIONS_DIR = monkeypatch_dir
+    try:
+        save_notifications("someone", [{"id": "x"}])
+        assert new_dir.exists()
+        assert (new_dir / "someone.json").exists()
+    finally:
+        ops.NOTIFICATIONS_DIR = original
+
+
+# ---------------------------------------------------------------------------
+# append_notification — järjekord ja kärpimine
+# ---------------------------------------------------------------------------
+
+def test_append_notification_newest_first(backend_env):
+    """Uued teatised lisatakse ette (indeks 0) — uuemad ees."""
+    from server.notifications_ops import append_notification, load_notifications
+    append_notification("editor", {"id": "1", "title": "Esimene"})
+    append_notification("editor", {"id": "2", "title": "Teine"})
+    notifs = load_notifications("editor")
+    assert notifs[0]["id"] == "2"  # uuem ees
+    assert notifs[1]["id"] == "1"
+
+
+def test_append_notification_trims_to_max(backend_env):
+    """Kasutaja fail ei kasva lõpmatuks — vanemad kärbitakse MAX_NOTIFICATIONS-ni."""
+    from server.notifications_ops import append_notification, load_notifications, MAX_NOTIFICATIONS
+    for i in range(MAX_NOTIFICATIONS + 50):
+        append_notification("editor", {"id": str(i)})
+    notifs = load_notifications("editor")
+    assert len(notifs) == MAX_NOTIFICATIONS
+    # Viimati lisatud (MAX+49) peab olema eesotsas
+    assert notifs[0]["id"] == str(MAX_NOTIFICATIONS + 49)
+
+
+# ---------------------------------------------------------------------------
+# create_notification — struktuuri genereerimine
+# ---------------------------------------------------------------------------
+
+def test_create_notification_generates_id_and_timestamp(backend_env):
+    from server.notifications_ops import create_notification, load_notifications
+    notif = create_notification("editor", "system", "Testpealkiri", "Testsisu")
+    assert "id" in notif and len(notif["id"]) > 0
+    assert "created_at" in notif
+    assert notif["read_at"] is None
+    assert notif["type"] == "system"
+    assert notif["title"] == "Testpealkiri"
+    # Peab olema salvestatud
+    loaded = load_notifications("editor")
+    assert loaded[0]["id"] == notif["id"]
+
+
+def test_create_notification_fills_actor_fields(backend_env):
+    """actor dict täidab actor_username ja actor_name väljad."""
+    from server.notifications_ops import create_notification
+    actor = {"username": "admin", "name": "Admin Kasutaja"}
+    notif = create_notification("editor", "review_request", "X", actor=actor)
+    assert notif["actor_username"] == "admin"
+    assert notif["actor_name"] == "Admin Kasutaja"
+
+
+def test_create_notification_actor_falls_back_to_username(backend_env):
+    """Kui actor.name puudub, kasutatakse actor.username-i actor_name väljal."""
+    from server.notifications_ops import create_notification
+    notif = create_notification("editor", "review_request", "X", actor={"username": "admin"})
+    assert notif["actor_name"] == "admin"
+
+
+def test_create_notification_without_actor(backend_env):
+    """actor=None → tühjad actor väljad (mitte None väärtused)."""
+    from server.notifications_ops import create_notification
+    notif = create_notification("editor", "system", "X", actor=None)
+    assert notif["actor_username"] == ""
+    assert notif["actor_name"] == ""
+
+
+def test_create_notification_metadata_defaults_empty(backend_env):
+    """metadata=None → {} (mitte None)."""
+    from server.notifications_ops import create_notification
+    notif = create_notification("editor", "system", "X", metadata=None)
+    assert notif["metadata"] == {}
+
+
+# ---------------------------------------------------------------------------
+# find_username_by_display_name
+# ---------------------------------------------------------------------------
+
+def test_find_username_by_display_name_matches_username(backend_env):
+    from server.notifications_ops import find_username_by_display_name
+    # conftest loob kasutajad: admin (name "Admin User"), editor (name "Editor User")
+    assert find_username_by_display_name("admin") == "admin"
+    assert find_username_by_display_name("editor") == "editor"
+
+
+def test_find_username_by_display_name_matches_name(backend_env):
+    """Legacy kommentaarid sisaldavad vaid kuvanime (name), mitte username-i."""
+    from server.notifications_ops import find_username_by_display_name
+    assert find_username_by_display_name("Admin User") == "admin"
+    assert find_username_by_display_name("Editor User") == "editor"
+
+
+def test_find_username_by_display_name_returns_none_for_unknown(backend_env):
+    from server.notifications_ops import find_username_by_display_name
+    assert find_username_by_display_name("olematu") is None
+    assert find_username_by_display_name("") is None
+    assert find_username_by_display_name(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat re-eksport main.py-st
+# ---------------------------------------------------------------------------
+
+def test_main_re_exports_notification_helpers():
+    """main.py backward-compat re-eksport: vanad _-nimed peavad jääma ligipääsetavaks.
+
+    Kaitseb regressiooni: kui mõni main.py endpoint või test veel impordib
+    _create_notification vms server.main-st, peab see töötama.
+    """
+    import server.main as main
+    assert callable(main._create_notification)
+    assert callable(main._load_notifications)
+    assert callable(main._save_notifications)
+    assert callable(main._append_notification)
+    assert callable(main._safe_username)
+    assert callable(main._get_notifications_path)
+    assert callable(main._find_username_by_display_name)
+    # _notifications_lock peab olema ops mooduli sama objekt
+    import server.notifications_ops as ops
+    assert main._notifications_lock is ops._notifications_lock


### PR DESCRIPTION
Closes #39 (Faas 1 / katus-issue #36).

## Kontekst

`server/main.py` refaktoreeringu **Faas 1 — notifications (teavitused)**. Tõstab notifications domeeni täielikult eraldi moodulitesse, järgides Faasis 0 (#37) loodud vundamenti. See on kõige iseseisvam domeen (5 endpointi + 8 abifunktsiooni + RLock) — ideaalne esimene endpointide tõstmine.

Täielik plaan: `docs/REFACTOR_main_py_2026-06-25.md`.

## Muudatused

### Uued moodulid
- **`server/notifications_ops.py`** — äraloogika (`load/save/append/create_notification`, `find_username_by_display_name`, `safe_username`, `get_notifications_path`). Failipõhine salvestus `state/notifications/{username}.json`, RLock kaitseb samaaegseid kirjutusi, `MAX_NOTIFICATIONS=200` kärpimine. Avalikud nimed (ilma `_` eeliseta).
- **`server/routers/notifications.py`** — 5 endpointi (APIRouter). Kasutavad `server/deps.py` ühiseid auth-dependency'sid (Faas 0).

### main.py
- Eemaldatud 8 abifunktsiooni + 5 endpointi (**−286 rida**)
- `app.include_router(notifications_router)`
- Backward-compat re-eksport vanade `_`-nimedega
- Eemaldatud surnud `NOTIFICATIONS_DIR` import

### tests/conftest.py
- `NOTIFICATIONS_DIR` patch lisatud (uus tmp kataloog). **Varsti ei olnud seda patchitud** — notifications testid oleksid kirjutanud päris state kausta.
- `_patch_config_const` moodulite loetelu (`["server.main", "server.notifications_ops"]`) on **otsiruum**: helper patchib vaid mooduleid, mis konstandi tegelikult omavad (vähemalt üks peab olema — turvavõrk vaikse testi-katkemise vastu). Selles faasis `server.main` enam `NOTIFICATIONS_DIR`-i ei oma (import eemaldati), seega patchitakse ainult `server.notifications_ops`. See ongi ootuspärane ja idiomaatiline — just refaktoreeringu eesmärk (konstandi allikas on nüüd ühes kohas).

## Teadlik resilience-paranus (MITTE puhas struktuuriline tõstmine)

Üks erand "käitumine muutmata" põhimõttest (review tagasiside põhjal dokumenteeritud):

`load_notifications` lisas `try/except` `json.load` ümber, mida algne `_load_notifications` **polnud**. Algne andis korrumpeerunud teavituste-faili korral käsitlemata erindi → **HTTP 500**. Siin neelatakse see ja tagastatakse `[]`: ühe kasutaja katkine teatistefail ei tohi lammutada kogu teavituste funktsionaalsust. Kaetud testiga `test_load_notifications_returns_empty_for_corrupt_json`. Kood on teadlikult muudetud (parandus, mitte regressioon); dokumenteeritud `notifications_ops.py` docstring-is.

Kõik muud osad on puhas struktuuriline refaktoreering.

## Testikate (peamine võit — domeen oli 0 testi)

**Domeen oli enne refaktoreeringut täiesti testita.** See faas lisab 44 testi:

- **`test_notifications_ops.py` (19)**: path-traversali kaitse (`../etc/passwd` → `passwd`), round-trip, korrumpeerunud JSON → `[]`, `MAX_NOTIFICATIONS` kärpimine, actors väljade täitmine, backward-compat re-eksport.
- **`test_notifications_endpoints.py` (25)**: autoriseerimine (401 ilma tokenita), `?unread=true` filter, kasutajatevaheline isoleeritus, kõik 4 `recipient_mode` (single/multiple/admins/all), `all` → admin õigus (403 editorile), sisendi valideerimine (pealkiri/link/pikkus), idempotentne `read`, saatja koopia.

```
$ pytest tests/ -q
637 passed in 16.22s   (baasjoon 593 + 44 uut)
```

## main.py kahaneb

```
2302 (algne) → 2222 (Faas 0) → 1955 (Faas 1)   = -347 rida kokku
```

## Olulised märkused

- **`/page-comments/reply` on cross-domain endpoint** (puudutab git + meilisearch + notifications). Viidud siia, sest peamine "ära" on teatise loomine; kui kommentaaride domeen hiljem eraldatakse, saab ümber paigutada. Kommentaari vastamise tuumloogika (notificationi loomine autorile) on kaetud ops testidega; endpoint ise vajaks lehe failide setup-i (jäetud tulevikuks).
- **`get_notifications_path` tõstab `HTTPException`** (HTTP teadlikkus ops-is) — tech debt, märgitud docstring-is. Ideaalis peaks ops tõstma `ValueError` ja endpoint teisendama. Eraldi cleanup, mitte selles refaktoreeringus.

## Mitte-skoop
- Ei muuda ops-moodulite sisu peale tõstetud funktsioonide (v.a dokumenteeritud resilience-paranus).
- Muu osa on puhas struktuuriline refaktoreering — kinnitatud 637 testiga.

## Järgmine samm
Faas 2 (upload + re-OCR, ~17 endpointi) — mehaaniline tõstmine, ops juba eraldatud.

## Viited
- Katus-issue: #36
- Plaan: `docs/REFACTOR_main_py_2026-06-25.md` (Faas 1)
- Eelnev: #37 (Faas 0, merge'itud #38)
