### PR TITLE
Paranda topelt upload-sync thread: käivita ainult API-protsessis

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -75,6 +75,8 @@ from .upload_ops import (
     save_and_transfer_to_ocr, add_image_page, poll_and_sync_thumbs, get_ocr_status,
     # Etapp 4: import VUTT-i
     import_as_work,
+    # Taustasünk-loop starter (kutsutakse main.py lifespan'ist, mitte import-kõrvalmõjuna)
+    start_upload_sync_loop,
 )
 
 # Re-OCR operatsioonid (olemasoleva lehekülje uuesti transkribeerimine)

--- a/server/main.py
+++ b/server/main.py
@@ -8,6 +8,7 @@ from .utils import build_work_id_cache
 
 logger = get_logger(__name__)
 from .meilisearch_ops import metadata_watcher_loop, _keepwarm_loop, _ensure_filterable_attributes
+from .upload_ops import start_upload_sync_loop
 from .git_ops import run_git_fsck
 # NB: upload/re-OCR endpointid + nende ops-importid elavad nüüd routerites
 # (server/routers/upload.py, reocr.py). Paketi-tasandi re-eksport käib
@@ -42,6 +43,7 @@ async def lifespan(app: FastAPI):
     threading.Thread(target=metadata_watcher_loop, daemon=True).start()
     threading.Thread(target=_keepwarm_loop, daemon=True).start()
     threading.Thread(target=_ensure_filterable_attributes, daemon=True).start()
+    start_upload_sync_loop()  # upload taustasünk — AINULT API-protsessis (mitte image_server import)
     yield
     print("VUTT FastAPI sulgemine.")
 

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -1621,8 +1621,18 @@ def _upload_sync_loop():
                 logger.warning(f"upload-sync taustapoll viga ({uid}): {e}")
 
 
-# Käivita ainult kui upload-funktsionaalsus on lubatud (testides/ilma OCR-serverita
-# UPLOAD_ENABLED=false → ei tekita asjatut SFTP-koormust ega taimerit).
-if UPLOAD_ENABLED:
+def start_upload_sync_loop():
+    """Käivita upload taustasünk daemon-thread. Kutsutakse main.py lifespan'ist,
+    et see jookseks AINULT API-protsessis (uvicorn server.main).
+
+    NB: EI käivita seda import-kõrvalmõjuna. `python3 -m server.image_server`
+    impordib enne `server` paketi (server/__init__.py → upload_ops), nii et
+    moodulitaseme käivitus tekitaks teise, asjatu upload-sync threadi ka
+    pildiserveri protsessis (topelt SFTP-poll iga 60s + state.json võistlus).
+
+    Käivitatakse ainult kui upload-funktsionaalsus on lubatud (testides/ilma
+    OCR-serverita UPLOAD_ENABLED=false → ei tekita asjatut SFTP-koormust)."""
+    if not UPLOAD_ENABLED:
+        return
     threading.Thread(target=_upload_sync_loop, daemon=True, name="upload-sync").start()
     logger.info(f"Upload taustasünk käivitatud (intervall {UPLOAD_SYNC_INTERVAL}s)")


### PR DESCRIPTION
## Probleem

Stardilogis ilmus `Upload taustasünk käivitatud (intervall 60s)` **kaks korda** sama ajatempliga.

**Juur-põhjus:** `upload-sync` daemon-thread käivitati `upload_ops.py` mooduli tasemel import-kõrvalmõjuna. Docker CMD jooksutab kaht protsessi:

```
python3 -m uvicorn server.main:app  &   # API
python3 -m server.image_server      &   # pildiserver
```

`-m server.image_server` impordib enne `server` paketi → `server/__init__.py` teeb `from .upload_ops import (...)` → käivitub moodulitaseme thread-start. Nii **mõlemad** protsessid käivitasid `upload-sync` threadi.

**Mõju:** topelt SFTP-poll iga 60s + võimalik `state.json` võistlus aktiivsetel uploadidel. Pildiserveril pole sünk-loopi üldse vaja.

## Lahendus

Moodulitaseme käivitus asendatud `start_upload_sync_loop()` funktsiooniga, mida kutsutakse `main.py` `lifespan()`-ist — sama mustriga nagu teised startup-daemonid (`rebuild_indices`, `_keepwarm_loop` jne). Jookseb täpselt korra, ainult API-protsessis. `UPLOAD_ENABLED`-guard ja log-rida säilivad.

## Muudatused
- `server/upload_ops.py` — `start_upload_sync_loop()` funktsioon (asendab import-kõrvalmõju)
- `server/__init__.py` — ekspordi lisamine
- `server/main.py` — kutse `lifespan()`-is

## Test
- Kõik **658 testi läbivad**
- Lokaalselt verifitseeritud: import-ahel resolvib, `server.main` impordib puhtalt, ainus `name="upload-sync"` on starter-funktsiooni sees

## Deploy
Vajab backendi `--no-cache` rebuildi. Serveris testitakse õhtul (väiksem koormus). Pärast deploy't: stardilogis peaks `Upload taustasünk käivitatud` esinema **üks kord**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)