### PR TITLE
Faas 2: tõsta upload ja re-OCR routeritesse

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -30,6 +30,8 @@ from .registration import (
     update_registration_status, create_invite_token, validate_invite_token,
     create_user_from_invite, suggest_username_for_email
 )
+# Backward-compat re-eksport Faas 2 jaoks: upload/re-OCR endpointid elavad
+# routerites, aga vanad testid/skriptid võivad neid nimesid veel main.py-st importida.
 from .upload_ops import (
     sanitize_slug, create_upload, update_upload_meta,
     list_uploads, get_upload, mark_page_deleted, cancel_upload,
@@ -57,6 +59,8 @@ from .admin_page_ops import (
 from .image_server import generate_thumbnail
 from .prosopography.router import router as prosopography_router
 from .routers.notifications import router as notifications_router
+from .routers.upload import router as upload_router
+from .routers.reocr import router as reocr_router
 from .prosopography.ops import update_page_person_mentions, rebuild_indices, _load_index
 from .metadata_ops import save_work_metadata, bulk_update_field, ALLOWED_METADATA_FIELDS
 from .marginalia_normalize import normalize_marginalia_tags
@@ -83,6 +87,8 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="VUTT API", version="1.0.0", lifespan=lifespan)
 app.include_router(prosopography_router, prefix="/prosopography")
 app.include_router(notifications_router)
+app.include_router(upload_router)
+app.include_router(reocr_router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -1027,226 +1033,6 @@ async def bulk_genre(request: Request, background_tasks: BackgroundTasks, user=D
         )
     _invalidate_all_caches()
     return {"status": "success"}
-
-# =========================================================
-# UPLOAD JA OCR (GET status, POST files/import, DELETE cancel)
-# =========================================================
-
-@app.get("/admin/uploads")
-async def admin_uploads(user=Depends(require_role("admin"))):
-    if not UPLOAD_ENABLED: raise HTTPException(status_code=503)
-    return {"status": "success", "uploads": list_uploads()}
-
-@app.post("/admin/upload/create")
-async def admin_upload_create(request: Request, user=Depends(require_role("admin"))):
-    data = await get_json_data(request)
-    # Saniteeri slug alati (ka kliendi antud) — väldib path traversal'i import_as_work-is.
-    # sanitize_slug on idempotentne, seega juba korrektne slug ei muutu.
-    slug = sanitize_slug(data.get('slug') or data.get('title', ''))
-    data['slug'] = slug
-    return {"status": "success", "upload": create_upload(data)}
-
-@app.get("/admin/upload/{upload_id}/status")
-def admin_upload_status(upload_id: str, user=Depends(require_role("admin"))):
-    # SÜNKROONNE def (mitte async) — FastAPI jooksutab selle threadpoolis, et
-    # poll_and_sync_thumbs'i blokeeriv SFTP/SSH EI külmutaks event-loopi (ja
-    # seeläbi kogu saiti), kui OCR-server on kättesaamatu (2026-06-13 outage).
-    # poll_and_sync_thumbs tagastab oma "status" välja (upload olek: pending/processing/done jne)
-    # mis kirjutab üle siinsest "success" — seega tagastatav "status" on upload olek, mitte HTTP wrapper
-    return poll_and_sync_thumbs(upload_id)
-
-@app.get("/admin/upload/{upload_id}/thumb/{page_num}")
-async def admin_upload_thumb(upload_id: str, page_num: int, user=Depends(require_role("admin"))):
-    if not _valid_upload_id(upload_id): raise HTTPException(status_code=400, detail="Vigane upload_id")
-    path = os.path.join(UPLOADS_DIR, upload_id, 'thumbs', f"{page_num:03d}.jpg")
-    if not os.path.isfile(path): raise HTTPException(status_code=404)
-    return FileResponse(path, media_type="image/jpeg")
-
-@app.post("/admin/upload/{upload_id}/files")
-async def admin_upload_files(upload_id: str, request: Request, user=Depends(require_role("admin"))):
-    if not _valid_upload_id(upload_id): raise HTTPException(status_code=400, detail="Vigane upload_id")
-    x_pg, x_total = int(request.headers.get('X-Page-Number', '0')), int(request.headers.get('X-Total-Pages', '0'))
-    tmp_path = f"/tmp/vutt-upload-{upload_id}-pg{x_pg}" if x_pg > 0 else f"/tmp/vutt-upload-{upload_id}"
-    try:
-        with open(tmp_path, 'wb') as f:
-            async for chunk in request.stream():
-                f.write(chunk)
-        import asyncio
-        loop = asyncio.get_running_loop()
-        if x_pg > 0:
-            pages = await loop.run_in_executor(None, add_image_page, upload_id, tmp_path, x_pg, x_total)
-        else:
-            pages = await loop.run_in_executor(None, save_and_transfer_to_ocr, upload_id, tmp_path)
-        return {"status": "accepted", "upload_id": upload_id, "expected_pages": pages}
-    except ValueError as e:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        if os.path.exists(tmp_path):
-            os.unlink(tmp_path)
-        logger.error(f"Üleslaadimise viga ({upload_id}): {e}")
-        raise HTTPException(status_code=500, detail="Serveri viga faili töötlemisel")
-
-@app.post("/admin/upload/{upload_id}/import")
-async def admin_upload_import(upload_id: str, user=Depends(require_role("admin"))):
-    try:
-        res = import_as_work(upload_id, username=user['username'])
-        build_work_id_cache()
-        return {"status": "success", **res}
-    except ValueError as e: raise HTTPException(status_code=400, detail=str(e))
-
-@app.post("/admin/upload/{upload_id}/replace-work/{work_id}")
-async def admin_upload_replace_work(
-    upload_id: str,
-    work_id: str,
-    request: Request,
-    background_tasks: BackgroundTasks,
-    user=Depends(require_role("admin")),
-):
-    try:
-        data = await request.json()
-    except Exception:
-        data = {}
-    metadata_updates = (data.get("metadata_updates") or {}) if isinstance(data, dict) else {}
-    res = await replace_work_content(
-        upload_id,
-        work_id,
-        metadata_updates,
-        user['username'],
-        background_tasks,
-    )
-    return {"status": "success", **res}
-
-@app.get("/admin/upload/{upload_id}/meta")
-async def admin_upload_get_meta(upload_id: str, user=Depends(require_role("admin"))):
-    state = get_upload(upload_id)
-    if not state:
-        raise HTTPException(status_code=404, detail="Upload ei leitud")
-    return {"status": "success", "meta": state.get("meta", {})}
-
-@app.patch("/admin/upload/{upload_id}/meta")
-async def admin_upload_update_meta(upload_id: str, request: Request, user=Depends(require_role("admin"))):
-    data = await get_json_data(request)
-    if not update_upload_meta(upload_id, data):
-        raise HTTPException(status_code=404, detail="Upload ei leitud")
-    return {"status": "success"}
-
-@app.delete("/admin/upload/{upload_id}")
-async def admin_upload_cancel(upload_id: str, user=Depends(require_role("admin"))):
-    if cancel_upload(upload_id): return {"status": "success"}
-    raise HTTPException(status_code=500)
-
-# =========================================================
-# RE-OCR — olemasoleva lehekülje uuesti transkribeerimine
-# =========================================================
-
-@app.post("/admin/work/{work_id}/reocr-page")
-async def admin_reocr_page(work_id: str, request: Request, user=Depends(require_role("admin"))):
-    """Alustab lehekülje pildi re-OCR tööd. Tagastab job_id pollimiseks."""
-    if get_active_reocr_count() >= REOCR_MAX_CONCURRENT:
-        raise HTTPException(status_code=429, detail=f"Liiga palju korraga ({REOCR_MAX_CONCURRENT} max). Proovi hetke pärast uuesti.")
-    path = find_directory_by_id(work_id)
-    if not path:
-        raise HTTPException(status_code=404, detail="Teos ei leitud")
-    slug = os.path.basename(path)
-    data = await get_json_data(request)
-    page_filename = data.get("page_filename")
-    if not page_filename:
-        raise HTTPException(status_code=400, detail="page_filename puudub")
-    img_path = os.path.join(path, page_filename)
-    if not os.path.isfile(img_path):
-        raise HTTPException(status_code=404, detail="Pilti ei leitud")
-    page_number = data.get("page_number")
-    meta_path = os.path.join(path, '_metadata.json')
-    ocr_model = 'print'
-    if os.path.isfile(meta_path):
-        with open(meta_path, 'r', encoding='utf-8') as _mf:
-            _meta = json.load(_mf)
-        if isinstance(_meta.get('type'), dict) and _meta['type'].get('id') == 'Q87167':
-            ocr_model = 'hand'
-    tmp_path = f"/tmp/vutt-reocr-{generate_nanoid()}.jpg"
-    shutil.copy2(img_path, tmp_path)
-    job_id = start_reocr_job(work_id, slug, tmp_path, page_filename=page_filename, page_number=page_number, username=user['username'], material_type=ocr_model)
-    return {"status": "accepted", "job_id": job_id}
-
-@app.get("/admin/reocr/{job_id}/status")
-async def admin_reocr_status(job_id: str, user=Depends(require_role("admin"))):
-    """Küsib re-OCR töö staatust. Küsida korduvalt kuni done/error."""
-    return {"status": "success", **poll_reocr_job(job_id)}
-
-@app.get("/admin/reocr/jobs")
-async def admin_reocr_jobs(user=Depends(require_role("admin"))):
-    """Tagastab kõigi aktiivsete ja hiljutiste re-OCR tööde loendi."""
-    return {"status": "success", "jobs": list_reocr_jobs()}
-
-@app.get("/admin/reocr/log")
-async def admin_reocr_log(offset: int = 0, limit: int = 50, user=Depends(require_role("admin"))):
-    """Tagastab re-OCR ajalogi (püsiv, uuemad ees)."""
-    return {"status": "success", **get_reocr_log(offset, limit)}
-
-@app.get("/admin/work/{work_id}/page-ocr")
-async def get_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
-    """Tagastab lehekülje .ocr faili sisu, kui see eksisteerib."""
-    path = find_directory_by_id(work_id)
-    if not path:
-        raise HTTPException(status_code=404, detail="Teos ei leitud")
-    stem = os.path.splitext(os.path.basename(filename))[0]
-    ocr_path = os.path.join(path, stem + ".ocr")
-    if not os.path.isfile(ocr_path):
-        raise HTTPException(status_code=404, detail=".ocr fail puudub")
-    with open(ocr_path, "r", encoding="utf-8") as f:
-        text = f.read()
-    return {"status": "success", "text": text}
-
-@app.delete("/admin/work/{work_id}/page-ocr")
-async def delete_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
-    """Kustutab lehekülje .ocr faili (tulemus rakendatud või tagasi lükatud)."""
-    path = find_directory_by_id(work_id)
-    if not path:
-        raise HTTPException(status_code=404, detail="Teos ei leitud")
-    stem = os.path.splitext(os.path.basename(filename))[0]
-    ocr_path = os.path.join(path, stem + ".ocr")
-    if os.path.isfile(ocr_path):
-        os.remove(ocr_path)
-    return {"status": "success"}
-
-
-@app.post("/admin/work/{work_id}/reocr-batch")
-async def admin_reocr_batch(work_id: str, request: Request, user=Depends(require_role("admin"))):
-    """Alustab mitme lehe batch re-OCR tööd. Tagastab job_id."""
-    path = find_directory_by_id(work_id)
-    if not path:
-        raise HTTPException(status_code=404, detail="Teost ei leitud")
-    if get_active_batch_for_work(work_id):
-        raise HTTPException(status_code=409, detail="Sellel teosel käib juba batch re-OCR.")
-    slug = os.path.basename(path)
-    data = await get_json_data(request)
-    page_filenames = data.get("page_filenames") or []
-    if not isinstance(page_filenames, list) or not page_filenames:
-        raise HTTPException(status_code=400, detail="page_filenames puudub või tühi")
-    material_type = data.get("material_type") if data.get("material_type") in ("print", "hand") else "print"
-    pages = []
-    for fn in page_filenames:
-        # Turvalisus: ainult bare failinimi — väldi path traversal'i (nt ../../state/users.json)
-        if not isinstance(fn, str) or fn != os.path.basename(fn):
-            raise HTTPException(status_code=400, detail=f"Vigane failinimi: {fn}")
-        if not os.path.isfile(os.path.join(path, fn)):
-            raise HTTPException(status_code=400, detail=f"Pilti ei leitud: {fn}")
-        pages.append((fn, None))
-    job_id = start_reocr_batch(work_id, slug, path, pages,
-                               material_type=material_type, username=user['username'])
-    return {"status": "accepted", "job_id": job_id}
-
-
-@app.get("/admin/work/{work_id}/reocr-status")
-async def admin_reocr_status_for_work(work_id: str, user=Depends(require_role("admin"))):
-    """Teose re-OCR koondstaatus manage-lehele (active/ocr_ready/errors/progress)."""
-    path = find_directory_by_id(work_id)
-    if not path:
-        raise HTTPException(status_code=404, detail="Teost ei leitud")
-    return {"status": "success", **build_reocr_status(work_id, path)}
-
 
 # =========================================================
 # AVALIKUD ANDMED JA SEO

--- a/server/main.py
+++ b/server/main.py
@@ -30,19 +30,9 @@ from .registration import (
     update_registration_status, create_invite_token, validate_invite_token,
     create_user_from_invite, suggest_username_for_email
 )
-# Backward-compat re-eksport Faas 2 jaoks: upload/re-OCR endpointid elavad
-# routerites, aga vanad testid/skriptid võivad neid nimesid veel main.py-st importida.
-from .upload_ops import (
-    sanitize_slug, create_upload, update_upload_meta,
-    list_uploads, get_upload, mark_page_deleted, cancel_upload,
-    save_and_transfer_to_ocr, add_image_page, poll_and_sync_thumbs,
-    import_as_work, replace_work_content, _valid_upload_id,
-)
-from .reocr_ops import (
-    start_reocr_job, poll_reocr_job, list_reocr_jobs,
-    get_active_reocr_count, REOCR_MAX_CONCURRENT, get_reocr_log,
-    start_reocr_batch, get_active_batch_for_work, build_reocr_status,
-)
+# NB: upload/re-OCR endpointid + nende ops-importid elavad nüüd routerites
+# (server/routers/upload.py, reocr.py). Paketi-tasandi re-eksport käib
+# server/__init__.py kaudu otse ops-moodulitest, seega main.py ei impordi neid.
 from .cache import (
     get_cached_collections, get_cached_vocabularies, get_cached_people_aliases,
     get_cached_people_register, get_cached_suggestions, invalidate_cache,

--- a/server/routers/reocr.py
+++ b/server/routers/reocr.py
@@ -1,0 +1,132 @@
+import json
+import os
+import shutil
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from ..deps import get_json_data, require_role
+from ..reocr_ops import (
+    REOCR_MAX_CONCURRENT,
+    build_reocr_status,
+    get_active_batch_for_work,
+    get_active_reocr_count,
+    get_reocr_log,
+    list_reocr_jobs,
+    poll_reocr_job,
+    start_reocr_batch,
+    start_reocr_job,
+)
+from ..utils import find_directory_by_id, generate_nanoid
+
+router = APIRouter()
+
+
+@router.post("/admin/work/{work_id}/reocr-page")
+async def admin_reocr_page(work_id: str, request: Request, user=Depends(require_role("admin"))):
+    """Alustab lehekülje pildi re-OCR tööd. Tagastab job_id pollimiseks."""
+    if get_active_reocr_count() >= REOCR_MAX_CONCURRENT:
+        raise HTTPException(status_code=429, detail=f"Liiga palju korraga ({REOCR_MAX_CONCURRENT} max). Proovi hetke pärast uuesti.")
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teos ei leitud")
+    slug = os.path.basename(path)
+    data = await get_json_data(request)
+    page_filename = data.get("page_filename")
+    if not page_filename:
+        raise HTTPException(status_code=400, detail="page_filename puudub")
+    img_path = os.path.join(path, page_filename)
+    if not os.path.isfile(img_path):
+        raise HTTPException(status_code=404, detail="Pilti ei leitud")
+    page_number = data.get("page_number")
+    meta_path = os.path.join(path, "_metadata.json")
+    ocr_model = "print"
+    if os.path.isfile(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as _mf:
+            _meta = json.load(_mf)
+        if isinstance(_meta.get("type"), dict) and _meta["type"].get("id") == "Q87167":
+            ocr_model = "hand"
+    tmp_path = f"/tmp/vutt-reocr-{generate_nanoid()}.jpg"
+    shutil.copy2(img_path, tmp_path)
+    job_id = start_reocr_job(work_id, slug, tmp_path, page_filename=page_filename, page_number=page_number, username=user["username"], material_type=ocr_model)
+    return {"status": "accepted", "job_id": job_id}
+
+
+@router.get("/admin/reocr/{job_id}/status")
+async def admin_reocr_status(job_id: str, user=Depends(require_role("admin"))):
+    """Küsib re-OCR töö staatust. Küsida korduvalt kuni done/error."""
+    return {"status": "success", **poll_reocr_job(job_id)}
+
+
+@router.get("/admin/reocr/jobs")
+async def admin_reocr_jobs(user=Depends(require_role("admin"))):
+    """Tagastab kõigi aktiivsete ja hiljutiste re-OCR tööde loendi."""
+    return {"status": "success", "jobs": list_reocr_jobs()}
+
+
+@router.get("/admin/reocr/log")
+async def admin_reocr_log(offset: int = 0, limit: int = 50, user=Depends(require_role("admin"))):
+    """Tagastab re-OCR ajalogi (püsiv, uuemad ees)."""
+    return {"status": "success", **get_reocr_log(offset, limit)}
+
+
+@router.get("/admin/work/{work_id}/page-ocr")
+async def get_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
+    """Tagastab lehekülje .ocr faili sisu, kui see eksisteerib."""
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teos ei leitud")
+    stem = os.path.splitext(os.path.basename(filename))[0]
+    ocr_path = os.path.join(path, stem + ".ocr")
+    if not os.path.isfile(ocr_path):
+        raise HTTPException(status_code=404, detail=".ocr fail puudub")
+    with open(ocr_path, "r", encoding="utf-8") as f:
+        text = f.read()
+    return {"status": "success", "text": text}
+
+
+@router.delete("/admin/work/{work_id}/page-ocr")
+async def delete_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
+    """Kustutab lehekülje .ocr faili (tulemus rakendatud või tagasi lükatud)."""
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teos ei leitud")
+    stem = os.path.splitext(os.path.basename(filename))[0]
+    ocr_path = os.path.join(path, stem + ".ocr")
+    if os.path.isfile(ocr_path):
+        os.remove(ocr_path)
+    return {"status": "success"}
+
+
+@router.post("/admin/work/{work_id}/reocr-batch")
+async def admin_reocr_batch(work_id: str, request: Request, user=Depends(require_role("admin"))):
+    """Alustab mitme lehe batch re-OCR tööd. Tagastab job_id."""
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    if get_active_batch_for_work(work_id):
+        raise HTTPException(status_code=409, detail="Sellel teosel käib juba batch re-OCR.")
+    slug = os.path.basename(path)
+    data = await get_json_data(request)
+    page_filenames = data.get("page_filenames") or []
+    if not isinstance(page_filenames, list) or not page_filenames:
+        raise HTTPException(status_code=400, detail="page_filenames puudub või tühi")
+    material_type = data.get("material_type") if data.get("material_type") in ("print", "hand") else "print"
+    pages = []
+    for fn in page_filenames:
+        # Turvalisus: ainult bare failinimi — väldi path traversal'i (nt ../../state/users.json)
+        if not isinstance(fn, str) or fn != os.path.basename(fn):
+            raise HTTPException(status_code=400, detail=f"Vigane failinimi: {fn}")
+        if not os.path.isfile(os.path.join(path, fn)):
+            raise HTTPException(status_code=400, detail=f"Pilti ei leitud: {fn}")
+        pages.append((fn, None))
+    job_id = start_reocr_batch(work_id, slug, path, pages, material_type=material_type, username=user["username"])
+    return {"status": "accepted", "job_id": job_id}
+
+
+@router.get("/admin/work/{work_id}/reocr-status")
+async def admin_reocr_status_for_work(work_id: str, user=Depends(require_role("admin"))):
+    """Teose re-OCR koondstaatus manage-lehele (active/ocr_ready/errors/progress)."""
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    return {"status": "success", **build_reocr_status(work_id, path)}

--- a/server/routers/upload.py
+++ b/server/routers/upload.py
@@ -1,0 +1,147 @@
+import asyncio
+import os
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi.responses import FileResponse
+
+from ..config import UPLOAD_ENABLED, UPLOADS_DIR, get_logger
+from ..deps import get_json_data, require_role
+from ..upload_ops import (
+    add_image_page,
+    cancel_upload,
+    create_upload,
+    get_upload,
+    import_as_work,
+    list_uploads,
+    poll_and_sync_thumbs,
+    replace_work_content,
+    sanitize_slug,
+    save_and_transfer_to_ocr,
+    update_upload_meta,
+    _valid_upload_id,
+)
+from ..utils import build_work_id_cache
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+@router.get("/admin/uploads")
+async def admin_uploads(user=Depends(require_role("admin"))):
+    if not UPLOAD_ENABLED:
+        raise HTTPException(status_code=503)
+    return {"status": "success", "uploads": list_uploads()}
+
+
+@router.post("/admin/upload/create")
+async def admin_upload_create(request: Request, user=Depends(require_role("admin"))):
+    data = await get_json_data(request)
+    # Saniteeri slug alati (ka kliendi antud) — väldib path traversal'i import_as_work-is.
+    # sanitize_slug on idempotentne, seega juba korrektne slug ei muutu.
+    slug = sanitize_slug(data.get("slug") or data.get("title", ""))
+    data["slug"] = slug
+    return {"status": "success", "upload": create_upload(data)}
+
+
+@router.get("/admin/upload/{upload_id}/status")
+def admin_upload_status(upload_id: str, user=Depends(require_role("admin"))):
+    # SÜNKROONNE def (mitte async) — FastAPI jooksutab selle threadpoolis, et
+    # poll_and_sync_thumbs'i blokeeriv SFTP/SSH EI külmutaks event-loopi (ja
+    # seeläbi kogu saiti), kui OCR-server on kättesaamatu (2026-06-13 outage).
+    # poll_and_sync_thumbs tagastab oma "status" välja (upload olek: pending/processing/done jne)
+    # mis kirjutab üle siinsest "success" — seega tagastatav "status" on upload olek, mitte HTTP wrapper
+    return poll_and_sync_thumbs(upload_id)
+
+
+@router.get("/admin/upload/{upload_id}/thumb/{page_num}")
+async def admin_upload_thumb(upload_id: str, page_num: int, user=Depends(require_role("admin"))):
+    if not _valid_upload_id(upload_id):
+        raise HTTPException(status_code=400, detail="Vigane upload_id")
+    path = os.path.join(UPLOADS_DIR, upload_id, "thumbs", f"{page_num:03d}.jpg")
+    if not os.path.isfile(path):
+        raise HTTPException(status_code=404)
+    return FileResponse(path, media_type="image/jpeg")
+
+
+@router.post("/admin/upload/{upload_id}/files")
+async def admin_upload_files(upload_id: str, request: Request, user=Depends(require_role("admin"))):
+    if not _valid_upload_id(upload_id):
+        raise HTTPException(status_code=400, detail="Vigane upload_id")
+    x_pg = int(request.headers.get("X-Page-Number", "0"))
+    x_total = int(request.headers.get("X-Total-Pages", "0"))
+    tmp_path = f"/tmp/vutt-upload-{upload_id}-pg{x_pg}" if x_pg > 0 else f"/tmp/vutt-upload-{upload_id}"
+    try:
+        with open(tmp_path, "wb") as f:
+            async for chunk in request.stream():
+                f.write(chunk)
+        loop = asyncio.get_running_loop()
+        if x_pg > 0:
+            pages = await loop.run_in_executor(None, add_image_page, upload_id, tmp_path, x_pg, x_total)
+        else:
+            pages = await loop.run_in_executor(None, save_and_transfer_to_ocr, upload_id, tmp_path)
+        return {"status": "accepted", "upload_id": upload_id, "expected_pages": pages}
+    except ValueError as e:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        logger.error(f"Üleslaadimise viga ({upload_id}): {e}")
+        raise HTTPException(status_code=500, detail="Serveri viga faili töötlemisel")
+
+
+@router.post("/admin/upload/{upload_id}/import")
+async def admin_upload_import(upload_id: str, user=Depends(require_role("admin"))):
+    try:
+        res = import_as_work(upload_id, username=user["username"])
+        build_work_id_cache()
+        return {"status": "success", **res}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post("/admin/upload/{upload_id}/replace-work/{work_id}")
+async def admin_upload_replace_work(
+    upload_id: str,
+    work_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    user=Depends(require_role("admin")),
+):
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+    metadata_updates = (data.get("metadata_updates") or {}) if isinstance(data, dict) else {}
+    res = await replace_work_content(
+        upload_id,
+        work_id,
+        metadata_updates,
+        user["username"],
+        background_tasks,
+    )
+    return {"status": "success", **res}
+
+
+@router.get("/admin/upload/{upload_id}/meta")
+async def admin_upload_get_meta(upload_id: str, user=Depends(require_role("admin"))):
+    state = get_upload(upload_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Upload ei leitud")
+    return {"status": "success", "meta": state.get("meta", {})}
+
+
+@router.patch("/admin/upload/{upload_id}/meta")
+async def admin_upload_update_meta(upload_id: str, request: Request, user=Depends(require_role("admin"))):
+    data = await get_json_data(request)
+    if not update_upload_meta(upload_id, data):
+        raise HTTPException(status_code=404, detail="Upload ei leitud")
+    return {"status": "success"}
+
+
+@router.delete("/admin/upload/{upload_id}")
+async def admin_upload_cancel(upload_id: str, user=Depends(require_role("admin"))):
+    if cancel_upload(upload_id):
+        return {"status": "success"}
+    raise HTTPException(status_code=500)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,10 +96,9 @@ def backend_env(tmp_path, monkeypatch):
     # kõigis asjakohastes moodulites ühe helperiga JA nõuab, et vähemalt üks
     # moodul konstandi omaks (turvavõrk vaikse testi-katkemise vastu).
     #
-    # NB: praegusel hetkel on reaalne omanik ``server.main`` (+ UPLOADS_DIR-i
-    # jaoks ``server.upload_ops``) — need read on teadlik skafold: kui mõni faas
-    # konstandi routerisse tõstab, lisatakse vastav moodul siia loetellu (main
-    # jääb samuti, sest jätab re-eksporti kuni kõik viited uuenevad).
+    # NB: konstandi routerisse tõstmisel lisatakse vastav moodul siia loetellu.
+    # Näiteks Faas 2 tõstab upload-endpointid ``server.routers.upload`` alla,
+    # seega UPLOADS_DIR patchitakse nii ops-moodulis kui routeris.
     # ``server.work_meta`` pole siin, sest see impordib ainult BASE_DIR (mitte
     # ühtegi neist konstantidest) — tõstaksime selle siia alles siis, kui work_meta
     # hakkaks mõnda neist importima.
@@ -117,7 +116,7 @@ def backend_env(tmp_path, monkeypatch):
     _patch_config_const(
         monkeypatch,
         {"UPLOADS_DIR": str(uploads_dir)},
-        modules=["server.main", "server.upload_ops"],
+        modules=["server.main", "server.upload_ops", "server.routers.upload"],
     )
 
     upload_ops = importlib.import_module("server.upload_ops")

--- a/tests/test_conftest_patch_helper.py
+++ b/tests/test_conftest_patch_helper.py
@@ -58,19 +58,21 @@ def test_patch_const_succeeds_when_at_least_one_module_owns(monkeypatch):
 
 
 def test_patch_const_patches_all_owners(monkeypatch):
-    """Kui konstant on mitmes moodulis (nt UPLOADS_DIR main-is + upload_ops-is),
-    patchitakse mõlemad."""
+    """Kui konstant on mitmes moodulis (nt UPLOADS_DIR main-is + upload_ops-is + upload-routeris),
+    patchitakse kõik."""
     from tests.conftest import _patch_config_const
     from server import main
     import server.upload_ops as upload_ops
+    import server.routers.upload as upload_router
 
     _patch_config_const(
         monkeypatch,
         {"UPLOADS_DIR": "/tmp/test-uploads-xyz"},
-        modules=["server.main", "server.upload_ops"],
+        modules=["server.main", "server.upload_ops", "server.routers.upload"],
     )
     assert main.UPLOADS_DIR == "/tmp/test-uploads-xyz"
     assert upload_ops.UPLOADS_DIR == "/tmp/test-uploads-xyz"
+    assert upload_router.UPLOADS_DIR == "/tmp/test-uploads-xyz"
 
 
 def test_patch_const_ignores_non_owners_without_creating_phantoms(monkeypatch):
@@ -82,7 +84,7 @@ def test_patch_const_ignores_non_owners_without_creating_phantoms(monkeypatch):
     _patch_config_const(
         monkeypatch,
         {"UPLOADS_DIR": "/tmp/test-uploads-xyz"},
-        modules=["server.main", "server.work_meta"],  # work_meta ei oma UPLOADS_DIR-i
+        modules=["server.upload_ops", "server.work_meta"],  # work_meta ei oma UPLOADS_DIR-i
     )
     # work_meta peab jääma puutumata: ei UPLOADS_DIR-i atribuuti ega muudatust
     assert not hasattr(work_meta, "UPLOADS_DIR"), (

--- a/tests/test_reocr_batch.py
+++ b/tests/test_reocr_batch.py
@@ -186,11 +186,11 @@ def test_build_reocr_status_agregeerib(tmp_path, monkeypatch):
 def test_reocr_batch_validatsioon(backend_env, client, login, monkeypatch, tmp_path):
     """404 tundmatu teose korral, 400 tühja listi ja puuduva faili korral."""
     from server import reocr_ops
-    main = backend_env["main"]
+    from server.routers import reocr as reocr_router
     work = tmp_path / "1700-teos"
     work.mkdir()
     (work / "a.jpg").write_bytes(b"IMG")
-    monkeypatch.setattr(main, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
+    monkeypatch.setattr(reocr_router, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
     # Tühjendame globaalse batch-registri, et varasemad testid ei segaks
     reocr_ops._reocr_batch_jobs.clear()
 
@@ -212,13 +212,13 @@ def test_reocr_batch_validatsioon(backend_env, client, login, monkeypatch, tmp_p
 
 def test_reocr_batch_aktiivne_409(backend_env, client, login, monkeypatch, tmp_path):
     """409 kui sellel teosel käib juba aktiivne batch."""
-    main = backend_env["main"]
+    from server.routers import reocr as reocr_router
     work = tmp_path / "1700-teos"
     work.mkdir()
     (work / "a.jpg").write_bytes(b"IMG")
-    monkeypatch.setattr(main, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
-    # main.py kasutab otseimporti, seega patch main-moodulil
-    monkeypatch.setattr(main, "get_active_batch_for_work", lambda wid: "jid-123")
+    monkeypatch.setattr(reocr_router, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
+    # router kasutab otseimporti, seega patch router-moodulil
+    monkeypatch.setattr(reocr_router, "get_active_batch_for_work", lambda wid: "jid-123")
 
     token = login("admin", "adminpass")
     h = {"Authorization": f"Bearer {token}"}
@@ -234,10 +234,10 @@ def test_reocr_batch_auth_nouab_admini(backend_env, client):
 
 def test_reocr_status_kuju(backend_env, client, login, monkeypatch, tmp_path):
     """GET reocr-status tagastab oodatud väljad: active, ocr_ready, errors, progress."""
-    main = backend_env["main"]
+    from server.routers import reocr as reocr_router
     work = tmp_path / "1700-teos"
     work.mkdir()
-    monkeypatch.setattr(main, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
+    monkeypatch.setattr(reocr_router, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
 
     token = login("admin", "adminpass")
     r = client.get("/admin/work/w1/reocr-status", headers={"Authorization": f"Bearer {token}"})
@@ -248,8 +248,8 @@ def test_reocr_status_kuju(backend_env, client, login, monkeypatch, tmp_path):
 
 def test_reocr_status_tundmatu_teos_404(backend_env, client, login, monkeypatch):
     """GET reocr-status tundmatu teose korral → 404."""
-    main = backend_env["main"]
-    monkeypatch.setattr(main, "find_directory_by_id", lambda w: None)
+    from server.routers import reocr as reocr_router
+    monkeypatch.setattr(reocr_router, "find_directory_by_id", lambda w: None)
 
     token = login("admin", "adminpass")
     r = client.get("/admin/work/zzz/reocr-status", headers={"Authorization": f"Bearer {token}"})
@@ -264,11 +264,12 @@ def test_reocr_status_auth_nouab_admini(backend_env, client):
 
 def test_reocr_batch_lykkab_traversal_tagasi(backend_env, client, login, monkeypatch, tmp_path):
     """Path traversal failinimed tagasi lükatud."""
-    from server import reocr_ops, main
+    from server import reocr_ops
+    from server.routers import reocr as reocr_router
     work = tmp_path / "1700-teos"
     work.mkdir()
     (work / "a.jpg").write_bytes(b"IMG")
-    monkeypatch.setattr(main, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
+    monkeypatch.setattr(reocr_router, "find_directory_by_id", lambda w: str(work) if w == "w1" else None)
     reocr_ops._reocr_batch_jobs.clear()
 
     token = login("admin", "adminpass")


### PR DESCRIPTION
## Kokkuvõte
- tõstab upload endpointid `server/routers/upload.py` alla
- tõstab re-OCR endpointid `server/routers/reocr.py` alla
- registreerib uued routerid `server/main.py`-s
- uuendab testide monkeypatch'id router-moodulitele
- jätab `main.py` backward-compat importid vanade viidete jaoks

## Kontroll
- `./.venv/bin/python -m pytest -q tests/ --maxfail=1` → 637 passed

Osa issue #36 Faas 2-st.
