### PR TITLE
Faas 3: tõsta lehekülgede haldus routerisse

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -7,8 +7,7 @@ import uuid
 import re
 from datetime import datetime
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, Request, HTTPException, Depends, status, BackgroundTasks, UploadFile
-from fastapi.datastructures import FormData
+from fastapi import FastAPI, Request, HTTPException, Depends, status, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, HTMLResponse, FileResponse, StreamingResponse, Response
 from starlette.concurrency import run_in_threadpool
@@ -22,7 +21,7 @@ from .meilisearch_ops import metadata_watcher_loop, _keepwarm_loop, sync_work_to
 from .metadata_handler import build_meta_html, build_person_meta_html, build_persons_meta_html, build_sitemap_xml
 from .people_ops import process_creators_metadata, process_person_fields_metadata, get_refresh_status, refresh_all_people_safe
 from .entity_labels_ops import load_entity_labels, enrich_entity_labels_async, enrich_entity_labels_async_qcodes, refresh_all_entity_labels
-from .git_ops import run_git_fsck, save_with_git, get_recent_commits, delete_work_from_git, delete_page_from_git, clear_git_failures, get_git_failures, get_file_git_history, get_file_diff, get_file_at_commit, get_commit_diff, get_or_init_repo
+from .git_ops import run_git_fsck, save_with_git, get_recent_commits, delete_work_from_git, clear_git_failures, get_git_failures, get_file_git_history, get_file_diff, get_file_at_commit, get_commit_diff, get_or_init_repo
 from .auth import verify_user, create_session, delete_session, require_token, get_all_users, update_user_role, delete_user, delete_user_sessions, get_session, load_users, save_users
 from .rate_limit import get_client_ip, check_rate_limit, check_account_lockout, record_login_failure, clear_login_failures
 from .registration import (
@@ -39,18 +38,14 @@ from .cache import (
     get_cached_archives,
 )
 from .trash_ops import list_deleted_works, restore_deleted_work, list_deleted_pages, restore_deleted_page
-from .admin_page_ops import (
-    clear_original_backup, get_page_sequence, get_sorted_images,
-    rebalance_sequences, reorder_pages, split_page, transform_page_image,
-    detect_and_convert_image, write_new_page, add_pages, work_lock,
-    delete_pages,
-    _validate_base_names,
-)
-from .image_server import generate_thumbnail
+# get_sorted_images on jätkuvalt kasutusel download endpointides; _validate_base_names
+# jääb Faas 3 ajal backward-compat re-ekspordiks testidele/importijatele.
+from .admin_page_ops import get_sorted_images, _validate_base_names
 from .prosopography.router import router as prosopography_router
 from .routers.notifications import router as notifications_router
 from .routers.upload import router as upload_router
 from .routers.reocr import router as reocr_router
+from .routers.pages import router as pages_router
 from .prosopography.ops import update_page_person_mentions, rebuild_indices, _load_index
 from .metadata_ops import save_work_metadata, bulk_update_field, ALLOWED_METADATA_FIELDS
 from .marginalia_normalize import normalize_marginalia_tags
@@ -79,6 +74,7 @@ app.include_router(prosopography_router, prefix="/prosopography")
 app.include_router(notifications_router)
 app.include_router(upload_router)
 app.include_router(reocr_router)
+app.include_router(pages_router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -361,363 +357,6 @@ async def admin_work_delete(work_id: str, user=Depends(require_role("admin"))):
     update_work_collections(work_id, [])
     build_work_id_cache()
     return {"status": "success"}
-
-# =========================================================
-# LEHEKÜLGEDE HALDUS (admin)
-# =========================================================
-
-@app.get("/admin/work/{work_id}/pages")
-async def admin_work_pages(work_id: str, user=Depends(require_role("admin"))):
-    """Tagastab teose lehekülgede nimekirja halduseks (sequence järgi sorditud)."""
-    path = find_directory_by_id(work_id)
-    if not path: raise HTTPException(status_code=404, detail="Teost ei leitud")
-    folder_name = os.path.basename(path)
-
-    images = get_sorted_images(path)
-    pages = []
-    for i, img_name in enumerate(images):
-        base = os.path.splitext(img_name)[0]
-        json_path = os.path.join(path, base + '.json')
-        txt_path = os.path.join(path, base + '.txt')
-
-        status = 'Toores'
-        sequence = (i + 1) * 100
-        if os.path.exists(json_path):
-            try:
-                with open(json_path, 'r', encoding='utf-8') as f:
-                    d = json.load(f)
-                src = d.get('meta_content', d)
-                status = src.get('status', 'Toores')
-                seq = d.get('sequence') or d.get('meta_content', {}).get('sequence')
-                if seq is not None:
-                    sequence = int(seq)
-            except Exception:
-                pass
-
-        pages.append({
-            'page_num': i + 1,
-            'sequence': sequence,
-            'base_name': base,
-            'filename': img_name,
-            'lehekylje_pilt': f"{folder_name}/{img_name}",
-            'status': status,
-            'has_text': os.path.exists(txt_path) and os.path.getsize(txt_path) > 0
-        })
-
-    return {"status": "success", "pages": pages}
-
-
-@app.delete("/admin/work/{work_id}/page/{page_num}")
-async def admin_delete_page(work_id: str, page_num: int, user=Depends(require_role("admin"))):
-    """Kustutab teose lehekülje: liigutab .jpg prügikasti, kustutab .txt ja .json gitist."""
-    path = find_directory_by_id(work_id)
-    if not path: raise HTTPException(status_code=404, detail="Teost ei leitud")
-    folder_name = os.path.basename(path)
-
-    with work_lock(folder_name, path):
-        images = get_sorted_images(path)
-        if page_num < 1 or page_num > len(images):
-            raise HTTPException(status_code=404, detail=f"Lehekülge {page_num} ei leitud")
-
-        img_name = images[page_num - 1]
-        base = os.path.splitext(img_name)[0]
-
-        # Liiguta .jpg prügikasti
-        trash_dir = os.path.join(BASE_DIR, '._trash', work_id, 'pages')
-        os.makedirs(trash_dir, exist_ok=True)
-        img_path = os.path.join(path, img_name)
-        if os.path.exists(img_path):
-            shutil.move(img_path, os.path.join(trash_dir, img_name))
-
-        # Kustuta .txt ja .json gitist
-        commit_msg = f"Kustuta leht {page_num}: {folder_name}/{base} [{work_id}]"
-        delete_page_from_git(folder_name, base, commit_msg, username=user['username'])
-
-        # Sünkroniseeri Meilisearch (leheküljed renumberdatakse)
-        sync_work_to_meilisearch(folder_name)
-
-        new_page_count = len(get_sorted_images(path))
-        return {"status": "success", "new_page_count": new_page_count}
-
-
-@app.post("/admin/work/{work_id}/delete-pages")
-async def admin_delete_pages(work_id: str, request: Request, user=Depends(require_role("admin"))):
-    """Kustutab mitu lehekülge korraga (kõik-või-mitte-midagi)."""
-    try:
-        body = await request.json()
-        base_names = _validate_base_names(body.get("base_names"))
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception:
-        raise HTTPException(status_code=400, detail="Vigane päring")
-
-    result = delete_pages(work_id, base_names, username=user['username'])
-    if result["status"] == "not_found":
-        raise HTTPException(status_code=404, detail={"missing": result["missing"]})
-    if result["status"] == "conflict":
-        raise HTTPException(status_code=409, detail={"missing": result["missing"]})
-    return result
-
-
-@app.post("/admin/work/{work_id}/page/{page_num}/replace-image")
-async def admin_replace_page_image(work_id: str, page_num: int, request: Request, user=Depends(require_role("admin"))):
-    """
-    Asendab lehekülje pildi uuega. Vana pilt säilitatakse prügikastis 90 päeva.
-    Body: multipart — file (JPG/PNG)
-    """
-    path = find_directory_by_id(work_id)
-    if not path:
-        raise HTTPException(status_code=404, detail="Teost ei leitud")
-    folder_name = os.path.basename(path)
-
-    # Parse multipart (async — enne luku võtmist)
-    try:
-        form: FormData = await request.form()
-        file: UploadFile = form.get('file')
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
-
-    if not file:
-        raise HTTPException(status_code=400, detail="Fail puudub")
-
-    # Kontrolli failitüüpi + teisenda (jagatud helper: magic-byte, mõõtmekaitse,
-    # PNG→JPG valgele taustale). Enne luku võtmist.
-    content = await file.read()
-    try:
-        content, _ext = detect_and_convert_image(content, file.filename or "")
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-
-    with work_lock(folder_name, path):
-        images = get_sorted_images(path)
-        if page_num < 1 or page_num > len(images):
-            raise HTTPException(status_code=404, detail=f"Lehekülge {page_num} ei leitud")
-
-        img_name = images[page_num - 1]
-        img_path = os.path.join(path, img_name)
-        base = os.path.splitext(img_name)[0]
-
-        # Salvesta vana pilt prügikasti (._trash/{work_id}/replaced_images/)
-        trash_dir = os.path.join(BASE_DIR, '._trash', work_id, 'replaced_images')
-        os.makedirs(trash_dir, exist_ok=True)
-        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        trash_filename = f"{base}_{timestamp}{os.path.splitext(img_name)[1]}"
-        if os.path.exists(img_path):
-            shutil.copy2(img_path, os.path.join(trash_dir, trash_filename))
-            logger.info(f"REPLACE-IMG: Vana pilt salvestatud: {trash_filename}")
-
-        # Kirjuta uus pilt üle
-        with open(img_path, 'wb') as f:
-            f.write(content)
-        os.chmod(img_path, 0o644)
-
-        # Regenereeri thumbnail
-        thumbs_dir = os.path.join(path, '_thumbs')
-        os.makedirs(thumbs_dir, exist_ok=True)
-        thumb_path = os.path.join(thumbs_dir, f"_thumb_{img_name}")
-        if os.path.exists(thumb_path):
-            os.remove(thumb_path)
-        generate_thumbnail(img_path, thumb_path)
-
-        # Kirjuta püsiv logi
-        log_path = os.path.join(BASE_DIR, 'replace_image.log')
-        log_entry = f"{datetime.now().isoformat()} | {work_id} | {folder_name}/{img_name} | leht {page_num} | {user['username']}\n"
-        with open(log_path, 'a', encoding='utf-8') as lf:
-            lf.write(log_entry)
-
-        # Asendatud pilt on lehe uus pristine algolek → eemalda vana ._originals kirje
-        clear_original_backup(work_id, img_name)
-
-        logger.info(f"REPLACE-IMG: {folder_name}/{img_name} asendatud ({user['username']})")
-        sync_work_to_meilisearch(folder_name)
-        return {"status": "success", "filename": img_name}
-
-
-@app.post("/admin/work/{work_id}/add-page")
-async def admin_add_page(work_id: str, request: Request, user=Depends(require_role("admin"))):
-    """
-    Lisab teosele uue lehekülje (JPG/PNG).
-    Body: multipart — file (JPG/PNG), after_page_num (int, 0=algusesse, -1=lõppu)
-    Laienduspunkt: ocr_requested (bool, praegu ignoreeritakse)
-    """
-    path = find_directory_by_id(work_id)
-    if not path: raise HTTPException(status_code=404, detail="Teost ei leitud")
-    folder_name = os.path.basename(path)
-
-    # Parse multipart (async — enne luku võtmist)
-    try:
-        form: FormData = await request.form()
-        file: UploadFile = form.get('file')
-        after_page_num = int(form.get('after_page_num', -1))
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
-
-    if not file:
-        raise HTTPException(status_code=400, detail="Fail puudub")
-
-    # Kontrolli failitüüpi + teisenda (enne luku võtmist)
-    content = await file.read()
-    try:
-        content, ext = detect_and_convert_image(content, file.filename or "")
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-
-    with work_lock(folder_name, path):
-        # Arvuta uus sequence (lukus — loeb värsket olekut)
-        images = get_sorted_images(path)
-        page_count = len(images)
-
-        def seq_of(idx):
-            """Tagastab lehe effective sequence; fallback: positsioon × 100."""
-            if idx < 0 or idx >= len(images):
-                return None
-            base = os.path.splitext(images[idx])[0]
-            s = get_page_sequence(os.path.join(path, base + '.json'))
-            if s == float('inf'):
-                return (idx + 1) * 100  # images on juba sorteeritud, positsioon on korrektne
-            return int(s)
-
-        if after_page_num == -1 or after_page_num >= page_count:
-            # Lõppu
-            last_seq = seq_of(page_count - 1)
-            if last_seq == float('inf') or last_seq is None:
-                new_seq = (page_count + 1) * 100
-            else:
-                new_seq = int(last_seq) + 100
-        elif after_page_num == 0:
-            # Algusesse
-            first_seq = seq_of(0)
-            if first_seq == float('inf') or first_seq is None:
-                new_seq = 50
-            else:
-                new_seq = int(first_seq) // 2
-                if new_seq <= 0:
-                    rebalance_sequences(path)
-                    images = get_sorted_images(path)
-                    new_seq = 50
-        else:
-            # Vahele: pärast after_page_num-ndat (1-indekseeritud)
-            idx = after_page_num - 1
-            seq_before = seq_of(idx)
-            seq_after = seq_of(idx + 1)
-            if seq_before == float('inf') or seq_before is None:
-                seq_before = after_page_num * 100
-            if seq_after == float('inf') or seq_after is None:
-                seq_after = (after_page_num + 1) * 100
-            new_seq = (int(seq_before) + int(seq_after)) // 2
-            if new_seq <= int(seq_before):
-                # Ruumi pole — tasakaalusta
-                rebalance_sequences(path)
-                images = get_sorted_images(path)
-                idx = after_page_num - 1
-                seq_before = get_page_sequence(os.path.join(path, os.path.splitext(images[idx])[0] + '.json')) if idx < len(images) else after_page_num * 100
-                seq_after_val = get_page_sequence(os.path.join(path, os.path.splitext(images[idx+1])[0] + '.json')) if idx + 1 < len(images) else (after_page_num + 1) * 100
-                new_seq = (int(seq_before) + int(seq_after_val)) // 2
-
-        # Salvesta leht (jagatud helper; single → staging == work dir)
-        page = write_new_page(path, path, folder_name, work_id, content, ext, new_seq)
-        new_filename = page["filename"]
-        base = page["base"]
-        txt_path = page["txt_path"]
-        json_path = page["json_path"]
-        page_meta = page["page_meta"]
-
-        # Git commit
-        save_with_git(
-            txt_path, '',
-            user['username'],
-            message=f"Lisa leht: {folder_name}/{base} [sequence={new_seq}]",
-            additional_files=[(json_path, json.dumps(page_meta, indent=2, ensure_ascii=False))]
-        )
-
-        # Sünkroniseeri Meilisearch
-        sync_work_to_meilisearch(folder_name)
-
-        new_page_count = len(get_sorted_images(path))
-        return {"status": "success", "new_page_count": new_page_count, "sequence": new_seq, "filename": new_filename}
-
-
-@app.post("/admin/work/{work_id}/add-pages")
-async def admin_add_pages(work_id: str, request: Request, user=Depends(require_role("admin"))):
-    """Lisab teosele mitu lehekülge korraga (JPG/PNG), nimejärgi sorteeritud.
-    Body: multipart — mitu `file`-välja + after_page_num (int, 0=algusesse, -1=lõppu).
-    """
-    try:
-        form: FormData = await request.form()
-        after_page_num = int(form.get('after_page_num', -1))
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
-
-    uploads = form.getlist('file')
-    if not uploads:
-        raise HTTPException(status_code=400, detail="Faile pole")
-
-    files = []
-    for up in uploads:
-        if not hasattr(up, 'read'):
-            continue
-        content = await up.read()
-        files.append((up.filename or "", content))
-
-    try:
-        # add_pages on blokeeriv (Pillow-teisendus, failikirjutus, flock, git commit) —
-        # offload threadpooli, et mitte külmutada single-worker event-loopi (vt OCR-SSH outage)
-        import asyncio
-        loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, add_pages, work_id, files, after_page_num, user['username'])
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    if not result.get("found", True):
-        raise HTTPException(status_code=404, detail="Teost ei leitud")
-    return {"status": "success", **result}
-
-
-@app.post("/admin/work/{work_id}/page/{page_num}/split")
-async def admin_split_page(work_id: str, page_num: int, request: Request, user=Depends(require_role("admin"))):
-    """Lõikab topeltlehekülje kaheks. Body: { split_x: float (0.05–0.95) }"""
-    data = await get_json_data(request)
-    split_x = data.get("split_x")
-    if split_x is None:
-        raise HTTPException(status_code=400, detail="split_x on kohustuslik")
-    try:
-        result = split_page(work_id, page_num, float(split_x), user["username"])
-    except (ValueError, TypeError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    if not result.get("found", True):
-        raise HTTPException(status_code=404, detail="Teost või lehekülge ei leitud")
-    return {"status": "success", "new_page_count": result["new_page_count"]}
-
-
-@app.post("/admin/work/{work_id}/page-image/{filename}/transform")
-async def admin_transform_page_image(work_id: str, filename: str, request: Request, user=Depends(require_role("admin"))):
-    """Pöörab/kärbib lehepilti kohapeal. Body: { angle: float, crop: {x,y,w,h}|null }"""
-    data = await get_json_data(request)
-    angle = data.get("angle", 0.0)
-    crop = data.get("crop")
-    try:
-        result = transform_page_image(work_id, filename, angle=angle, crop=crop, username=user["username"])
-    except (ValueError, TypeError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    if not result.get("found", True):
-        raise HTTPException(status_code=404, detail="Teost või lehte ei leitud")
-    return result
-
-
-@app.post("/admin/work/{work_id}/reorder-pages")
-async def admin_reorder_pages(work_id: str, request: Request, user=Depends(require_role("admin"))):
-    """Muudab lehekülgede järjekorda. Body: {"order": ["fail1.jpg", "fail2.jpg", ...]}"""
-    path = find_directory_by_id(work_id)
-    if not path:
-        raise HTTPException(status_code=404, detail="Teost ei leitud")
-    data = await request.json()
-    new_order = data.get("order", [])
-    result = reorder_pages(path, new_order, user.get("username", "admin"))
-    if result.get("error"):
-        raise HTTPException(status_code=400, detail=result["error"])
-    folder_name = os.path.basename(path)
-    sync_work_to_meilisearch(folder_name)
-    return {"status": "success"}
-
 
 # =========================================================
 # TOIMETAMINE JA SALVESTAMINE

--- a/server/main.py
+++ b/server/main.py
@@ -38,9 +38,9 @@ from .cache import (
     get_cached_archives,
 )
 from .trash_ops import list_deleted_works, restore_deleted_work, list_deleted_pages, restore_deleted_page
-# get_sorted_images on jätkuvalt kasutusel download endpointides; _validate_base_names
-# jääb Faas 3 ajal backward-compat re-ekspordiks testidele/importijatele.
-from .admin_page_ops import get_sorted_images, _validate_base_names
+# get_sorted_images on jätkuvalt kasutusel download endpointides; lehekülgede
+# halduse endpointid + nende ops-importid elavad nüüd server/routers/pages.py-s.
+from .admin_page_ops import get_sorted_images
 from .prosopography.router import router as prosopography_router
 from .routers.notifications import router as notifications_router
 from .routers.upload import router as upload_router

--- a/server/routers/pages.py
+++ b/server/routers/pages.py
@@ -1,0 +1,388 @@
+import asyncio
+import json
+import os
+import shutil
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
+from fastapi.datastructures import FormData
+
+from ..admin_page_ops import (
+    clear_original_backup,
+    delete_pages,
+    detect_and_convert_image,
+    get_page_sequence,
+    get_sorted_images,
+    rebalance_sequences,
+    reorder_pages,
+    split_page,
+    transform_page_image,
+    work_lock,
+    write_new_page,
+    add_pages,
+    _validate_base_names,
+)
+from ..config import BASE_DIR, get_logger
+from ..deps import get_json_data, require_role
+from ..git_ops import delete_page_from_git, save_with_git
+from ..image_server import generate_thumbnail
+from ..meilisearch_ops import sync_work_to_meilisearch
+from ..utils import find_directory_by_id
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+@router.get("/admin/work/{work_id}/pages")
+async def admin_work_pages(work_id: str, user=Depends(require_role("admin"))):
+    """Tagastab teose lehekülgede nimekirja halduseks (sequence järgi sorditud)."""
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    folder_name = os.path.basename(path)
+
+    images = get_sorted_images(path)
+    pages = []
+    for i, img_name in enumerate(images):
+        base = os.path.splitext(img_name)[0]
+        json_path = os.path.join(path, base + ".json")
+        txt_path = os.path.join(path, base + ".txt")
+
+        status = "Toores"
+        sequence = (i + 1) * 100
+        if os.path.exists(json_path):
+            try:
+                with open(json_path, "r", encoding="utf-8") as f:
+                    d = json.load(f)
+                src = d.get("meta_content", d)
+                status = src.get("status", "Toores")
+                seq = d.get("sequence") or d.get("meta_content", {}).get("sequence")
+                if seq is not None:
+                    sequence = int(seq)
+            except Exception:
+                pass
+
+        pages.append({
+            "page_num": i + 1,
+            "sequence": sequence,
+            "base_name": base,
+            "filename": img_name,
+            "lehekylje_pilt": f"{folder_name}/{img_name}",
+            "status": status,
+            "has_text": os.path.exists(txt_path) and os.path.getsize(txt_path) > 0,
+        })
+
+    return {"status": "success", "pages": pages}
+
+
+@router.delete("/admin/work/{work_id}/page/{page_num}")
+async def admin_delete_page(work_id: str, page_num: int, user=Depends(require_role("admin"))):
+    """Kustutab teose lehekülje: liigutab .jpg prügikasti, kustutab .txt ja .json gitist."""
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    folder_name = os.path.basename(path)
+
+    with work_lock(folder_name, path):
+        images = get_sorted_images(path)
+        if page_num < 1 or page_num > len(images):
+            raise HTTPException(status_code=404, detail=f"Lehekülge {page_num} ei leitud")
+
+        img_name = images[page_num - 1]
+        base = os.path.splitext(img_name)[0]
+
+        # Liiguta .jpg prügikasti
+        trash_dir = os.path.join(BASE_DIR, "._trash", work_id, "pages")
+        os.makedirs(trash_dir, exist_ok=True)
+        img_path = os.path.join(path, img_name)
+        if os.path.exists(img_path):
+            shutil.move(img_path, os.path.join(trash_dir, img_name))
+
+        # Kustuta .txt ja .json gitist
+        commit_msg = f"Kustuta leht {page_num}: {folder_name}/{base} [{work_id}]"
+        delete_page_from_git(folder_name, base, commit_msg, username=user["username"])
+
+        # Sünkroniseeri Meilisearch (leheküljed renumberdatakse)
+        sync_work_to_meilisearch(folder_name)
+
+        new_page_count = len(get_sorted_images(path))
+        return {"status": "success", "new_page_count": new_page_count}
+
+
+@router.post("/admin/work/{work_id}/delete-pages")
+async def admin_delete_pages(work_id: str, request: Request, user=Depends(require_role("admin"))):
+    """Kustutab mitu lehekülge korraga (kõik-või-mitte-midagi)."""
+    try:
+        body = await request.json()
+        base_names = _validate_base_names(body.get("base_names"))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=400, detail="Vigane päring")
+
+    result = delete_pages(work_id, base_names, username=user["username"])
+    if result["status"] == "not_found":
+        raise HTTPException(status_code=404, detail={"missing": result["missing"]})
+    if result["status"] == "conflict":
+        raise HTTPException(status_code=409, detail={"missing": result["missing"]})
+    return result
+
+
+@router.post("/admin/work/{work_id}/page/{page_num}/replace-image")
+async def admin_replace_page_image(work_id: str, page_num: int, request: Request, user=Depends(require_role("admin"))):
+    """
+    Asendab lehekülje pildi uuega. Vana pilt säilitatakse prügikastis 90 päeva.
+    Body: multipart — file (JPG/PNG)
+    """
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    folder_name = os.path.basename(path)
+
+    # Parse multipart (async — enne luku võtmist)
+    try:
+        form: FormData = await request.form()
+        file: UploadFile = form.get("file")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
+
+    if not file:
+        raise HTTPException(status_code=400, detail="Fail puudub")
+
+    # Kontrolli failitüüpi + teisenda (jagatud helper: magic-byte, mõõtmekaitse,
+    # PNG→JPG valgele taustale). Enne luku võtmist.
+    content = await file.read()
+    try:
+        content, _ext = detect_and_convert_image(content, file.filename or "")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    with work_lock(folder_name, path):
+        images = get_sorted_images(path)
+        if page_num < 1 or page_num > len(images):
+            raise HTTPException(status_code=404, detail=f"Lehekülge {page_num} ei leitud")
+
+        img_name = images[page_num - 1]
+        img_path = os.path.join(path, img_name)
+        base = os.path.splitext(img_name)[0]
+
+        # Salvesta vana pilt prügikasti (._trash/{work_id}/replaced_images/)
+        trash_dir = os.path.join(BASE_DIR, "._trash", work_id, "replaced_images")
+        os.makedirs(trash_dir, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        trash_filename = f"{base}_{timestamp}{os.path.splitext(img_name)[1]}"
+        if os.path.exists(img_path):
+            shutil.copy2(img_path, os.path.join(trash_dir, trash_filename))
+            logger.info(f"REPLACE-IMG: Vana pilt salvestatud: {trash_filename}")
+
+        # Kirjuta uus pilt üle
+        with open(img_path, "wb") as f:
+            f.write(content)
+        os.chmod(img_path, 0o644)
+
+        # Regenereeri thumbnail
+        thumbs_dir = os.path.join(path, "_thumbs")
+        os.makedirs(thumbs_dir, exist_ok=True)
+        thumb_path = os.path.join(thumbs_dir, f"_thumb_{img_name}")
+        if os.path.exists(thumb_path):
+            os.remove(thumb_path)
+        generate_thumbnail(img_path, thumb_path)
+
+        # Kirjuta püsiv logi
+        log_path = os.path.join(BASE_DIR, "replace_image.log")
+        log_entry = f"{datetime.now().isoformat()} | {work_id} | {folder_name}/{img_name} | leht {page_num} | {user['username']}\n"
+        with open(log_path, "a", encoding="utf-8") as lf:
+            lf.write(log_entry)
+
+        # Asendatud pilt on lehe uus pristine algolek → eemalda vana ._originals kirje
+        clear_original_backup(work_id, img_name)
+
+        logger.info(f"REPLACE-IMG: {folder_name}/{img_name} asendatud ({user['username']})")
+        sync_work_to_meilisearch(folder_name)
+        return {"status": "success", "filename": img_name}
+
+
+@router.post("/admin/work/{work_id}/add-page")
+async def admin_add_page(work_id: str, request: Request, user=Depends(require_role("admin"))):
+    """
+    Lisab teosele uue lehekülje (JPG/PNG).
+    Body: multipart — file (JPG/PNG), after_page_num (int, 0=algusesse, -1=lõppu)
+    Laienduspunkt: ocr_requested (bool, praegu ignoreeritakse)
+    """
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    folder_name = os.path.basename(path)
+
+    # Parse multipart (async — enne luku võtmist)
+    try:
+        form: FormData = await request.form()
+        file: UploadFile = form.get("file")
+        after_page_num = int(form.get("after_page_num", -1))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
+
+    if not file:
+        raise HTTPException(status_code=400, detail="Fail puudub")
+
+    # Kontrolli failitüüpi + teisenda (enne luku võtmist)
+    content = await file.read()
+    try:
+        content, ext = detect_and_convert_image(content, file.filename or "")
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    with work_lock(folder_name, path):
+        # Arvuta uus sequence (lukus — loeb värsket olekut)
+        images = get_sorted_images(path)
+        page_count = len(images)
+
+        def seq_of(idx):
+            """Tagastab lehe effective sequence; fallback: positsioon × 100."""
+            if idx < 0 or idx >= len(images):
+                return None
+            base = os.path.splitext(images[idx])[0]
+            s = get_page_sequence(os.path.join(path, base + ".json"))
+            if s == float("inf"):
+                return (idx + 1) * 100  # images on juba sorteeritud, positsioon on korrektne
+            return int(s)
+
+        if after_page_num == -1 or after_page_num >= page_count:
+            # Lõppu
+            last_seq = seq_of(page_count - 1)
+            if last_seq == float("inf") or last_seq is None:
+                new_seq = (page_count + 1) * 100
+            else:
+                new_seq = int(last_seq) + 100
+        elif after_page_num == 0:
+            # Algusesse
+            first_seq = seq_of(0)
+            if first_seq == float("inf") or first_seq is None:
+                new_seq = 50
+            else:
+                new_seq = int(first_seq) // 2
+                if new_seq <= 0:
+                    rebalance_sequences(path)
+                    images = get_sorted_images(path)
+                    new_seq = 50
+        else:
+            # Vahele: pärast after_page_num-ndat (1-indekseeritud)
+            idx = after_page_num - 1
+            seq_before = seq_of(idx)
+            seq_after = seq_of(idx + 1)
+            if seq_before == float("inf") or seq_before is None:
+                seq_before = after_page_num * 100
+            if seq_after == float("inf") or seq_after is None:
+                seq_after = (after_page_num + 1) * 100
+            new_seq = (int(seq_before) + int(seq_after)) // 2
+            if new_seq <= int(seq_before):
+                # Ruumi pole — tasakaalusta
+                rebalance_sequences(path)
+                images = get_sorted_images(path)
+                idx = after_page_num - 1
+                seq_before = get_page_sequence(os.path.join(path, os.path.splitext(images[idx])[0] + ".json")) if idx < len(images) else after_page_num * 100
+                seq_after_val = get_page_sequence(os.path.join(path, os.path.splitext(images[idx + 1])[0] + ".json")) if idx + 1 < len(images) else (after_page_num + 1) * 100
+                new_seq = (int(seq_before) + int(seq_after_val)) // 2
+
+        # Salvesta leht (jagatud helper; single → staging == work dir)
+        page = write_new_page(path, path, folder_name, work_id, content, ext, new_seq)
+        new_filename = page["filename"]
+        base = page["base"]
+        txt_path = page["txt_path"]
+        json_path = page["json_path"]
+        page_meta = page["page_meta"]
+
+        # Git commit
+        save_with_git(
+            txt_path, "",
+            user["username"],
+            message=f"Lisa leht: {folder_name}/{base} [sequence={new_seq}]",
+            additional_files=[(json_path, json.dumps(page_meta, indent=2, ensure_ascii=False))],
+        )
+
+        # Sünkroniseeri Meilisearch
+        sync_work_to_meilisearch(folder_name)
+
+        new_page_count = len(get_sorted_images(path))
+        return {"status": "success", "new_page_count": new_page_count, "sequence": new_seq, "filename": new_filename}
+
+
+@router.post("/admin/work/{work_id}/add-pages")
+async def admin_add_pages(work_id: str, request: Request, user=Depends(require_role("admin"))):
+    """Lisab teosele mitu lehekülge korraga (JPG/PNG), nimejärgi sorteeritud.
+    Body: multipart — mitu `file`-välja + after_page_num (int, 0=algusesse, -1=lõppu).
+    """
+    try:
+        form: FormData = await request.form()
+        after_page_num = int(form.get("after_page_num", -1))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
+
+    uploads = form.getlist("file")
+    if not uploads:
+        raise HTTPException(status_code=400, detail="Faile pole")
+
+    files = []
+    for up in uploads:
+        if not hasattr(up, "read"):
+            continue
+        content = await up.read()
+        files.append((up.filename or "", content))
+
+    try:
+        # add_pages on blokeeriv (Pillow-teisendus, failikirjutus, flock, git commit) —
+        # offload threadpooli, et mitte külmutada single-worker event-loopi (vt OCR-SSH outage)
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(None, add_pages, work_id, files, after_page_num, user["username"])
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not result.get("found", True):
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    return {"status": "success", **result}
+
+
+@router.post("/admin/work/{work_id}/page/{page_num}/split")
+async def admin_split_page(work_id: str, page_num: int, request: Request, user=Depends(require_role("admin"))):
+    """Lõikab topeltlehekülje kaheks. Body: { split_x: float (0.05–0.95) }"""
+    data = await get_json_data(request)
+    split_x = data.get("split_x")
+    if split_x is None:
+        raise HTTPException(status_code=400, detail="split_x on kohustuslik")
+    try:
+        result = split_page(work_id, page_num, float(split_x), user["username"])
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not result.get("found", True):
+        raise HTTPException(status_code=404, detail="Teost või lehekülge ei leitud")
+    return {"status": "success", "new_page_count": result["new_page_count"]}
+
+
+@router.post("/admin/work/{work_id}/page-image/{filename}/transform")
+async def admin_transform_page_image(work_id: str, filename: str, request: Request, user=Depends(require_role("admin"))):
+    """Pöörab/kärbib lehepilti kohapeal. Body: { angle: float, crop: {x,y,w,h}|null }"""
+    data = await get_json_data(request)
+    angle = data.get("angle", 0.0)
+    crop = data.get("crop")
+    try:
+        result = transform_page_image(work_id, filename, angle=angle, crop=crop, username=user["username"])
+    except (ValueError, TypeError) as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if not result.get("found", True):
+        raise HTTPException(status_code=404, detail="Teost või lehte ei leitud")
+    return result
+
+
+@router.post("/admin/work/{work_id}/reorder-pages")
+async def admin_reorder_pages(work_id: str, request: Request, user=Depends(require_role("admin"))):
+    """Muudab lehekülgede järjekorda. Body: {\"order\": [\"fail1.jpg\", \"fail2.jpg\", ...]}"""
+    path = find_directory_by_id(work_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    data = await request.json()
+    new_order = data.get("order", [])
+    result = reorder_pages(path, new_order, user.get("username", "admin"))
+    if result.get("error"):
+        raise HTTPException(status_code=400, detail=result["error"])
+    folder_name = os.path.basename(path)
+    sync_work_to_meilisearch(folder_name)
+    return {"status": "success"}

--- a/tests/test_delete_pages_endpoint.py
+++ b/tests/test_delete_pages_endpoint.py
@@ -27,8 +27,8 @@ def test_validate_base_names_empty_raises():
 
 # --- Endpoint staatuse-mapping (autenditud, delete_pages mock'itud) ---
 def test_endpoint_success_200(backend_env, client, login, monkeypatch):
-    main = backend_env["main"]
-    monkeypatch.setattr(main, "delete_pages",
+    from server.routers import pages as pages_router
+    monkeypatch.setattr(pages_router, "delete_pages",
                         lambda wid, bn, username: {"status": "success", "deleted": bn, "new_page_count": 0})
     token = login("admin", "adminpass")
     r = client.post("/admin/work/w1/delete-pages", json={"base_names": ["pg1"]},
@@ -38,8 +38,8 @@ def test_endpoint_success_200(backend_env, client, login, monkeypatch):
 
 
 def test_endpoint_conflict_409(backend_env, client, login, monkeypatch):
-    main = backend_env["main"]
-    monkeypatch.setattr(main, "delete_pages", lambda *a, **k: {"status": "conflict", "missing": ["x"]})
+    from server.routers import pages as pages_router
+    monkeypatch.setattr(pages_router, "delete_pages", lambda *a, **k: {"status": "conflict", "missing": ["x"]})
     token = login("admin", "adminpass")
     r = client.post("/admin/work/w1/delete-pages", json={"base_names": ["pg1"]},
                     headers={"Authorization": f"Bearer {token}"})
@@ -47,8 +47,8 @@ def test_endpoint_conflict_409(backend_env, client, login, monkeypatch):
 
 
 def test_endpoint_not_found_404(backend_env, client, login, monkeypatch):
-    main = backend_env["main"]
-    monkeypatch.setattr(main, "delete_pages", lambda *a, **k: {"status": "not_found", "missing": ["x"]})
+    from server.routers import pages as pages_router
+    monkeypatch.setattr(pages_router, "delete_pages", lambda *a, **k: {"status": "not_found", "missing": ["x"]})
     token = login("admin", "adminpass")
     r = client.post("/admin/work/w1/delete-pages", json={"base_names": ["pg1"]},
                     headers={"Authorization": f"Bearer {token}"})

--- a/tests/test_delete_pages_endpoint.py
+++ b/tests/test_delete_pages_endpoint.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 # --- Puhas valideerimisfunktsioon (ilma autentimiseta) ---
 def test_validate_base_names_rejects_traversal():
-    from server.main import _validate_base_names
+    from server.admin_page_ops import _validate_base_names
     with pytest.raises(ValueError):
         _validate_base_names(["../../etc/passwd"])
     with pytest.raises(ValueError):
@@ -15,12 +15,12 @@ def test_validate_base_names_rejects_traversal():
 
 
 def test_validate_base_names_dedupes():
-    from server.main import _validate_base_names
+    from server.admin_page_ops import _validate_base_names
     assert _validate_base_names(["pg1", "pg1", "pg2"]) == ["pg1", "pg2"]
 
 
 def test_validate_base_names_empty_raises():
-    from server.main import _validate_base_names
+    from server.admin_page_ops import _validate_base_names
     with pytest.raises(ValueError):
         _validate_base_names([])
 

--- a/tests/test_split_page.py
+++ b/tests/test_split_page.py
@@ -190,8 +190,8 @@ def test_split_endpoint_403_editor(backend_env, login):
 
 
 def test_split_endpoint_404_unknown_work(backend_env, login, monkeypatch):
-    import server.main as main
-    monkeypatch.setattr(main, "split_page", lambda *a, **kw: {"found": False})
+    from server.routers import pages as pages_router
+    monkeypatch.setattr(pages_router, "split_page", lambda *a, **kw: {"found": False})
 
     token = login("admin", "adminpass")
     r = backend_env["client"].post(
@@ -203,12 +203,12 @@ def test_split_endpoint_404_unknown_work(backend_env, login, monkeypatch):
 
 
 def test_split_endpoint_400_invalid_split_x(backend_env, login, monkeypatch):
-    import server.main as main
+    from server.routers import pages as pages_router
 
     def _raise(*a, **kw):
         raise ValueError("split_x peab olema vahemikus [0.05, 0.95]")
 
-    monkeypatch.setattr(main, "split_page", _raise)
+    monkeypatch.setattr(pages_router, "split_page", _raise)
 
     token = login("admin", "adminpass")
     r = backend_env["client"].post(
@@ -220,9 +220,9 @@ def test_split_endpoint_400_invalid_split_x(backend_env, login, monkeypatch):
 
 
 def test_split_endpoint_200_success(backend_env, login, monkeypatch):
-    import server.main as main
+    from server.routers import pages as pages_router
     monkeypatch.setattr(
-        main, "split_page", lambda *a, **kw: {"success": True, "new_page_count": 2}
+        pages_router, "split_page", lambda *a, **kw: {"success": True, "new_page_count": 2}
     )
 
     token = login("admin", "adminpass")

--- a/tests/test_transform_page.py
+++ b/tests/test_transform_page.py
@@ -106,11 +106,11 @@ def test_transform_endpoint_401_no_auth(backend_env):
 
 
 def test_transform_endpoint_400_bad_crop(backend_env, login, monkeypatch):
-    import server.main as main
+    from server.routers import pages as pages_router
 
     def _raise(*a, **kw):
         raise ValueError("kärbe liiga väike")
-    monkeypatch.setattr(main, "transform_page_image", _raise)
+    monkeypatch.setattr(pages_router, "transform_page_image", _raise)
 
     token = login("admin", "adminpass")
     r = backend_env["client"].post(
@@ -122,8 +122,8 @@ def test_transform_endpoint_400_bad_crop(backend_env, login, monkeypatch):
 
 
 def test_transform_endpoint_404_unknown(backend_env, login, monkeypatch):
-    import server.main as main
-    monkeypatch.setattr(main, "transform_page_image", lambda *a, **kw: {"found": False})
+    from server.routers import pages as pages_router
+    monkeypatch.setattr(pages_router, "transform_page_image", lambda *a, **kw: {"found": False})
     token = login("admin", "adminpass")
     r = backend_env["client"].post(
         "/admin/work/x/page-image/a.jpg/transform",
@@ -134,9 +134,9 @@ def test_transform_endpoint_404_unknown(backend_env, login, monkeypatch):
 
 
 def test_transform_endpoint_200(backend_env, login, monkeypatch):
-    import server.main as main
+    from server.routers import pages as pages_router
     monkeypatch.setattr(
-        main, "transform_page_image",
+        pages_router, "transform_page_image",
         lambda *a, **kw: {"success": True, "changed": True, "filename": "a.jpg", "size": [100, 200], "thumbnail_warning": False},
     )
     token = login("admin", "adminpass")


### PR DESCRIPTION
## Kokkuvõte
- tõstab lehekülgede halduse endpointid `server/routers/pages.py` alla
- registreerib `pages_router` `server/main.py`-s
- eemaldab `main.py`-st vastava endpointide ploki ja surnud importid
- uuendab endpoint-testide monkeypatch'id router-moodulile
- jätab `get_sorted_images` kasutusse download endpointide jaoks ning `_validate_base_names` backward-compat re-ekspordiks

## Kontroll
- `./.venv/bin/python -m pytest -q tests/ --maxfail=1` → 637 passed
- kontrollitud: 9 pages admin route'i, duplikaate pole

Osa issue #36 Faas 3-st.
