### PR TITLE
Faas 6d: tõsta public access ja SEO routerisse

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -8,27 +8,21 @@ from datetime import datetime
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, HTTPException, Depends, status, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse, HTMLResponse, FileResponse, StreamingResponse, Response
 from starlette.concurrency import run_in_threadpool
 
 from .config import PORT, ALLOWED_ORIGINS, BASE_DIR, UPLOAD_ENABLED, UPLOADS_DIR, get_logger
 from .utils import build_work_id_cache, find_directory_by_id, generate_nanoid
-from .access_ops import can_read_work, can_write_work, is_work_public
+from .access_ops import can_write_work
 
 logger = get_logger(__name__)
 from .meilisearch_ops import metadata_watcher_loop, _keepwarm_loop, sync_work_to_meilisearch_async, _ensure_filterable_attributes
-from .metadata_handler import build_meta_html, build_person_meta_html, build_persons_meta_html, build_sitemap_xml
 from .people_ops import process_person_fields_metadata
 from .entity_labels_ops import enrich_entity_labels_async, enrich_entity_labels_async_qcodes
 from .git_ops import run_git_fsck, save_with_git, get_recent_commits, get_file_git_history, get_file_at_commit, get_commit_diff
-from .rate_limit import get_client_ip, check_rate_limit
 # NB: upload/re-OCR endpointid + nende ops-importid elavad nüüd routerites
 # (server/routers/upload.py, reocr.py). Paketi-tasandi re-eksport käib
 # server/__init__.py kaudu otse ops-moodulitest, seega main.py ei impordi neid.
 from .cache import get_cached_suggestions
-# get_sorted_images on jätkuvalt kasutusel download endpointides; lehekülgede
-# halduse endpointid + nende ops-importid elavad nüüd server/routers/pages.py-s.
-from .admin_page_ops import get_sorted_images
 from .prosopography.router import router as prosopography_router
 from .routers.notifications import router as notifications_router
 from .routers.upload import router as upload_router
@@ -38,10 +32,11 @@ from .routers.auth import router as auth_router
 from .routers.admin import router as admin_router
 from .routers.user_settings import router as user_settings_router
 from .routers.public_registries import router as public_registries_router
+from .routers.public import router as public_router
 from .routers.collections import router as collections_router
 from .prosopography.ops import update_page_person_mentions, rebuild_indices, _load_index
 from .metadata_ops import save_work_metadata, bulk_update_field, ALLOWED_METADATA_FIELDS
-from .cache_invalidation import _sitemap_cache, invalidate_all_caches as _invalidate_all_caches
+from .cache_invalidation import invalidate_all_caches as _invalidate_all_caches
 from .marginalia_normalize import normalize_marginalia_tags
 
 @asynccontextmanager
@@ -73,6 +68,7 @@ app.include_router(auth_router)
 app.include_router(admin_router)
 app.include_router(user_settings_router)
 app.include_router(public_registries_router)
+app.include_router(public_router)
 app.include_router(collections_router)
 
 app.add_middleware(
@@ -95,11 +91,9 @@ app.add_middleware(
 # docs/REFACTOR_main_py_2026-06-25.md). Siin jäetakse backward-compat
 # re-eksport, sest osa main.py endpointe ja teste viitab neile nimedele.
 from .deps import get_user, require_role, get_json_data
-from .deps import optional_user as _get_optional_user
 
 # Teose _metadata.json lugemine (ühine — server/work_meta.py). Kasutatakse
 # viewer-token, shareable, download, SEO meta ja collections ligipääsukontrollis.
-from .work_meta import load_work_metadata as _load_work_metadata
 from .work_meta import read_work_meta_direct_sync as _read_work_meta_direct_sync
 
 # =========================================================
@@ -410,243 +404,6 @@ async def bulk_genre(request: Request, background_tasks: BackgroundTasks, user=D
 # =========================================================
 # AVALIKUD ANDMED JA SEO
 # =========================================================
-
-@app.post("/work/{work_id}/shareable")
-async def toggle_shareable(work_id: str, request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("editor"))):
-    """Seab teose shareable lipu. Body: {shareable: bool}. Nähtav editorile ja adminile."""
-    body = await request.json()
-    shareable = bool(body.get("shareable", False))
-
-    folder = find_directory_by_id(work_id)
-    if not folder:
-        return {"status": "error", "message": "Teos ei leitud"}
-
-    meta_path = os.path.join(folder, '_metadata.json')
-    # Kirjutamisõiguse kontroll praeguse (toggle-eelse) seisu põhjal (Leid G).
-    if os.path.exists(meta_path):
-        try:
-            with open(meta_path, 'r', encoding='utf-8') as f:
-                _cur_meta = json.load(f)
-        except Exception:
-            _cur_meta = None
-        if _cur_meta is not None and not can_write_work(_cur_meta, user):
-            raise HTTPException(status_code=403, detail="Puudub õigus selle teose jagamist muuta")
-    slug = os.path.basename(folder)
-    save_work_metadata(
-        meta_path,
-        {"shareable": shareable},
-        user["username"],
-        f"{'Aktiveeri' if shareable else 'Deaktiveeri'} jagamine: {slug}",
-        background_tasks=background_tasks,
-        sync_meili=True,
-        call_ptw=False,
-    )
-    return {"status": "success", "shareable": shareable}
-
-
-@app.get("/work/{work_id}/viewer-token")
-async def get_viewer_token(work_id: str, request: Request):
-    """Tagastab Meilisearch tokeni + pildi HMAC andmed juurdepääsuks ühele teosele.
-    Kasutatakse shareable ja restricted teoste otselinkide jaoks."""
-    import hashlib as _hashlib
-    import hmac as _hmac
-    import time as _time
-    from .meilisearch_ops import generate_work_scoped_meili_token
-    from .config import IMAGE_TOKEN_SECRET
-    meta = _load_work_metadata(work_id)
-    if meta is None:
-        raise HTTPException(status_code=404, detail="Teost ei leitud")
-    user = _get_optional_user(request)
-    if not can_read_work(meta, user):
-        raise HTTPException(status_code=403, detail="Ligipääs keelatud")
-    meili_token = generate_work_scoped_meili_token(work_id)
-    image_exp = int(_time.time()) + 3600
-    image_sig = _hmac.new(
-        IMAGE_TOKEN_SECRET.encode(),
-        f"image:{work_id}:{image_exp}".encode(),
-        _hashlib.sha256,
-    ).hexdigest()
-    return {"token": meili_token, "image_exp": image_exp, "image_sig": image_sig}
-
-
-@app.get("/download/{work_id}")
-async def download_work(request: Request, work_id: str, content: str = "both"):
-    """Laeb alla teose failid.
-    content:
-      'text'   → üks kokku liidetud .txt fail (sequence järjekorras)
-      'images' → ZIP kõigi piltidega
-      'both'   → ZIP piltide + kokku liidetud tekstifailiga
-    """
-    import zipfile
-
-    client_ip = get_client_ip(request)
-    allowed, retry_after = check_rate_limit(client_ip, '/download')
-    if not allowed:
-        raise HTTPException(status_code=429, detail=f"Liiga palju päringuid. Proovi uuesti {retry_after}s pärast.")
-
-    folder = find_directory_by_id(work_id)
-    if not folder:
-        raise HTTPException(status_code=404, detail="Teos ei leitud")
-
-    # Ligipääsukontroll
-    meta_for_access = _load_work_metadata(work_id)
-    if meta_for_access is not None:
-        user = _get_optional_user(request)
-        if not can_read_work(meta_for_access, user):
-            raise HTTPException(status_code=403, detail="Ligipääs keelatud")
-
-    slug = os.path.basename(folder)
-
-    # Loe metaandmed päise jaoks (tekst) ja failinimeks kasutame slug-i otse
-    meta_path = os.path.join(folder, '_metadata.json')
-    title = slug
-    author = ''
-    year = ''
-    try:
-        with open(meta_path, 'r', encoding='utf-8') as f:
-            meta = json.load(f)
-        title = meta.get('title', slug)
-        year = str(meta.get('year', ''))
-        creators = meta.get('creators', [])
-        if creators:
-            author = creators[0].get('name', '') if isinstance(creators[0], dict) else str(creators[0])
-    except Exception:
-        pass
-
-    # Failinimeks: slug eesliitega aastaarv kui see seal juba pole
-    file_slug = slug if (not year or slug.startswith(year)) else f"{year}-{slug}"
-
-    # Sequence järgi sorteeritud pildid
-    sorted_images = get_sorted_images(folder)
-
-    if content == 'text':
-        import re
-        def _strip_tags(text: str) -> str:
-            """Eemaldab XML/HTML tagid tekstist."""
-            return re.sub(r'<[^>]+>', '', text)
-
-        def _build_full_text() -> str:
-            """Koostab kokku liidetud tekstifaili sisu (tagideta)."""
-            parts = [title]
-            if author: parts.append(f'\n{author}')
-            if year: parts.append(f', {year}')
-            parts.append('\n\n')
-            for i, img_fname in enumerate(sorted_images, start=1):
-                base = os.path.splitext(img_fname)[0]
-                txt_path = os.path.join(folder, base + '.txt')
-                if os.path.exists(txt_path):
-                    parts.append(f'---- lk {i} ----\n')
-                    with open(txt_path, 'r', encoding='utf-8') as f:
-                        parts.append(_strip_tags(f.read()))
-                    parts.append('\n')
-            return ''.join(parts)
-            
-        buf = _build_full_text().encode('utf-8')
-        return StreamingResponse(
-            iter([buf]),
-            media_type="text/plain; charset=utf-8",
-            headers={"Content-Disposition": f'attachment; filename="{file_slug}.txt"'}
-        )
-
-    # ZIP (images või both) — failid nimetatud {file_slug}_pg_NNN.ext sequence järjekorras
-    import tempfile
-
-    tmp = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
-    try:
-        with zipfile.ZipFile(tmp, 'w', zipfile.ZIP_DEFLATED) as zf:
-            if os.path.exists(meta_path):
-                zf.write(meta_path, f"{file_slug}/_metadata.json")
-
-            for i, img_fname in enumerate(sorted_images, start=1):
-                base = os.path.splitext(img_fname)[0]
-                ext = img_fname.rsplit('.', 1)[-1].lower()
-
-                # Lisa pilt
-                img_path = os.path.join(folder, img_fname)
-                if os.path.isfile(img_path):
-                    zf.write(img_path, f"{file_slug}/{file_slug}_pg_{i:03d}.{ext}")
-
-                # Lisa tekst eraldi failina (ainult 'both' puhul)
-                if content == 'both':
-                    txt_path = os.path.join(folder, base + '.txt')
-                    if os.path.exists(txt_path):
-                        zf.write(txt_path, f"{file_slug}/{file_slug}_pg_{i:03d}.txt")
-
-        tmp.seek(0)
-
-        def _stream_and_cleanup():
-            try:
-                with open(tmp.name, 'rb') as f:
-                    while chunk := f.read(65536):
-                        yield chunk
-            finally:
-                try:
-                    os.unlink(tmp.name)
-                except OSError:
-                    pass
-
-        return StreamingResponse(
-            _stream_and_cleanup(),
-            media_type="application/zip",
-            headers={"Content-Disposition": f'attachment; filename="{file_slug}.zip"'}
-        )
-    except Exception:
-        try:
-            os.unlink(tmp.name)
-        except OSError:
-            pass
-        raise
-
-@app.get("/meta/persons")
-async def persons_meta(request: Request):
-    client_ip = get_client_ip(request)
-    allowed, retry_after = check_rate_limit(client_ip, '/meta/persons')
-    if not allowed:
-        return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"}, headers={"Retry-After": str(retry_after)})
-    return HTMLResponse(content=build_persons_meta_html())
-
-
-@app.get("/meta/person/{person_id:path}")
-async def person_meta(person_id: str, request: Request):
-    client_ip = get_client_ip(request)
-    allowed, retry_after = check_rate_limit(client_ip, '/meta/person')
-    if not allowed:
-        return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"}, headers={"Retry-After": str(retry_after)})
-    html = build_person_meta_html(person_id)
-    if html is None:
-        return HTMLResponse(content="<html><body>Isikut ei leitud</body></html>", status_code=404)
-    return HTMLResponse(content=html)
-
-
-@app.get("/meta/work/{work_id}")
-async def work_meta(work_id: str, request: Request):
-    client_ip = get_client_ip(request)
-    allowed, retry_after = check_rate_limit(client_ip, '/meta/work')
-    if not allowed:
-        return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"}, headers={"Retry-After": str(retry_after)})
-    meta = _load_work_metadata(work_id)
-    if meta is not None:
-        user = _get_optional_user(request)
-        if not can_read_work(meta, user):
-            return HTMLResponse(content="<html><body>Ligipääs keelatud</body></html>", status_code=403)
-    return HTMLResponse(content=build_meta_html(work_id))
-
-@app.get("/sitemap.xml")
-async def sitemap_xml():
-    import time
-    from . import utils as utils_module
-    now = time.time()
-    if _sitemap_cache["xml"] is None or now > _sitemap_cache["expires"]:
-        person_index = _load_index()
-        _sitemap_cache["xml"] = build_sitemap_xml(
-            dict(utils_module.WORK_ID_CACHE),
-            is_work_public,
-            _load_work_metadata,
-            person_index.get("entries", []),
-        )
-        _sitemap_cache["expires"] = now + 3600
-    return Response(content=_sitemap_cache["xml"], media_type="application/xml")
-
 
 @app.get("/health")
 async def health(): return {"status": "ok"}

--- a/server/routers/public.py
+++ b/server/routers/public.py
@@ -1,0 +1,259 @@
+import json
+import os
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
+
+from ..access_ops import can_read_work, can_write_work, is_work_public
+from ..admin_page_ops import get_sorted_images
+from ..cache_invalidation import _sitemap_cache
+from ..config import BASE_DIR
+from ..deps import optional_user as _get_optional_user, require_role
+from ..metadata_handler import build_meta_html, build_person_meta_html, build_persons_meta_html, build_sitemap_xml
+from ..metadata_ops import save_work_metadata
+from ..prosopography.ops import _load_index
+from ..rate_limit import check_rate_limit, get_client_ip
+from ..utils import find_directory_by_id
+from ..work_meta import load_work_metadata as _load_work_metadata
+
+router = APIRouter()
+
+
+@router.post("/work/{work_id}/shareable")
+async def toggle_shareable(work_id: str, request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("editor"))):
+    """Seab teose shareable lipu. Body: {shareable: bool}. Nähtav editorile ja adminile."""
+    body = await request.json()
+    shareable = bool(body.get("shareable", False))
+
+    folder = find_directory_by_id(work_id)
+    if not folder:
+        return {"status": "error", "message": "Teos ei leitud"}
+
+    meta_path = os.path.join(folder, '_metadata.json')
+    # Kirjutamisõiguse kontroll praeguse (toggle-eelse) seisu põhjal (Leid G).
+    if os.path.exists(meta_path):
+        try:
+            with open(meta_path, 'r', encoding='utf-8') as f:
+                _cur_meta = json.load(f)
+        except Exception:
+            _cur_meta = None
+        if _cur_meta is not None and not can_write_work(_cur_meta, user):
+            raise HTTPException(status_code=403, detail="Puudub õigus selle teose jagamist muuta")
+    slug = os.path.basename(folder)
+    save_work_metadata(
+        meta_path,
+        {"shareable": shareable},
+        user["username"],
+        f"{'Aktiveeri' if shareable else 'Deaktiveeri'} jagamine: {slug}",
+        background_tasks=background_tasks,
+        sync_meili=True,
+        call_ptw=False,
+    )
+    return {"status": "success", "shareable": shareable}
+
+
+@router.get("/work/{work_id}/viewer-token")
+async def get_viewer_token(work_id: str, request: Request):
+    """Tagastab Meilisearch tokeni + pildi HMAC andmed juurdepääsuks ühele teosele.
+    Kasutatakse shareable ja restricted teoste otselinkide jaoks."""
+    import hashlib as _hashlib
+    import hmac as _hmac
+    import time as _time
+    from ..config import IMAGE_TOKEN_SECRET
+    from ..meilisearch_ops import generate_work_scoped_meili_token
+    
+    meta = _load_work_metadata(work_id)
+    if meta is None:
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    user = _get_optional_user(request)
+    if not can_read_work(meta, user):
+        raise HTTPException(status_code=403, detail="Ligipääs keelatud")
+    meili_token = generate_work_scoped_meili_token(work_id)
+    image_exp = int(_time.time()) + 3600
+    image_sig = _hmac.new(
+        IMAGE_TOKEN_SECRET.encode(),
+        f"image:{work_id}:{image_exp}".encode(),
+        _hashlib.sha256,
+    ).hexdigest()
+    return {"token": meili_token, "image_exp": image_exp, "image_sig": image_sig}
+
+
+@router.get("/download/{work_id}")
+async def download_work(request: Request, work_id: str, content: str = "both"):
+    """Laeb alla teose failid.
+    content:
+      'text'   → üks kokku liidetud .txt fail (sequence järjekorras)
+      'images' → ZIP kõigi piltidega
+      'both'   → ZIP piltide + kokku liidetud tekstifailiga
+    """
+    import zipfile
+
+    client_ip = get_client_ip(request)
+    allowed, retry_after = check_rate_limit(client_ip, '/download')
+    if not allowed:
+        raise HTTPException(status_code=429, detail=f"Liiga palju päringuid. Proovi uuesti {retry_after}s pärast.")
+
+    folder = find_directory_by_id(work_id)
+    if not folder:
+        raise HTTPException(status_code=404, detail="Teos ei leitud")
+
+    # Ligipääsukontroll
+    meta_for_access = _load_work_metadata(work_id)
+    if meta_for_access is not None:
+        user = _get_optional_user(request)
+        if not can_read_work(meta_for_access, user):
+            raise HTTPException(status_code=403, detail="Ligipääs keelatud")
+
+    slug = os.path.basename(folder)
+
+    # Loe metaandmed päise jaoks (tekst) ja failinimeks kasutame slug-i otse
+    meta_path = os.path.join(folder, '_metadata.json')
+    title = slug
+    author = ''
+    year = ''
+    try:
+        with open(meta_path, 'r', encoding='utf-8') as f:
+            meta = json.load(f)
+        title = meta.get('title', slug)
+        year = str(meta.get('year', ''))
+        creators = meta.get('creators', [])
+        if creators:
+            author = creators[0].get('name', '') if isinstance(creators[0], dict) else str(creators[0])
+    except Exception:
+        pass
+
+    # Failinimeks: slug eesliitega aastaarv kui see seal juba pole
+    file_slug = slug if (not year or slug.startswith(year)) else f"{year}-{slug}"
+
+    # Sequence järgi sorteeritud pildid
+    sorted_images = get_sorted_images(folder)
+
+    if content == 'text':
+        import re
+        def _strip_tags(text: str) -> str:
+            """Eemaldab XML/HTML tagid tekstist."""
+            return re.sub(r'<[^>]+>', '', text)
+
+        def _build_full_text() -> str:
+            """Koostab kokku liidetud tekstifaili sisu (tagideta)."""
+            parts = [title]
+            if author: parts.append(f'\n{author}')
+            if year: parts.append(f', {year}')
+            parts.append('\n\n')
+            for i, img_fname in enumerate(sorted_images, start=1):
+                base = os.path.splitext(img_fname)[0]
+                txt_path = os.path.join(folder, base + '.txt')
+                if os.path.exists(txt_path):
+                    parts.append(f'---- lk {i} ----\n')
+                    with open(txt_path, 'r', encoding='utf-8') as f:
+                        parts.append(_strip_tags(f.read()))
+                    parts.append('\n')
+            return ''.join(parts)
+            
+        buf = _build_full_text().encode('utf-8')
+        return StreamingResponse(
+            iter([buf]),
+            media_type="text/plain; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{file_slug}.txt"'}
+        )
+
+    # ZIP (images või both) — failid nimetatud {file_slug}_pg_NNN.ext sequence järjekorras
+    import tempfile
+
+    tmp = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
+    try:
+        with zipfile.ZipFile(tmp, 'w', zipfile.ZIP_DEFLATED) as zf:
+            if os.path.exists(meta_path):
+                zf.write(meta_path, f"{file_slug}/_metadata.json")
+
+            for i, img_fname in enumerate(sorted_images, start=1):
+                base = os.path.splitext(img_fname)[0]
+                ext = img_fname.rsplit('.', 1)[-1].lower()
+
+                # Lisa pilt
+                img_path = os.path.join(folder, img_fname)
+                if os.path.isfile(img_path):
+                    zf.write(img_path, f"{file_slug}/{file_slug}_pg_{i:03d}.{ext}")
+
+                # Lisa tekst eraldi failina (ainult 'both' puhul)
+                if content == 'both':
+                    txt_path = os.path.join(folder, base + '.txt')
+                    if os.path.exists(txt_path):
+                        zf.write(txt_path, f"{file_slug}/{file_slug}_pg_{i:03d}.txt")
+
+        tmp.seek(0)
+
+        def _stream_and_cleanup():
+            try:
+                with open(tmp.name, 'rb') as f:
+                    while chunk := f.read(65536):
+                        yield chunk
+            finally:
+                try:
+                    os.unlink(tmp.name)
+                except OSError:
+                    pass
+
+        return StreamingResponse(
+            _stream_and_cleanup(),
+            media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="{file_slug}.zip"'}
+        )
+    except Exception:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+        raise
+
+@router.get("/meta/persons")
+async def persons_meta(request: Request):
+    client_ip = get_client_ip(request)
+    allowed, retry_after = check_rate_limit(client_ip, '/meta/persons')
+    if not allowed:
+        return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"}, headers={"Retry-After": str(retry_after)})
+    return HTMLResponse(content=build_persons_meta_html())
+
+
+@router.get("/meta/person/{person_id:path}")
+async def person_meta(person_id: str, request: Request):
+    client_ip = get_client_ip(request)
+    allowed, retry_after = check_rate_limit(client_ip, '/meta/person')
+    if not allowed:
+        return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"}, headers={"Retry-After": str(retry_after)})
+    html = build_person_meta_html(person_id)
+    if html is None:
+        return HTMLResponse(content="<html><body>Isikut ei leitud</body></html>", status_code=404)
+    return HTMLResponse(content=html)
+
+
+@router.get("/meta/work/{work_id}")
+async def work_meta(work_id: str, request: Request):
+    client_ip = get_client_ip(request)
+    allowed, retry_after = check_rate_limit(client_ip, '/meta/work')
+    if not allowed:
+        return JSONResponse(status_code=429, content={"status": "error", "message": f"Proovi uuesti {retry_after}s pärast"}, headers={"Retry-After": str(retry_after)})
+    meta = _load_work_metadata(work_id)
+    if meta is not None:
+        user = _get_optional_user(request)
+        if not can_read_work(meta, user):
+            return HTMLResponse(content="<html><body>Ligipääs keelatud</body></html>", status_code=403)
+    return HTMLResponse(content=build_meta_html(work_id))
+
+@router.get("/sitemap.xml")
+async def sitemap_xml():
+    import time
+    from .. import utils as utils_module
+    now = time.time()
+    if _sitemap_cache["xml"] is None or now > _sitemap_cache["expires"]:
+        person_index = _load_index()
+        _sitemap_cache["xml"] = build_sitemap_xml(
+            dict(utils_module.WORK_ID_CACHE),
+            is_work_public,
+            _load_work_metadata,
+            person_index.get("entries", []),
+        )
+        _sitemap_cache["expires"] = now + 3600
+    return Response(content=_sitemap_cache["xml"], media_type="application/xml")
+
+

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -62,26 +62,24 @@ def test_meta_work_rate_limit_returns_retry_after(backend_env, monkeypatch):
 
 def test_sitemap_uses_snapshot_not_live_cache(monkeypatch):
     """sitemap_xml endpoint kasutab dict snapshot'i, mitte otseviita WORK_ID_CACHE-le."""
-    import importlib
-    import server.main as main_mod
+    from server.routers import public as public_router
     import server.utils as utils_mod
 
     captured_args = []
 
-    original = main_mod.build_sitemap_xml
+    original = public_router.build_sitemap_xml
 
     def capturing_build(cache, *args, **kwargs):
         captured_args.append(cache)
         return original(cache, *args, **kwargs)
 
-    monkeypatch.setattr(main_mod, "build_sitemap_xml", capturing_build)
-    monkeypatch.setattr(main_mod, "_sitemap_cache", {"xml": None, "expires": 0.0})
+    monkeypatch.setattr(public_router, "build_sitemap_xml", capturing_build)
+    monkeypatch.setattr(public_router, "_sitemap_cache", {"xml": None, "expires": 0.0})
 
-    original_cache = utils_mod.WORK_ID_CACHE
     monkeypatch.setattr(utils_mod, "WORK_ID_CACHE", {"w1": "/data/w1", "w2": "/data/w2"})
 
     import asyncio
-    asyncio.run(main_mod.sitemap_xml())
+    asyncio.run(public_router.sitemap_xml())
 
     assert captured_args, "build_sitemap_xml ei kutsutud"
     passed_cache = captured_args[0]

--- a/tests/test_viewer_token.py
+++ b/tests/test_viewer_token.py
@@ -42,13 +42,13 @@ def env(backend_env, monkeypatch):
 
 
 def set_work(monkeypatch, meta):
-    import server.main as main
-    monkeypatch.setattr(main, "_load_work_metadata", lambda work_id: meta if meta.get("work_id") == work_id else None)
+    from server.routers import public as public_router
+    monkeypatch.setattr(public_router, "_load_work_metadata", lambda work_id: meta if meta.get("work_id") == work_id else None)
 
 
 def test_viewer_token_404_unknown_work(env, monkeypatch):
-    import server.main as main
-    monkeypatch.setattr(main, "_load_work_metadata", lambda work_id: None)
+    from server.routers import public as public_router
+    monkeypatch.setattr(public_router, "_load_work_metadata", lambda work_id: None)
 
     r = env["client"].get("/work/unknown/viewer-token")
     assert r.status_code == 404


### PR DESCRIPTION
## Kokkuvõte
- tõstab public access + SEO endpointid `server/routers/public.py` alla
- registreerib `public_router` `server/main.py`-s
- eemaldab `main.py`-st vastava endpointide ploki ja surnud importid
- uuendab viewer-token ja sitemap teste uuele router-moodulile

## Tõstetud route'id
- `POST /work/{work_id}/shareable`
- `GET /work/{work_id}/viewer-token`
- `GET /download/{work_id}`
- `GET /meta/persons`
- `GET /meta/person/{person_id:path}`
- `GET /meta/work/{work_id}`
- `GET /sitemap.xml`

## Kontroll
- `./.venv/bin/python -m pytest -q tests/ --maxfail=1` → 637 passed
- kontrollitud: 7 public/SEO route'i, duplikaate pole

Osa issue #36 Faas 6-st.
