### PR TITLE
Faas 4: tõsta autentimine ja registreerimine routerisse

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -22,12 +22,11 @@ from .metadata_handler import build_meta_html, build_person_meta_html, build_per
 from .people_ops import process_creators_metadata, process_person_fields_metadata, get_refresh_status, refresh_all_people_safe
 from .entity_labels_ops import load_entity_labels, enrich_entity_labels_async, enrich_entity_labels_async_qcodes, refresh_all_entity_labels
 from .git_ops import run_git_fsck, save_with_git, get_recent_commits, delete_work_from_git, clear_git_failures, get_git_failures, get_file_git_history, get_file_diff, get_file_at_commit, get_commit_diff, get_or_init_repo
-from .auth import verify_user, create_session, delete_session, require_token, get_all_users, update_user_role, delete_user, delete_user_sessions, get_session, load_users, save_users
-from .rate_limit import get_client_ip, check_rate_limit, check_account_lockout, record_login_failure, clear_login_failures
+from .auth import get_all_users, update_user_role, delete_user, delete_user_sessions, load_users, save_users
+from .rate_limit import get_client_ip, check_rate_limit
 from .registration import (
-    add_registration, load_pending_registrations, get_registration_by_id,
-    update_registration_status, create_invite_token, validate_invite_token,
-    create_user_from_invite, suggest_username_for_email
+    load_pending_registrations, get_registration_by_id,
+    update_registration_status, create_invite_token
 )
 # NB: upload/re-OCR endpointid + nende ops-importid elavad nüüd routerites
 # (server/routers/upload.py, reocr.py). Paketi-tasandi re-eksport käib
@@ -46,6 +45,7 @@ from .routers.notifications import router as notifications_router
 from .routers.upload import router as upload_router
 from .routers.reocr import router as reocr_router
 from .routers.pages import router as pages_router
+from .routers.auth import router as auth_router
 from .prosopography.ops import update_page_person_mentions, rebuild_indices, _load_index
 from .metadata_ops import save_work_metadata, bulk_update_field, ALLOWED_METADATA_FIELDS
 from .marginalia_normalize import normalize_marginalia_tags
@@ -75,6 +75,7 @@ app.include_router(notifications_router)
 app.include_router(upload_router)
 app.include_router(reocr_router)
 app.include_router(pages_router)
+app.include_router(auth_router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -102,128 +103,6 @@ from .deps import optional_user as _get_optional_user
 # viewer-token, shareable, download, SEO meta ja collections ligipääsukontrollis.
 from .work_meta import load_work_metadata as _load_work_metadata
 from .work_meta import read_work_meta_direct_sync as _read_work_meta_direct_sync
-
-# =========================================================
-# KASUTAJAD JA SESSIOONID
-# =========================================================
-
-@app.post("/login")
-async def login(request: Request):
-    client_ip = get_client_ip(request)
-    # IP-põhine rate-limit (kaitse ühelt IP-lt tuleva brute-force'i vastu)
-    allowed, retry_after = check_rate_limit(client_ip, '/login')
-    if not allowed: return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"})
-    data = await request.json()
-    username = data.get("username", "").strip()
-    # Konto-põhine lockout (kaitse credential-stuffingu vastu — palju IP-sid, üks konto)
-    locked, acc_retry = check_account_lockout(username)
-    if locked:
-        logger.warning(f"Login blokeeritud (konto lukus): username={username!r} ip={client_ip} retry_after={acc_retry}s")
-        return JSONResponse(status_code=429, content={"status": "error", "message": f"Liiga palju ebaõnnestunud katseid. Proovi uuesti {acc_retry}s pärast"})
-    user = verify_user(username, data.get("password", ""))
-    if user:
-        clear_login_failures(username)
-        from .meilisearch_ops import generate_meili_token
-        try:
-            meili_token = generate_meili_token(user=user, ttl_seconds=3600)
-        except Exception as e:
-            logger.info(f"Meili token genereerimine ebaõnnestus (test env?): {e}")
-            meili_token = None
-        return {
-            "status": "success",
-            "user": user,
-            "token": create_session(user),
-            "meili_token": meili_token,
-        }
-    record_login_failure(username)
-    logger.warning(f"Ebaõnnestunud login: username={username!r} ip={client_ip}")
-    return {"status": "error", "message": "Vale kasutajanimi või parool"}
-
-@app.post("/verify-token")
-async def verify_token(request: Request):
-    # NB: See endpoint kasutab tahtlikult POST body tokenit, mitte Bearer päist.
-    # Põhjus: endpoint verifitseerib tokenit iseennast — get_user() dependency
-    # nõuaks kehtivat tokenit, mida me just kontrollima hakkame.
-    data = await request.json()
-    token = data.get("token", "").strip()
-    user, error = require_token({"auth_token": token})
-    if error:
-        return {"status": "error", "valid": False, "message": error["message"]}
-    return {"status": "success", "user": user, "valid": True}
-
-@app.post("/logout")
-async def logout(request: Request):
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        token = auth_header[7:].strip()
-        if token:
-            delete_session(token)
-    return {"status": "success"}
-
-@app.get("/api/meili-token")
-async def public_meili_token():
-    """Anonüümne Meilisearchi tenant token — filter: is_public = true."""
-    from .meilisearch_ops import generate_meili_token
-    try:
-        token = generate_meili_token(user=None, ttl_seconds=3600)
-        return {"token": token}
-    except Exception as e:
-        logger.info(f"Meili token genereerimine ebaõnnestus (test env?): {e}")
-        return {"token": ""}
-
-
-@app.post("/api/meili-token/refresh")
-async def refresh_meili_token(request: Request):
-    """Uuendab autentitud kasutaja Meilisearchi tokeni."""
-    from .meilisearch_ops import generate_meili_token
-    token_str = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
-    session = get_session(token_str)
-    if not session:
-        raise HTTPException(status_code=401, detail="Sessioon aegunud")
-    user = session["user"]
-    users = load_users()
-    full_user = users.get(user["username"], user)
-    user_with_collections = {**user, "allowed_collections": full_user.get("allowed_collections", [])}
-    try:
-        new_token = generate_meili_token(user=user_with_collections, ttl_seconds=3600)
-        return {"token": new_token}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Token refresh ebaõnnestus: {e}")
-
-
-@app.post("/register")
-async def register(request: Request):
-    client_ip = get_client_ip(request)
-    allowed, retry_after = check_rate_limit(client_ip, '/register')
-    if not allowed: return JSONResponse(status_code=429, content={"status": "error", "message": "Liiga palju päringuid"})
-    data = await request.json()
-    if data.get('website'): return {"status": "success"}
-    registration, error = add_registration(data.get('name', ''), data.get('email', ''), data.get('affiliation'), data.get('motivation', ''), gdpr_consent=bool(data.get('gdpr_consent')))
-    if not registration: raise HTTPException(status_code=400, detail=error)
-    return {"status": "success", "id": registration["id"], "username": registration.get("username")}
-
-@app.get("/register/username-preview")
-async def register_username_preview(email: str = ""):
-    email = email.strip().lower()
-    if not email or "@" not in email:
-        return {"status": "success", "username": ""}
-    return {"status": "success", "username": suggest_username_for_email(email)}
-
-@app.get("/invite/{token}")
-async def check_invite(token: str):
-    token_data, error = validate_invite_token(token)
-    if token_data: return {"status": "success", "valid": True, "email": token_data["email"], "username": token_data.get("username"), "name": token_data["name"], "expires_at": token_data["expires_at"]}
-    return {"status": "error", "valid": False, "message": error}
-
-@app.post("/invite/set-password")
-async def set_password(request: Request):
-    client_ip = get_client_ip(request)
-    allowed, retry_after = check_rate_limit(client_ip, '/invite/set-password')
-    if not allowed: return JSONResponse(status_code=429, content={"status": "error", "message": "Liiga palju päringuid"})
-    data = await request.json()
-    new_user, error = create_user_from_invite(data.get('token', ''), data.get('password', ''))
-    if not new_user: raise HTTPException(status_code=400, detail=error)
-    return {"status": "success", "username": new_user["username"]}
 
 # =========================================================
 # ADMIN JA HALDUS (POST)

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -1,0 +1,166 @@
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from ..auth import create_session, delete_session, get_session, load_users, require_token, verify_user
+from ..config import get_logger
+from ..rate_limit import (
+    check_account_lockout,
+    check_rate_limit,
+    clear_login_failures,
+    get_client_ip,
+    record_login_failure,
+)
+from ..registration import (
+    add_registration,
+    create_user_from_invite,
+    suggest_username_for_email,
+    validate_invite_token,
+)
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+@router.post("/login")
+async def login(request: Request):
+    client_ip = get_client_ip(request)
+    # IP-põhine rate-limit (kaitse ühelt IP-lt tuleva brute-force'i vastu)
+    allowed, retry_after = check_rate_limit(client_ip, "/login")
+    if not allowed:
+        return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"})
+    data = await request.json()
+    username = data.get("username", "").strip()
+    # Konto-põhine lockout (kaitse credential-stuffingu vastu — palju IP-sid, üks konto)
+    locked, acc_retry = check_account_lockout(username)
+    if locked:
+        logger.warning(f"Login blokeeritud (konto lukus): username={username!r} ip={client_ip} retry_after={acc_retry}s")
+        return JSONResponse(status_code=429, content={"status": "error", "message": f"Liiga palju ebaõnnestunud katseid. Proovi uuesti {acc_retry}s pärast"})
+    user = verify_user(username, data.get("password", ""))
+    if user:
+        clear_login_failures(username)
+        from ..meilisearch_ops import generate_meili_token
+        try:
+            meili_token = generate_meili_token(user=user, ttl_seconds=3600)
+        except Exception as e:
+            logger.info(f"Meili token genereerimine ebaõnnestus (test env?): {e}")
+            meili_token = None
+        return {
+            "status": "success",
+            "user": user,
+            "token": create_session(user),
+            "meili_token": meili_token,
+        }
+    record_login_failure(username)
+    logger.warning(f"Ebaõnnestunud login: username={username!r} ip={client_ip}")
+    return {"status": "error", "message": "Vale kasutajanimi või parool"}
+
+
+@router.post("/verify-token")
+async def verify_token(request: Request):
+    # NB: See endpoint kasutab tahtlikult POST body tokenit, mitte Bearer päist.
+    # Põhjus: endpoint verifitseerib tokenit iseennast — get_user() dependency
+    # nõuaks kehtivat tokenit, mida me just kontrollima hakkame.
+    data = await request.json()
+    token = data.get("token", "").strip()
+    user, error = require_token({"auth_token": token})
+    if error:
+        return {"status": "error", "valid": False, "message": error["message"]}
+    return {"status": "success", "user": user, "valid": True}
+
+
+@router.post("/logout")
+async def logout(request: Request):
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:].strip()
+        if token:
+            delete_session(token)
+    return {"status": "success"}
+
+
+@router.get("/api/meili-token")
+async def public_meili_token():
+    """Anonüümne Meilisearchi tenant token — filter: is_public = true."""
+    from ..meilisearch_ops import generate_meili_token
+    try:
+        token = generate_meili_token(user=None, ttl_seconds=3600)
+        return {"token": token}
+    except Exception as e:
+        logger.info(f"Meili token genereerimine ebaõnnestus (test env?): {e}")
+        return {"token": ""}
+
+
+@router.post("/api/meili-token/refresh")
+async def refresh_meili_token(request: Request):
+    """Uuendab autentitud kasutaja Meilisearchi tokeni."""
+    from ..meilisearch_ops import generate_meili_token
+    token_str = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+    session = get_session(token_str)
+    if not session:
+        raise HTTPException(status_code=401, detail="Sessioon aegunud")
+    user = session["user"]
+    users = load_users()
+    full_user = users.get(user["username"], user)
+    user_with_collections = {**user, "allowed_collections": full_user.get("allowed_collections", [])}
+    try:
+        new_token = generate_meili_token(user=user_with_collections, ttl_seconds=3600)
+        return {"token": new_token}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Token refresh ebaõnnestus: {e}")
+
+
+@router.post("/register")
+async def register(request: Request):
+    client_ip = get_client_ip(request)
+    allowed, retry_after = check_rate_limit(client_ip, "/register")
+    if not allowed:
+        return JSONResponse(status_code=429, content={"status": "error", "message": "Liiga palju päringuid"})
+    data = await request.json()
+    if data.get("website"):
+        return {"status": "success"}
+    registration, error = add_registration(
+        data.get("name", ""),
+        data.get("email", ""),
+        data.get("affiliation"),
+        data.get("motivation", ""),
+        gdpr_consent=bool(data.get("gdpr_consent")),
+    )
+    if not registration:
+        raise HTTPException(status_code=400, detail=error)
+    return {"status": "success", "id": registration["id"], "username": registration.get("username")}
+
+
+@router.get("/register/username-preview")
+async def register_username_preview(email: str = ""):
+    email = email.strip().lower()
+    if not email or "@" not in email:
+        return {"status": "success", "username": ""}
+    return {"status": "success", "username": suggest_username_for_email(email)}
+
+
+@router.get("/invite/{token}")
+async def check_invite(token: str):
+    token_data, error = validate_invite_token(token)
+    if token_data:
+        return {
+            "status": "success",
+            "valid": True,
+            "email": token_data["email"],
+            "username": token_data.get("username"),
+            "name": token_data["name"],
+            "expires_at": token_data["expires_at"],
+        }
+    return {"status": "error", "valid": False, "message": error}
+
+
+@router.post("/invite/set-password")
+async def set_password(request: Request):
+    client_ip = get_client_ip(request)
+    allowed, retry_after = check_rate_limit(client_ip, "/invite/set-password")
+    if not allowed:
+        return JSONResponse(status_code=429, content={"status": "error", "message": "Liiga palju päringuid"})
+    data = await request.json()
+    new_user, error = create_user_from_invite(data.get("token", ""), data.get("password", ""))
+    if not new_user:
+        raise HTTPException(status_code=400, detail=error)
+    return {"status": "success", "username": new_user["username"]}


### PR DESCRIPTION
## Kokkuvõte
- tõstab autentimise ja avaliku registreerumise endpointid `server/routers/auth.py` alla
- registreerib `auth_router` `server/main.py`-s
- eemaldab `main.py`-st vastava endpointide ploki ja surnud importid
- jätab admin-registreerimiste halduse (`/admin/registrations*`) Faas 5 alla, nagu plaanis

## Tõstetud route'id
- `POST /login`
- `POST /verify-token`
- `POST /logout`
- `GET /api/meili-token`
- `POST /api/meili-token/refresh`
- `POST /register`
- `GET /register/username-preview`
- `GET /invite/{token}`
- `POST /invite/set-password`

## Kontroll
- `./.venv/bin/python -m pytest -q tests/ --maxfail=1` → 637 passed
- kontrollitud: 9 auth/register route'i, duplikaate pole

Osa issue #36 Faas 4-st.
