### PR TITLE
Tüüp SavedUpload.meta.year string | number

### DIFF
--- a/src/pages/Upload.tsx
+++ b/src/pages/Upload.tsx
@@ -54,7 +54,7 @@ interface PollResult {
 interface SavedUpload {
   id: string;
   status: string;
-  meta: { title: string; year: string; slug: string; type?: { id: string; label: string; source: string; labels?: Record<string, string> } };
+  meta: { title: string; year: string | number; slug: string; type?: { id: string; label: string; source: string; labels?: Record<string, string> } };
   created_at: string;
   expected_pages: number | null;
   files: FileEntry[];


### PR DESCRIPTION
Tüüp `SavedUpload.meta.year` oli `string`, kuigi backend serveerib `year`-i numbrina (vt PR #50 crash). Tüüp peegeldab nüüd reaalsust, et TS sunniks edaspidi coerce'ima.

Runtime-mõju puudub — `handleResume` juba kasutab `String()`. `npx tsc --noEmit` puhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)