### PR TITLE
Refaktoreeri save_and_transfer_to_ocr: eralda PDF/pildi harud

### DIFF
--- a/docs/superpowers/specs/2026-06-25-kleepuv-krpe-suurus-design.md
+++ b/docs/superpowers/specs/2026-06-25-kleepuv-krpe-suurus-design.md
@@ -1,0 +1,66 @@
+# Kleepuv kärpe-suurus (sticky crop size)
+
+**Kuupäev:** 2026-06-25
+**Fail:** `src/components/PageImageEditorModal.tsx`
+
+## Probleem
+
+Manage-lehe pildiredaktoris (`PageImageEditorModal`) kärbib admin järjestikuseid
+lehekülgi. Pärast kärpe rakendamist liigutakse automaatselt järgmisele lehele, kuid
+kärpekast lähtestatakse täielikult (`resetTransforms`). Järjestikused skännid on sageli
+sama suuruse ja paigutusega, seega oleks mugav, kui järgmisel lehel oleks kohe **sama
+suur** kärpekast ette antud — admin teaks lehte täpselt samale suurusele kärpida.
+
+## Lahendus
+
+Jäta meelde viimati kasutatud kärpekasti **suurus** (normaliseeritud, proportsionaalne).
+Iga uue lehe avamisel ilmub sama suur tühi kast pildi **keskele**, kalle nullitud.
+Kasutaja lohistab selle õigesse kohta ja vajadusel kallutab.
+
+**Otsused (kasutajaga kokku lepitud):**
+- Üle kantakse **ainult suurus** (mitte asukoht ega kalle). Kast ilmub keskele,
+  kasutaja lohistab ise õigesse kohta.
+- Toimub **kõigil lehevahetustel** — nii pärast "Rakenda" automaatset edasiliikumist
+  kui ka käsitsi ←/→ navigeerimisel.
+- Kalle (`boxAngle`, deskew) **alati nullitakse** — iga leht on erinevalt kaldu.
+
+## Muudatused (ainult `PageImageEditorModal.tsx`)
+
+1. **Uus ref** `lastCropSizeRef = useRef<{ w: number; h: number } | null>(null)` —
+   hoiab viimase kasti normaliseeritud mõõtu (`cropRect.w` / `cropRect.h`). Ref, mitte
+   state → ei tekita re-render'it ega püsi üle modaali sulgemise (iga seanss algab puhtalt).
+
+2. **Püüdmine:** `useEffect(…, [cropRect])` — kui `cropRect` on olemas, salvesta
+   `{ w: cropRect.w, h: cropRect.h }` ref'i. Suurus jääb meelde joonistamisel, suuruse
+   muutmisel ja rakendamisel.
+
+3. **Taastamine:** olemasolevas reset-effektis (`[current?.filename, cacheBust]`) pärast
+   `resetTransforms()` — kui `lastCropSizeRef.current` on olemas, sea tsentreeritud kast:
+   `{ x: (1 - w) / 2, y: (1 - h) / 2, w, h }`. `boxAngle` jääb 0 (resetTransforms nullis).
+   Esimesel avamisel on ref tühi → kasti ei teki (nagu praegu).
+
+4. **Selge "unustamine":** CircleX (kärpe-reset) nupp nullib lisaks `cropRect`/`boxAngle`-le
+   ka `lastCropSizeRef.current = null` → lõpetab kleepumise, järgmine leht algab puhtalt.
+
+## Mida tahtlikult EI tehta
+
+- Ei taastata kasti `grossAngle` (90/180) muutmisel — tahtlik per-leht tegevus, kast kustub.
+- Ei säilitata üle modaali sulgemise/avamise.
+- Ei säilitata asukohta ega kallet — ainult suurus.
+
+## Servajuhud
+
+- Pärast pildi asendust või poolitust uueneb `cacheBust` → kast taastub tsentreerituna
+  (kahjutu, kasutaja saab CircleX-iga eemaldada).
+- Viimasel lehel pärast "Rakenda" jääb index samaks, kuid `cacheBust` muutub → kast ilmub
+  uuesti tsentreerituna (kahjutu).
+- Taastatud kast teeb "Rakenda" nupu aktiivseks (`noEditChange` on false), kuid rakendamine
+  nõuab kinnitusdialoogi → kogemata kärpimise risk minimaalne.
+
+## Testimine
+
+Manuaalne (väike puhtalt-frontend muudatus, normaliseeritud geomeetria):
+1. Kärbi leht → Rakenda → kontrolli, et järgmisel lehel on sama suur kast keskel, kalleta.
+2. Liigu käsitsi ←/→ → sama suur kast ilmub.
+3. Vajuta CircleX → kast kaob, järgmine leht algab puhtalt.
+4. Esmaavamine: kasti ei ole enne esimest kärbet.

--- a/docs/superpowers/specs/2026-06-25-kleepuv-krpe-suurus-design.md
+++ b/docs/superpowers/specs/2026-06-25-kleepuv-krpe-suurus-design.md
@@ -34,13 +34,30 @@ Kasutaja lohistab selle õigesse kohta ja vajadusel kallutab.
    `{ w: cropRect.w, h: cropRect.h }` ref'i. Suurus jääb meelde joonistamisel, suuruse
    muutmisel ja rakendamisel.
 
-3. **Taastamine:** olemasolevas reset-effektis (`[current?.filename, cacheBust]`) pärast
-   `resetTransforms()` — kui `lastCropSizeRef.current` on olemas, sea tsentreeritud kast:
-   `{ x: (1 - w) / 2, y: (1 - h) / 2, w, h }`. `boxAngle` jääb 0 (resetTransforms nullis).
-   Esimesel avamisel on ref tühi → kasti ei teki (nagu praegu).
+3. **Taastamine:** olemasolevas reset-effektis (`[current?.filename, cacheBust]`) **kohe
+   pärast** `resetTransforms()` (samas efektis, et `boxAngle` jääks garanteeritult 0 ega
+   ükski vana nurga-olek taastuks):
+   ```
+   resetTransforms()
+   if (lastCropSizeRef.current) {
+     const w = Math.min(Math.max(lastCropSizeRef.current.w, 0.01), 0.98)
+     const h = Math.min(Math.max(lastCropSizeRef.current.h, 0.01), 0.98)
+     setCropRect({ x: (1 - w) / 2, y: (1 - h) / 2, w, h })
+   }
+   ```
+   **Clamp [0.01, 0.98]** kaitseb imeliku/vahepealse oleku eest — kast ei saa kogemata
+   üle ääre ulatuda. Esimesel avamisel on ref tühi → kasti ei teki (nagu praegu).
 
 4. **Selge "unustamine":** CircleX (kärpe-reset) nupp nullib lisaks `cropRect`/`boxAngle`-le
    ka `lastCropSizeRef.current = null` → lõpetab kleepumise, järgmine leht algab puhtalt.
+   Tooltip täpsustatakse (`cropReset` locale): "Eemalda kärpekast ja unusta viimati
+   kasutatud suurus" / "Remove crop box and forget last used size".
+
+**Märkus püüdmise semantika kohta:** `useEffect([cropRect])` salvestab iga `cropRect`
+muutuse peale. See on aktsepteeritav, sest joonistamise lõpetamine (`onCropUp`) viskab
+`MIN_DRAG_PX`-st väiksemad kastid ära (`setCropRect(null)`) → liiga väikest kogemata kasti
+ei salvestata. Suuruse muutmisel kirjutab viimane (lõplik) olek vahepealsed üle, seega
+navigeerimise hetkeks hoiab ref õiget lõppsuurust.
 
 ## Mida tahtlikult EI tehta
 
@@ -62,5 +79,7 @@ Kasutaja lohistab selle õigesse kohta ja vajadusel kallutab.
 Manuaalne (väike puhtalt-frontend muudatus, normaliseeritud geomeetria):
 1. Kärbi leht → Rakenda → kontrolli, et järgmisel lehel on sama suur kast keskel, kalleta.
 2. Liigu käsitsi ←/→ → sama suur kast ilmub.
-3. Vajuta CircleX → kast kaob, järgmine leht algab puhtalt.
-4. Esmaavamine: kasti ei ole enne esimest kärbet.
+3. **Muuda kärpekasti suurust lehel A, ÄRA rakenda, liigu käsitsi lehele B → lehel B
+   ilmub viimane suurus keskele** (kinnitab, et suurus jääb meelde ka ilma rakendamiseta).
+4. Vajuta CircleX → kast kaob, järgmine leht algab puhtalt.
+5. Esmaavamine: kasti ei ole enne esimest kärbet.

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -15,6 +15,7 @@ import subprocess
 import threading
 import unicodedata
 from datetime import datetime
+from typing import Optional
 
 # OCR-serveri SSH-connecti timeout (s). Hoiab event-loopi/threadi blokeerumast
 # minuteid, kui OCR-server on kättesaamatu (vt tests/test_upload_ssh_timeout.py).
@@ -462,7 +463,7 @@ def _safe_unlink(path: str):
         pass
 
 
-def _set_upload_state(upload_id: str, *, status: str = None, **extra):
+def _set_upload_state(upload_id: str, *, status: Optional[str] = None, **extra):
     """Uuendab state.json välju upload-i luku all (thread-turvaline).
 
     Kasutatakse taustalõimedes staatusemasina uuendamiseks:

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -443,125 +443,89 @@ def _detect_file_type(path: str) -> str:
     return 'unknown'
 
 
-def save_and_transfer_to_ocr(upload_id: str, tmp_path: str) -> int:
-    """
-    Edastab faili OCR serverisse SFTP kaudu.
+# =========================================================
+# SFTP TRANSFER (etapp 2): PDF/pildi edastamine OCR serverisse
+#
+# save_and_transfer_to_ocr dispatchib failitüübi järgi kahte haru:
+#   - pilt (JPEG/PNG/TIFF) → _prepare_image_upload + _sftp_transfer_image
+#   - PDF                  → _prepare_pdf_upload  + _sftp_transfer_pdf
+# Ühised helperid (_set_upload_state, _init_upload_progress, _sftp_progress_cb,
+# _ensure_remote_dirs, _close_sftp_and_unlink) jagavad state/progress ja SFTP
+# raamistikku, mida mõlemad taustalõimed kasutavad.
+# =========================================================
 
-    - PDF: pdfinfo → lehekülgede arv → staging kausta → OCR server lõhub ise lahti
-    - JPG/PNG: pannakse otse remote work kausta {slug}_pg_001.jpg nimega
-      (OCR server leiab pildi rglob-iga ja teeb OCR-i ilma PDF-i lahti lõhkumata)
+def _safe_unlink(path: str):
+    """Kustutab faili, ignoreerides vigu (ajutised failid, juba kustutatud)."""
+    try:
+        os.unlink(path)
+    except Exception:
+        pass
 
-    Tagastab expected_pages (int).
-    Tõstab ValueError kui fail on vigane või toetamata formaadis.
+
+def _set_upload_state(upload_id: str, *, status: str = None, **extra):
+    """Uuendab state.json välju upload-i luku all (thread-turvaline).
+
+    Kasutatakse taustalõimedes staatusemasina uuendamiseks:
+    edu → status='processing', viga → status='error' + error_message.
+    Kui state on vahepeal kadunud (import/kustutus), ei tee midagi (idempotentne).
     """
     state_lock = _get_upload_lock(upload_id)
     with state_lock:
-        state = _read_state(upload_id)
-    if not state:
-        raise ValueError(f"Upload {upload_id} ei leitud")
+        s = _read_state(upload_id)
+        if not s:
+            return
+        if status is not None:
+            s['status'] = status
+        for key, value in extra.items():
+            s[key] = value
+        _write_state(upload_id, s)
 
-    year = state['meta']['year']
-    slug = state['meta']['slug']
 
-    # --- Tuvasta faili tüüp ---
-    file_type = _detect_file_type(tmp_path)
+def _init_upload_progress(upload_id: str, tmp_path: str) -> int:
+    """Lähtestab mälupõhise SFTP progressi (bytes_total = faili suurus).
+    Tagastab faili suuruse baitides. Kutsutud sünkroonselt enne taustalõime
+    käivitamist."""
+    file_size = os.path.getsize(tmp_path)
+    upload_progress[upload_id] = {"bytes_sent": 0, "bytes_total": file_size, "error": None}
+    return file_size
 
-    if file_type in ('jpeg', 'png', 'tiff'):
-        # Pildi puhul: laadi otse remote work kausta, OCR server teeb ise üles
-        pages = 1
-        file_size = os.path.getsize(tmp_path)
-        upload_progress[upload_id] = {"bytes_sent": 0, "bytes_total": file_size, "error": None}
 
-        remote_staging_abs = f"{OCR_SERVER_PATH}/{state['remote_staging_path']}"
-        remote_work_abs = f"{OCR_SERVER_PATH}/{state['remote_work_path']}"
-        remote_img_name = f"{slug}_pg_001.jpg"
+def _sftp_progress_cb(upload_id: str):
+    """Loob SFTP put() callback'i, mis uuendab upload_progress mäludikti."""
+    def _progress(transferred, total):
+        upload_progress[upload_id]['bytes_sent'] = transferred
+        upload_progress[upload_id]['bytes_total'] = total
+    return _progress
 
-        with state_lock:
-            s = _read_state(upload_id)
-            s['expected_pages'] = pages
-            s['status'] = 'uploading'
-            _write_state(upload_id, s)
 
-        def _sftp_transfer_image():
-            sftp = None
-            try:
-                sftp = _sftp_open(upload_id)
-                # Loo staging + work kaustad
-                for remote_dir in (remote_staging_abs, remote_work_abs):
-                    try:
-                        sftp.stat(remote_dir)
-                    except FileNotFoundError:
-                        sftp.mkdir(remote_dir)
-
-                remote_tmp = f"{remote_work_abs}/{remote_img_name}.tmp"
-                remote_dst = f"{remote_work_abs}/{remote_img_name}"
-
-                def _progress(transferred, total):
-                    upload_progress[upload_id]['bytes_sent'] = transferred
-                    upload_progress[upload_id]['bytes_total'] = total
-
-                # Konverteeri JPEG-iks kui PNG või TIFF
-                if file_type in ('png', 'tiff'):
-                    from PIL import Image
-                    conv_path = tmp_path + '.conv.jpg'
-                    with Image.open(tmp_path) as img:
-                        img.convert('RGB').save(conv_path, 'JPEG', quality=95)
-                    sftp.put(conv_path, remote_tmp, callback=_progress)
-                    os.unlink(conv_path)
-                else:
-                    sftp.put(tmp_path, remote_tmp, callback=_progress)
-
-                # Kustuta sihtfail kui see juba eksisteerib (uuesti üleslaadimine)
-                try:
-                    sftp.stat(remote_dst)
-                    sftp.unlink(remote_dst)
-                except FileNotFoundError:
-                    pass
-                sftp.rename(remote_tmp, remote_dst)
-                logger.info(f"Pilt edastatud OCR serverisse: {upload_id} ({remote_img_name})")
-
-                with state_lock:
-                    s = _read_state(upload_id)
-                    if s:
-                        s['status'] = 'processing'
-                        _write_state(upload_id, s)
-
-            except Exception as e:
-                logger.error(f"SFTP pilt {upload_id}: {e}")
-                upload_progress[upload_id]['error'] = str(e)
-                with state_lock:
-                    s = _read_state(upload_id)
-                    if s:
-                        s['status'] = 'error'
-                        s['error_message'] = str(e)
-                        _write_state(upload_id, s)
-            finally:
-                if sftp:
-                    try:
-                        sftp.close()
-                    except Exception:
-                        pass
-                try:
-                    os.unlink(tmp_path)
-                except Exception:
-                    pass
-
-        thread = threading.Thread(target=_sftp_transfer_image, daemon=True, name=f"sftp-img-{upload_id}")
-        thread.start()
-        return pages
-
-    elif file_type == 'unknown':
+def _ensure_remote_dirs(sftp, remote_dirs):
+    """Loob OCR-serveri kaustad kui need puuduvad (idempotentne)."""
+    for remote_dir in remote_dirs:
         try:
-            os.unlink(tmp_path)
+            sftp.stat(remote_dir)
+        except FileNotFoundError:
+            sftp.mkdir(remote_dir)
+
+
+def _close_sftp_and_unlink(sftp, tmp_path: str):
+    """Taustalõime finally-puhastus: sulge SFTP seanss ja kustuta ajutine fail."""
+    if sftp:
+        try:
+            sftp.close()
         except Exception:
             pass
-        raise ValueError(
-            "Toetamata failivorming. Palun laadi üles PDF, JPG, PNG või TIFF fail."
-        )
+    _safe_unlink(tmp_path)
 
-    # file_type == 'pdf' → tavapärane PDF flow allpool
 
-    # --- Loe lehekülgede arv pdfinfo abil ---
+def _count_pdf_pages(tmp_path: str) -> int:
+    """Loeb PDF-i lehekülgede arvu pdfinfo abil.
+
+    Tõstab ValueError kui:
+      - PDF on vigane (pdfinfo viga) — tmp_path kustutatakse;
+      - lehekülgede arvu ei leidu pdfinfo väljundist;
+      - pdfinfo pole paigaldatud (FileNotFoundError);
+      - pdfinfo aegub (TimeoutExpired).
+    """
     try:
         result = subprocess.run(
             ['pdfinfo', tmp_path],
@@ -569,10 +533,7 @@ def save_and_transfer_to_ocr(upload_id: str, tmp_path: str) -> int:
         )
         if result.returncode != 0:
             logger.error(f"pdfinfo viga: {result.stderr}")
-            try:
-                os.unlink(tmp_path)
-            except Exception:
-                pass
+            _safe_unlink(tmp_path)
             raise ValueError(
                 f"Vigane PDF — fail ei ole korrektne PDF-dokument (pdfinfo viga). "
                 f"Kontrolli, et laadid üles õige faili."
@@ -586,79 +547,159 @@ def save_and_transfer_to_ocr(upload_id: str, tmp_path: str) -> int:
         if pages is None:
             logger.error(f"pdfinfo väljundis puudus 'Pages:': {result.stdout}")
             raise ValueError("PDF lehekülgede arvu ei õnnestunud tuvastada")
+        return pages
 
     except FileNotFoundError:
         raise ValueError("pdfinfo pole paigaldatud (apt install poppler-utils)")
     except subprocess.TimeoutExpired:
         raise ValueError("PDF analüüs võttis liiga kaua — fail on liiga suur või kahjustatud")
 
-    # --- Uuenda state.json ja progress ---
-    file_size = os.path.getsize(tmp_path)
-    upload_progress[upload_id] = {"bytes_sent": 0, "bytes_total": file_size, "error": None}
 
-    with state_lock:
-        state = _read_state(upload_id)
-        state['expected_pages'] = pages
-        state['status'] = 'uploading'
-        _write_state(upload_id, state)
+def _prepare_image_upload(state: dict) -> tuple:
+    """Arvutab pildi-upload'i (alati 1 leht) remote teed.
 
-    # Remote teed (OCR_SERVER_PATH on absoluutne tee OCR serveris)
+    Tagastab: (pages, remote_dirs, remote_tmp, remote_dst, remote_img_name).
+    """
+    slug = state['meta']['slug']
     remote_staging_abs = f"{OCR_SERVER_PATH}/{state['remote_staging_path']}"
-    remote_pdf_name = f"{slug}.pdf"
-    remote_pdf_tmp_name = f"{slug}.pdf.tmp"
+    remote_work_abs = f"{OCR_SERVER_PATH}/{state['remote_work_path']}"
+    remote_img_name = f"{slug}_pg_001.jpg"
+    remote_tmp = f"{remote_work_abs}/{remote_img_name}.tmp"
+    remote_dst = f"{remote_work_abs}/{remote_img_name}"
+    remote_dirs = (remote_staging_abs, remote_work_abs)
+    return 1, remote_dirs, remote_tmp, remote_dst, remote_img_name
 
-    # --- Daemon thread SFTP edastuseks ---
-    def _sftp_transfer():
-        sftp = None
+
+def _prepare_pdf_upload(state: dict, tmp_path: str) -> tuple:
+    """Arvutab PDF-upload'i remote teed (pärast pdfinfo lehekülgede loendust).
+
+    Tagastab: (pages, remote_dirs, remote_tmp, remote_dst).
+    """
+    pages = _count_pdf_pages(tmp_path)
+    slug = state['meta']['slug']
+    remote_staging_abs = f"{OCR_SERVER_PATH}/{state['remote_staging_path']}"
+    remote_tmp = f"{remote_staging_abs}/{slug}.pdf.tmp"
+    remote_dst = f"{remote_staging_abs}/{slug}.pdf"
+    remote_dirs = (remote_staging_abs,)
+    return pages, remote_dirs, remote_tmp, remote_dst
+
+
+def _sftp_transfer_image(upload_id: str, tmp_path: str, file_type: str,
+                          remote_dirs, remote_tmp: str, remote_dst: str,
+                          remote_img_name: str):
+    """Taustalõime sihtfunktsioon: edastab üksiku pildi OCR-serverisse.
+
+    PNG/TIFF konvertitakse Pillow'ga JPEG-iks; sihtfail eemaldatakse kui see
+    juba eksisteerib (uuesti üleslaadimine). Edukorral state → 'processing',
+    veakorral state → 'error' + error_message.
+    """
+    sftp = None
+    try:
+        sftp = _sftp_open(upload_id)
+        _ensure_remote_dirs(sftp, remote_dirs)
+
+        # Konverteeri JPEG-iks kui PNG või TIFF
+        if file_type in ('png', 'tiff'):
+            from PIL import Image
+            conv_path = tmp_path + '.conv.jpg'
+            with Image.open(tmp_path) as img:
+                img.convert('RGB').save(conv_path, 'JPEG', quality=95)
+            sftp.put(conv_path, remote_tmp, callback=_sftp_progress_cb(upload_id))
+            os.unlink(conv_path)
+        else:
+            sftp.put(tmp_path, remote_tmp, callback=_sftp_progress_cb(upload_id))
+
+        # Kustuta sihtfail kui see juba eksisteerib (uuesti üleslaadimine)
         try:
-            sftp = _sftp_open(upload_id)
+            sftp.stat(remote_dst)
+            sftp.unlink(remote_dst)
+        except FileNotFoundError:
+            pass
+        sftp.rename(remote_tmp, remote_dst)
+        logger.info(f"Pilt edastatud OCR serverisse: {upload_id} ({remote_img_name})")
 
-            # Loo staging kaust OCR serveris
-            try:
-                sftp.stat(remote_staging_abs)
-            except FileNotFoundError:
-                sftp.mkdir(remote_staging_abs)
+        _set_upload_state(upload_id, status='processing')
 
-            remote_tmp = f"{remote_staging_abs}/{remote_pdf_tmp_name}"
-            remote_pdf = f"{remote_staging_abs}/{remote_pdf_name}"
+    except Exception as e:
+        logger.error(f"SFTP pilt {upload_id}: {e}")
+        upload_progress[upload_id]['error'] = str(e)
+        _set_upload_state(upload_id, status='error', error_message=str(e))
+    finally:
+        _close_sftp_and_unlink(sftp, tmp_path)
 
-            def _progress(transferred, total):
-                upload_progress[upload_id]['bytes_sent'] = transferred
-                upload_progress[upload_id]['bytes_total'] = total
 
-            sftp.put(tmp_path, remote_tmp, callback=_progress)
-            sftp.rename(remote_tmp, remote_pdf)
+def _sftp_transfer_pdf(upload_id: str, tmp_path: str,
+                        remote_dirs, remote_tmp: str, remote_dst: str,
+                        pages: int, file_size: int):
+    """Taustalõime sihtfunktsioon: edastab PDF-i OCR-serverisse (OCR server
+    lõhub ise lehekülgedeks). Edukorral state → 'processing', veakorral
+    state → 'error' + error_message.
+    """
+    sftp = None
+    try:
+        sftp = _sftp_open(upload_id)
+        _ensure_remote_dirs(sftp, remote_dirs)
 
-            logger.info(f"SFTP upload valmis: {upload_id} ({pages} lk, {file_size} B)")
+        sftp.put(tmp_path, remote_tmp, callback=_sftp_progress_cb(upload_id))
+        sftp.rename(remote_tmp, remote_dst)
 
-            with state_lock:
-                s = _read_state(upload_id)
-                if s:
-                    s['status'] = 'processing'
-                    _write_state(upload_id, s)
+        logger.info(f"SFTP upload valmis: {upload_id} ({pages} lk, {file_size} B)")
 
-        except Exception as e:
-            logger.error(f"SFTP transfer {upload_id}: {e}")
-            upload_progress[upload_id]['error'] = str(e)
-            with state_lock:
-                s = _read_state(upload_id)
-                if s:
-                    s['status'] = 'error'
-                    s['error_message'] = str(e)
-                    _write_state(upload_id, s)
-        finally:
-            if sftp:
-                try:
-                    sftp.close()
-                except Exception:
-                    pass
-            try:
-                os.unlink(tmp_path)
-            except Exception:
-                pass
+        _set_upload_state(upload_id, status='processing')
 
-    thread = threading.Thread(target=_sftp_transfer, daemon=True, name=f"sftp-{upload_id}")
-    thread.start()
+    except Exception as e:
+        logger.error(f"SFTP transfer {upload_id}: {e}")
+        upload_progress[upload_id]['error'] = str(e)
+        _set_upload_state(upload_id, status='error', error_message=str(e))
+    finally:
+        _close_sftp_and_unlink(sftp, tmp_path)
+
+
+def save_and_transfer_to_ocr(upload_id: str, tmp_path: str) -> int:
+    """
+    Edastab faili OCR serverisse SFTP kaudu.
+
+    - PDF: pdfinfo → lehekülgede arv → staging kaust → OCR server lõhub ise lahti
+    - JPG/PNG: pannakse otse remote work kausta {slug}_pg_001.jpg nimega
+      (OCR server leiab pildi rglob-iga ja teeb OCR-i ilma PDF-i lahti lõhkumata)
+
+    Tagastab expected_pages (int).
+    Tõstab ValueError kui fail on vigane või toetamata formaadis.
+    """
+    with _get_upload_lock(upload_id):
+        state = _read_state(upload_id)
+    if not state:
+        raise ValueError(f"Upload {upload_id} ei leitud")
+
+    file_type = _detect_file_type(tmp_path)
+
+    if file_type in ('jpeg', 'png', 'tiff'):
+        # Pildi puhul: laadi otse remote work kausta, OCR server teeb ise üles
+        pages, remote_dirs, remote_tmp, remote_dst, remote_img_name = _prepare_image_upload(state)
+        _init_upload_progress(upload_id, tmp_path)
+        _set_upload_state(upload_id, status='uploading', expected_pages=pages)
+        threading.Thread(
+            target=_sftp_transfer_image,
+            args=(upload_id, tmp_path, file_type, remote_dirs, remote_tmp, remote_dst, remote_img_name),
+            daemon=True, name=f"sftp-img-{upload_id}",
+        ).start()
+        return pages
+
+    if file_type == 'unknown':
+        _safe_unlink(tmp_path)
+        raise ValueError(
+            "Toetamata failivorming. Palun laadi üles PDF, JPG, PNG või TIFF fail."
+        )
+
+    # file_type == 'pdf' → tavapärane PDF flow allpool
+    pages, remote_dirs, remote_tmp, remote_dst = _prepare_pdf_upload(state, tmp_path)
+    file_size = _init_upload_progress(upload_id, tmp_path)
+    _set_upload_state(upload_id, status='uploading', expected_pages=pages)
+    threading.Thread(
+        target=_sftp_transfer_pdf,
+        args=(upload_id, tmp_path, remote_dirs, remote_tmp, remote_dst, pages, file_size),
+        daemon=True, name=f"sftp-{upload_id}",
+    ).start()
     return pages
 
 

--- a/src/components/PageImageEditorModal.tsx
+++ b/src/components/PageImageEditorModal.tsx
@@ -59,6 +59,10 @@ const PageImageEditorModal: React.FC<Props> = ({
 
   // Kärpe-lohistuse ajutine olek (display-pikslites)
   const [cropDraft, setCropDraft] = useState<{ x0: number; y0: number; x1: number; y1: number } | null>(null);
+  // "Kleepuv" kärpe-suurus: viimati kasutatud kasti normaliseeritud mõõt. Iga uue lehe
+  // avamisel ilmub sama suur tühi kast keskele (asukohta/kallet ei taastata). Ref, mitte
+  // state → ei tekita re-render'it ega püsi üle modaali sulgemise. CircleX nullib selle.
+  const lastCropSizeRef = useRef<{ w: number; h: number } | null>(null);
   // Aktiivne interaktsioon: uue joonistamine, liigutamine, sangaga muutmine või pööramine
   const interaction = useRef<
     | { mode: 'draw' }
@@ -96,9 +100,22 @@ const PageImageEditorModal: React.FC<Props> = ({
 
   // Lähtesta teisendused + mõõda uuesti, kui leht vahetub VÕI pildi sisu muutub
   // (cacheBust uueneb iga mutatsiooni järel — nt kärbe muudab kuvasuhet).
+  // Kohe pärast lähtestust taasta "kleepuv" kärpe-suurus tsentreeritud kastina (kui
+  // mõni varem oli) — samas efektis, et boxAngle jääks garanteeritult 0.
   useEffect(() => {
     resetTransforms();
+    if (lastCropSizeRef.current) {
+      const w = Math.min(Math.max(lastCropSizeRef.current.w, 0.01), 0.98);
+      const h = Math.min(Math.max(lastCropSizeRef.current.h, 0.01), 0.98);
+      setCropRect({ x: (1 - w) / 2, y: (1 - h) / 2, w, h });
+    }
   }, [current?.filename, cacheBust, resetTransforms]);
+
+  // Jäta meelde viimati kasutatud kärpe-suurus. onCropUp viskab MIN_DRAG_PX-st väiksemad
+  // kastid ära (cropRect=null) → liiga väikest kogemata kasti ei salvestata.
+  useEffect(() => {
+    if (cropRect) lastCropSizeRef.current = { w: cropRect.w, h: cropRect.h };
+  }, [cropRect]);
 
   // Mõõda lava tegelik suurus (uueneb akna/modaali muutudes ja tabi vahetusel).
   // Korraga on mountitud ainult ühe tabi lava → re-attach [tab] muutudes.
@@ -641,7 +658,7 @@ const PageImageEditorModal: React.FC<Props> = ({
                     <FlipVertical2 size={16} />
                   </button>
                   {cropRect && (
-                    <button onClick={() => { setCropRect(null); setBoxAngle(0); }} title={t('manage.editor.cropReset')} className="p-2 rounded border border-gray-300 bg-white hover:bg-gray-100 text-gray-500 hover:text-gray-700">
+                    <button onClick={() => { setCropRect(null); setBoxAngle(0); lastCropSizeRef.current = null; }} title={t('manage.editor.cropReset')} className="p-2 rounded border border-gray-300 bg-white hover:bg-gray-100 text-gray-500 hover:text-gray-700">
                       <CircleX size={16} />
                     </button>
                   )}

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -192,7 +192,7 @@
       "viewNewHalves": "View new halves",
       "thumbWarning": "Image was changed, but thumbnail update failed.",
       "cropHint": "Drag a rectangle; resize from handles, move from inside, tilt from the top knob",
-      "cropReset": "Reset crop",
+      "cropReset": "Remove crop box and forget last used size",
       "dragPanel": "Drag buttons elsewhere",
       "applyError": "Operation failed",
       "close": "Close"

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -192,7 +192,7 @@
       "viewNewHalves": "Vaata uusi pooli",
       "thumbWarning": "Pilt muudeti, aga pisipildi uuendamine ebaõnnestus.",
       "cropHint": "Lohista ristkülik; sangadest muuda suurust, seest liiguta, ülemisest nupust kalluta",
-      "cropReset": "Lähtesta kärbe",
+      "cropReset": "Eemalda kärpekast ja unusta viimati kasutatud suurus",
       "dragPanel": "Lohista nupud teise kohta",
       "applyError": "Toiming ebaõnnestus",
       "close": "Sulge"

--- a/tests/test_save_and_transfer.py
+++ b/tests/test_save_and_transfer.py
@@ -1,0 +1,434 @@
+"""Regressioonitestid save_and_transfer_to_ocr refaktoringule (issue #17).
+
+Refaktoreering (docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 2):
+save_and_transfer_to_ocr (~239 rida) → eraldatud mooduli-taseme funktsioonid
+(_prepare_image_upload, _prepare_pdf_upload, _sftp_transfer_image,
+_sftp_transfer_pdf, _count_pdf_pages) + ühised helperid (_set_upload_state,
+_init_upload_progress, _sftp_progress_cb, _ensure_remote_dirs,
+_close_sftp_and_unlink).
+
+Need testid lukustavad refaktoringu käitumise (käitumismuudatuseta):
+- dispatch: pilt/PDF/tundmatu → õige haru
+- pdfinfo vead (_count_pdf_pages): vigane PDF / puuduv pdfinfo / timeout / puuduv 'Pages:'
+- _prepare_*: õiged remote teed + lehekülgede arv
+- _sftp_transfer_*: state 'processing'/'error' üleminekud SFTP mock'iga
+- _set_upload_state: thread-turvaline state uuendus + idempotentsus
+- _ensure_remote_dirs: loob puuduvad, ei puutu olemasolevaid
+- PNG/TIFF → JPEG konverteerimine pildi harus
+"""
+import io
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import ANY, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from server import upload_ops
+
+
+# =========================================================
+# FIXTURE'id
+# =========================================================
+
+@pytest.fixture
+def uploads_dir(tmp_path, monkeypatch):
+    """Suuna UPLOADS_DIR tmp_path/uploads alla + tühjenda upload_progress."""
+    d = tmp_path / "uploads"
+    d.mkdir()
+    monkeypatch.setattr(upload_ops, "UPLOADS_DIR", str(d))
+    upload_ops.upload_progress.clear()
+    yield d
+    upload_ops.upload_progress.clear()
+
+
+@pytest.fixture
+def make_state(uploads_dir):
+    """Loob state.json antud upload_id jaoks. Tagastab (upload_id, state)."""
+    def _make(upload_id="abc123", slug="test-teos-abc123", **overrides):
+        upload_dir = uploads_dir / upload_id
+        upload_dir.mkdir()
+        (upload_dir / "thumbs").mkdir()
+        state = {
+            "id": upload_id,
+            "status": "pending",
+            "meta": {"title": "T", "year": "1700", "slug": slug},
+            "remote_staging_path": f"AUTO-OCR/print/{upload_id}",
+            "remote_work_path": f"AUTO-OCR/print/{upload_id}/{slug}",
+            "expected_pages": None,
+        }
+        state.update(overrides)
+        (upload_dir / "state.json").write_text(
+            json.dumps(state, ensure_ascii=False), encoding="utf-8")
+        return upload_id, state
+    return _make
+
+
+@pytest.fixture
+def fake_file(tmp_path):
+    """Loob tõelise ajutise faili. Tagastab path stringi."""
+    def _make(name="upload.bin", content=b"data"):
+        p = tmp_path / name
+        p.write_bytes(content)
+        return str(p)
+    return _make
+
+
+@pytest.fixture
+def capture_threads(monkeypatch):
+    """Asendab threading.Thread klassiga, mis salvestab kutsed aga ei käivita.
+    Tagastab listi FakeThread objekte (.target, .args, .name)."""
+    started = []
+
+    class FakeThread:
+        def __init__(self, target, args=(), kwargs=None, daemon=False, name=None):
+            self.target = target
+            self.args = args
+            self.kwargs = kwargs or {}
+            self.daemon = daemon
+            self.name = name
+            started.append(self)
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(upload_ops.threading, "Thread", FakeThread)
+    return started
+
+
+def _read_state(uploads_dir, upload_id):
+    """Abi: loe state.json testi järgi."""
+    return json.loads((uploads_dir / upload_id / "state.json").read_text(encoding="utf-8"))
+
+
+def _fake_sftp():
+    """Mock SFTPClient. Vaikimisi stat() -> FileNotFoundError ('kaustu pole')."""
+    sftp = MagicMock()
+    sftp.stat.side_effect = FileNotFoundError
+    return sftp
+
+
+# =========================================================
+# _count_pdf_pages (eraldatud pdfinfo loogika)
+# =========================================================
+
+def _pdfinfo_result(stdout="", returncode=0, stderr=""):
+    r = MagicMock()
+    r.stdout = stdout
+    r.stderr = stderr
+    r.returncode = returncode
+    return r
+
+
+class TestCountPdfPages:
+    def test_loeb_lehekylgede_arvu(self, fake_file, monkeypatch):
+        path = fake_file("doc.pdf", b"%PDF-1.4")
+        monkeypatch.setattr(subprocess, "run",
+                            lambda *a, **k: _pdfinfo_result("Pages: 42\n"))
+        assert upload_ops._count_pdf_pages(path) == 42
+
+    def test_vigane_pdf_kustutab_tmp(self, fake_file, monkeypatch):
+        path = fake_file("bad.pdf", b"not a pdf")
+        monkeypatch.setattr(subprocess, "run",
+                            lambda *a, **k: _pdfinfo_result("Pages: 1", returncode=1, stderr="err"))
+        with pytest.raises(ValueError, match="Vigane PDF"):
+            upload_ops._count_pdf_pages(path)
+        assert not os.path.exists(path), "vigase PDF-i tmp_path peab kustutatama"
+
+    def test_pages_valjundist_puudub(self, fake_file, monkeypatch):
+        path = fake_file("nopages.pdf", b"%PDF")
+        monkeypatch.setattr(subprocess, "run",
+                            lambda *a, **k: _pdfinfo_result("Title: Foo\n"))
+        with pytest.raises(ValueError, match="ei õnnestunud tuvastada"):
+            upload_ops._count_pdf_pages(path)
+        # Käitumine säilitatud (refaktooring eelne): tmp_path EI kustutata
+        # selles harus — vaid returncode!=0 haru kustutab.
+        assert os.path.exists(path)
+
+    def test_pdfinfo_puudub(self, fake_file, monkeypatch):
+        path = fake_file("doc.pdf", b"%PDF")
+
+        def raise_fnf(*a, **k):
+            raise FileNotFoundError(2, "No such file", "pdfinfo")
+
+        monkeypatch.setattr(subprocess, "run", raise_fnf)
+        with pytest.raises(ValueError, match="pdfinfo pole paigaldatud"):
+            upload_ops._count_pdf_pages(path)
+
+    def test_pdfinfo_timeout(self, fake_file, monkeypatch):
+        path = fake_file("doc.pdf", b"%PDF")
+
+        def raise_timeout(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="pdfinfo", timeout=30)
+
+        monkeypatch.setattr(subprocess, "run", raise_timeout)
+        with pytest.raises(ValueError, match="liiga kaua"):
+            upload_ops._count_pdf_pages(path)
+
+
+# =========================================================
+# _prepare_image_upload / _prepare_pdf_upload
+# =========================================================
+
+class TestPrepareUpload:
+    def test_image_upload_teid(self):
+        state = {
+            "meta": {"slug": "minu-teos-xyz"},
+            "remote_staging_path": "AUTO-OCR/print/abc123",
+            "remote_work_path": "AUTO-OCR/print/abc123/minu-teos-xyz",
+        }
+        pages, dirs, tmp, dst, img_name = upload_ops._prepare_image_upload(state)
+        base = upload_ops.OCR_SERVER_PATH
+        assert pages == 1
+        assert dirs == (f"{base}/AUTO-OCR/print/abc123",
+                        f"{base}/AUTO-OCR/print/abc123/minu-teos-xyz")
+        assert img_name == "minu-teos-xyz_pg_001.jpg"
+        assert tmp == f"{base}/AUTO-OCR/print/abc123/minu-teos-xyz/minu-teos-xyz_pg_001.jpg.tmp"
+        assert dst == f"{base}/AUTO-OCR/print/abc123/minu-teos-xyz/minu-teos-xyz_pg_001.jpg"
+
+    def test_pdf_upload_teid(self, monkeypatch):
+        monkeypatch.setattr(upload_ops, "_count_pdf_pages", lambda p: 7)
+        state = {
+            "meta": {"slug": "pdf-teos-123"},
+            "remote_staging_path": "AUTO-OCR/print/abc123",
+        }
+        pages, dirs, tmp, dst = upload_ops._prepare_pdf_upload(state, "/tmp/f.pdf")
+        base = upload_ops.OCR_SERVER_PATH
+        assert pages == 7
+        assert dirs == (f"{base}/AUTO-OCR/print/abc123",)
+        assert tmp == f"{base}/AUTO-OCR/print/abc123/pdf-teos-123.pdf.tmp"
+        assert dst == f"{base}/AUTO-OCR/print/abc123/pdf-teos-123.pdf"
+
+
+# =========================================================
+# _set_upload_state / _ensure_remote_dirs
+# =========================================================
+
+class TestHelpers:
+    def test_set_upload_state_uuendab_staatus(self, make_state):
+        upload_id, _ = make_state()
+        upload_ops._set_upload_state(upload_id, status='uploading', expected_pages=3)
+        s = upload_ops._read_state(upload_id)
+        assert s['status'] == 'uploading'
+        assert s['expected_pages'] == 3
+
+    def test_set_upload_state_idempotentne_kui_state_puudub(self, uploads_dir):
+        # state.json puudub → _set_upload_state ei tohi visata
+        upload_ops._set_upload_state("olematu", status='processing')
+
+    def test_ensure_remote_dirs_loob_puuduvad(self):
+        sftp = MagicMock()
+        sftp.stat.side_effect = FileNotFoundError  # kõik "puuduvad"
+        upload_ops._ensure_remote_dirs(sftp, ["/a", "/b"])
+        assert sftp.mkdir.call_count == 2
+
+    def test_ensure_remote_dirs_ei_puutu_olemasolevaid(self):
+        sftp = MagicMock()
+        sftp.stat.return_value = None  # kõik "olemas"
+        upload_ops._ensure_remote_dirs(sftp, ["/a", "/b"])
+        sftp.mkdir.assert_not_called()
+
+
+# =========================================================
+# save_and_transfer_to_ocr dispatch
+# =========================================================
+
+class TestDispatch:
+    def test_puuduv_state_tõstab_vea(self, uploads_dir, fake_file):
+        path = fake_file()
+        with pytest.raises(ValueError, match="ei leitud"):
+            upload_ops.save_and_transfer_to_ocr("olematu", path)
+
+    def test_tundmatu_tuup_kustutab_tmp(self, make_state, monkeypatch, fake_file):
+        upload_id, _ = make_state()
+        path = fake_file("mystery.dat", b"\x00\x01")
+        monkeypatch.setattr(upload_ops, "_detect_file_type", lambda p: 'unknown')
+        with pytest.raises(ValueError, match="Toetamata failivorming"):
+            upload_ops.save_and_transfer_to_ocr(upload_id, path)
+        assert not os.path.exists(path), "tundmatu tüüp peab tmp_path kustutama"
+
+    def test_pilt_dispatch_käivitab_image_thread(self, make_state, monkeypatch,
+                                                 fake_file, capture_threads, uploads_dir):
+        upload_id, _ = make_state()
+        path = fake_file("img.jpg", b"\xff\xd8\xff\xe0")
+        monkeypatch.setattr(upload_ops, "_detect_file_type", lambda p: 'jpeg')
+
+        pages = upload_ops.save_and_transfer_to_ocr(upload_id, path)
+
+        assert pages == 1
+        assert len(capture_threads) == 1
+        t = capture_threads[0]
+        assert t.target == upload_ops._sftp_transfer_image
+        assert t.name == f"sftp-img-{upload_id}"
+        # args: (upload_id, tmp_path, file_type, remote_dirs, remote_tmp, remote_dst, remote_img_name)
+        assert t.args[0] == upload_id
+        assert t.args[1] == path
+        assert t.args[2] == 'jpeg'
+        s = _read_state(uploads_dir, upload_id)
+        assert s['status'] == 'uploading'
+        assert s['expected_pages'] == 1
+        # progress init
+        assert upload_ops.upload_progress[upload_id]['bytes_total'] > 0
+        assert upload_ops.upload_progress[upload_id]['error'] is None
+
+    def test_pdf_dispatch_käivitab_pdf_thread(self, make_state, monkeypatch,
+                                              fake_file, capture_threads, uploads_dir):
+        upload_id, _ = make_state()
+        path = fake_file("doc.pdf", b"%PDF-1.4")
+        monkeypatch.setattr(upload_ops, "_detect_file_type", lambda p: 'pdf')
+        monkeypatch.setattr(upload_ops, "_count_pdf_pages", lambda p: 15)
+
+        pages = upload_ops.save_and_transfer_to_ocr(upload_id, path)
+
+        assert pages == 15
+        assert len(capture_threads) == 1
+        t = capture_threads[0]
+        assert t.target == upload_ops._sftp_transfer_pdf
+        assert t.name == f"sftp-{upload_id}"
+        # args: (upload_id, tmp_path, remote_dirs, remote_tmp, remote_dst, pages, file_size)
+        assert t.args[0] == upload_id
+        assert t.args[1] == path
+        assert t.args[5] == 15  # pages
+        assert t.args[6] == os.path.getsize(path)  # file_size
+        s = _read_state(uploads_dir, upload_id)
+        assert s['status'] == 'uploading'
+        assert s['expected_pages'] == 15
+
+    def test_png_dispatch_kasutab_image_haru(self, make_state, monkeypatch,
+                                             fake_file, capture_threads):
+        upload_id, _ = make_state()
+        path = fake_file("img.png", b"\x89PNG\r\n\x1a\n")
+        monkeypatch.setattr(upload_ops, "_detect_file_type", lambda p: 'png')
+
+        pages = upload_ops.save_and_transfer_to_ocr(upload_id, path)
+
+        assert pages == 1
+        assert capture_threads[0].target == upload_ops._sftp_transfer_image
+        assert capture_threads[0].args[2] == 'png'  # file_type edastatakse konverteerimiseks
+
+
+# =========================================================
+# _sftp_transfer_image / _sftp_transfer_pdf (SFTP mock'iga)
+# =========================================================
+
+class TestSftpTransfer:
+    def test_image_edu_staatus_processing(self, make_state, uploads_dir, monkeypatch, fake_file):
+        upload_id, _ = make_state(status='uploading')
+        path = fake_file("img.jpg", b"\xff\xd8")
+        sftp = _fake_sftp()
+        monkeypatch.setattr(upload_ops, "_sftp_open", lambda uid: sftp)
+
+        upload_ops._sftp_transfer_image(
+            upload_id, path, 'jpeg',
+            remote_dirs=("/staging", "/work"),
+            remote_tmp="/work/img.jpg.tmp",
+            remote_dst="/work/img.jpg",
+            remote_img_name="img.jpg",
+        )
+
+        sftp.put.assert_called_once_with(path, "/work/img.jpg.tmp", callback=ANY)
+        sftp.rename.assert_called_once_with("/work/img.jpg.tmp", "/work/img.jpg")
+        assert sftp.mkdir.call_count == 2  # staging + work
+        sftp.close.assert_called_once()
+        assert not os.path.exists(path), "tmp_path peab finally's kustutama"
+        assert _read_state(uploads_dir, upload_id)['status'] == 'processing'
+
+    def test_image_viga_staatus_error(self, make_state, uploads_dir, monkeypatch, fake_file):
+        upload_id, _ = make_state(status='uploading')
+        path = fake_file("img.jpg", b"\xff\xd8")
+        # upload_progress lähtestatakse tavaliselt dispatcheris (_init_upload_progress)
+        # enne threadi starti — simuleerime seda siin otsekutsumise korral.
+        upload_ops._init_upload_progress(upload_id, path)
+        sftp = _fake_sftp()
+        sftp.put.side_effect = RuntimeError("ühendus katkes")
+        monkeypatch.setattr(upload_ops, "_sftp_open", lambda uid: sftp)
+
+        upload_ops._sftp_transfer_image(
+            upload_id, path, 'jpeg',
+            remote_dirs=("/staging", "/work"),
+            remote_tmp="/work/img.jpg.tmp",
+            remote_dst="/work/img.jpg",
+            remote_img_name="img.jpg",
+        )
+
+        s = _read_state(uploads_dir, upload_id)
+        assert s['status'] == 'error'
+        assert "ühendus katkes" in s['error_message']
+        assert not os.path.exists(path), "finally kustutab tmp_path ka vea korral"
+        assert upload_ops.upload_progress[upload_id]['error'] == "ühendus katkes"
+
+    def test_image_png_konverteerib_jpegiks(self, make_state, monkeypatch, fake_file):
+        """PNG → JPEG konverteerimine: sftp.put saab .conv.jpg teed."""
+        from PIL import Image
+        upload_id, _ = make_state(status='uploading')
+        buf = io.BytesIO()
+        Image.new("RGB", (4, 4), (10, 20, 30)).save(buf, format="PNG")
+        path = fake_file("img.png", buf.getvalue())
+
+        sftp = _fake_sftp()
+        captured = {}
+        monkeypatch.setattr(upload_ops, "_sftp_open", lambda uid: sftp)
+
+        def spy_put(src, dst, callback=None):
+            captured['src'] = src
+            captured['dst'] = dst
+        sftp.put.side_effect = spy_put
+
+        upload_ops._sftp_transfer_image(
+            upload_id, path, 'png',
+            remote_dirs=("/staging", "/work"),
+            remote_tmp="/work/img.jpg.tmp",
+            remote_dst="/work/img.jpg",
+            remote_img_name="img.jpg",
+        )
+
+        # Konverteeritud fail läheb üles (mitte originaal PNG)
+        assert captured['src'].endswith(".conv.jpg")
+        assert captured['dst'] == "/work/img.jpg.tmp"
+        assert not os.path.exists(path), "originaal tmp_path kustutatakse finally's"
+
+    def test_pdf_edu_staatus_processing(self, make_state, uploads_dir, monkeypatch, fake_file):
+        upload_id, _ = make_state(status='uploading')
+        path = fake_file("doc.pdf", b"%PDF")
+        sftp = _fake_sftp()
+        monkeypatch.setattr(upload_ops, "_sftp_open", lambda uid: sftp)
+
+        upload_ops._sftp_transfer_pdf(
+            upload_id, path,
+            remote_dirs=("/staging",),
+            remote_tmp="/staging/doc.pdf.tmp",
+            remote_dst="/staging/doc.pdf",
+            pages=5, file_size=100,
+        )
+
+        sftp.put.assert_called_once_with(path, "/staging/doc.pdf.tmp", callback=ANY)
+        sftp.rename.assert_called_once_with("/staging/doc.pdf.tmp", "/staging/doc.pdf")
+        assert sftp.mkdir.call_count == 1  # ainult staging
+        sftp.close.assert_called_once()
+        assert not os.path.exists(path)
+        assert _read_state(uploads_dir, upload_id)['status'] == 'processing'
+
+    def test_pdf_viga_staatus_error(self, make_state, uploads_dir, monkeypatch, fake_file):
+        upload_id, _ = make_state(status='uploading')
+        path = fake_file("doc.pdf", b"%PDF")
+        upload_ops._init_upload_progress(upload_id, path)
+        sftp = _fake_sftp()
+        sftp.rename.side_effect = OSError("IO viga")
+        monkeypatch.setattr(upload_ops, "_sftp_open", lambda uid: sftp)
+
+        upload_ops._sftp_transfer_pdf(
+            upload_id, path,
+            remote_dirs=("/staging",),
+            remote_tmp="/staging/doc.pdf.tmp",
+            remote_dst="/staging/doc.pdf",
+            pages=5, file_size=100,
+        )
+
+        s = _read_state(uploads_dir, upload_id)
+        assert s['status'] == 'error'
+        assert "IO viga" in s['error_message']
+        assert not os.path.exists(path)


### PR DESCRIPTION
Closes #17 · Ülevaate [Leid 2](../blob/main/docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md)

## Mis muutus

`save_and_transfer_to_ocr` (~239 rida, üks monoliitne funktsioon PDF- ja pildiharudega + pesastatud sisefunktsioonidega) → **käitumismuudatuseta** jagatud mooduli-taseme funktsioonideks:

| Funktsioon | Vastutus |
|------------|----------|
| `_prepare_image_upload` / `_prepare_pdf_upload` | remote teede + lehekülgede arvu arvutamine |
| `_sftp_transfer_image` / `_sftp_transfer_pdf` | taustalõime sihtfunktsioonid (mooduli-tasemele tõstetud) |
| `_count_pdf_pages` | pdfinfo loogika eraldatud |
| `_set_upload_state` | thread-turvaline state uuendus (ühine edu/vea jaoks) |
| `_init_upload_progress`, `_sftp_progress_cb`, `_ensure_remote_dirs`, `_close_sftp_and_unlink`, `_safe_unlink` | ühised helperid |

Dispatcher ise kahanes ~30 reale.

## Miks
- Sisefunktsioonid (`_sftp_transfer`, `_sftp_transfer_image`) olid closure'ina testimatud.
- PDF- ja pildiharu kordasid identset raamistikku (SFTP open, kaustade loomine, state → processing/error, finally puhastus).
- Nüüd on iga osa isoleeritult testitav.

## Käitumise säilitamine (verifitseeritud testidega)
- Dispatchi järjekord: `pilt → unknown → PDF` (täpselt sama fallback).
- pdfinfo veaharud: vaid `returncode != 0` kustutab `tmp_path` (säilitatud).
- State-üleminekud: `uploading` (üks atomiseeritud write), `processing`/`error`.
- PNG/TIFF → JPEG konverteerimine, sihtfaili ülekirjutamine.

## Testid
+21 regressioonitesti (`tests/test_save_and_transfer.py`): dispatch, pdfinfo vead, teede arvutamine, state üleminekud (SFTP mock'iga), PNG→JPEG konverteerimine.

```
658 passed in 16.60s   # kogu backend suite (sh +21 uut)
```

## Deploy
Backend muudatus — pärast merge'i `./scripts/server_update.sh` serveris.