### PR TITLE
Paranda upload resume crash: year-number .trim() viga

### DIFF
--- a/src/components/MetadataModal.tsx
+++ b/src/components/MetadataModal.tsx
@@ -149,7 +149,7 @@ export const CollectionDropdown: React.FC<CollectionDropdownProps> = ({ collecti
  */
 export const YearInputPreview: React.FC<{ value: string; existing?: YearFieldsExisting }> = ({ value, existing }) => {
   const { t } = useTranslation(['workspace', 'common']);
-  const trimmed = (value ?? '').trim();
+  const trimmed = String(value ?? '').trim();  // value võib olla number (resume) — String() väldib crashi
   if (!trimmed) return null;  // tühi → vaikne
 
   // Tuletame sama loogikaga mis salvestus (reegel 4: säilitatud year arvestab existing-it)

--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -702,7 +702,9 @@ const Upload: React.FC = () => {
   function handleResume(saved: SavedUpload) {
     setUploadId(saved.id);
     setTitle(saved.meta.title);
-    setYear(saved.meta.year);
+    // saved.meta.year võib backendist tulla numbrina, kuigi tüüp ütleb string
+    // — year-olek on alati string, muidu YearInputPreview .trim() crashib
+    setYear(saved.meta.year != null ? String(saved.meta.year) : '');
     setSlug(saved.meta.slug);
     setWorkType(saved.meta.type?.id === 'Q87167' ? TYPE_HAND : TYPE_PRINT);
     setSlugManual(true);


### PR DESCRIPTION
## Probleem

`/upload` lehel poolelioleva teose juurde minnes crashis vorm:
`(intermediate value).trim is not a function`.

## Juurpõhjus

`handleResume()` kutsus `setYear(saved.meta.year)`. Tüüp `SavedUpload.meta.year` ütleb `string`, aga backend serveerib `year`-i **numbrina**. Number jõudis `year`-oleku kaudu `YearInputPreview`-sse, kus `(value ?? '').trim()` crashis — `?? ''` ei asenda numbrit, sest see pole nullish.

## Parandus

- `Upload.tsx`: coerce `String()` `handleResume`-s (allikaparandus)
- `MetadataModal.tsx`: `YearInputPreview` `String(value ?? '')` (defense-in-depth — komponent on jagatud `MetadataModal` + `UploadMetaForm` vahel)

## Testitud

Serveris deploy'tud (`rsync dist/`) ja kinnitatud: viga kadunud, resume töötab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)