### PR TITLE
Kontekstist /manage-isse deep-link + pildivaate ergonoomika

### DIFF
--- a/docs/superpowers/plans/2026-06-27-context-to-manage-deeplink.md
+++ b/docs/superpowers/plans/2026-06-27-context-to-manage-deeplink.md
@@ -1,0 +1,607 @@
+# Kontekstist /manage-isse deep-link — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin saab ImageVieweris vajutada nuppu, mis viib `/manage`-isse täpselt sellele lehele (keri + esiletõst), ja sealt tagasi samale lehele; `/manage` grid saab veeru-reguleerija ja reset-ikoon muudetakse arusaadavaks.
+
+**Architecture:** Puhas navigatsiooni-/parsimisloogika eraldatakse testitavasse util-moodulisse (`manageDeeplink.ts`, vitest). Komponentide ühendus (nupp, scroll, highlight, slider) tehakse olemasolevatesse failidesse ja verifitseeritakse käsitsi jooksvas rakenduses, sest projektis pole React-komponentide testimise infrat (vitest `environment: 'node'`, ei `@testing-library/react`).
+
+**Tech Stack:** React 19 + TypeScript, Vite, Tailwind, react-router-dom, react-i18next, lucide-react ikoonid, vitest (node-keskkond).
+
+## Global Constraints
+
+- **Ainult frontend.** Backend muudatusi EI tehta — kõik `/manage` operatsioonid on juba olemas.
+- **Privileegid:** "Halda lehte" nupp ainult `user?.role === 'admin'`. `/manage` ise jääb olemasoleva admin-kaitse alla (`WorkManage.tsx:117-123`). Workspace jääb anonüümselt vaadatavaks.
+- **`focus` param:** ainult positiivne täisarv; muu (`abc`, `-1`, `12.5`, puuduv) → tavavaade, ei crash.
+- **Fookus rakendub AINULT esmasel laadimisel** (`handledFocusRef` guard; talub React StrictMode topelt-effecti). Hilisem salvestamata reorder EI käivita uut scroll'i.
+- **Tagasitee = parima-püüde** `/work/:workId/<focus>`; puuduva `focus` korral senine käitumine (leht 1).
+- **Veerud:** `MIN_COLS = 3`, `MAX_COLS = 10` (sama nagu `ThumbnailGrid.tsx`); dünaamiline grid inline-stiiliga `gridTemplateColumns: repeat(${cols}, 1fr)` (Tailwind JIT ei purgeks `grid-cols-${n}`).
+- **A11y:** highlight kasutab `motion-safe:` varianti (`prefers-reduced-motion` korral animatsioonita).
+- **Ikoonid:** "Halda lehte" = `Scissors` (sama ikoon mida `PageCard` juba edit-nupul kasutab); reset-nupp `RotateCcw` → `Maximize2`.
+- **ImageVieweri tooltipid on hardkodeeritud eesti keeles** (olemasolev muster, vt `title="Suumi sisse"`). Uus nupp järgib seda: `title="Halda lehte"`. i18n lisatakse ainult `WorkManage` tagasinupule (kasutab juba `t()`).
+
+---
+
+### Task 1: Puhtad deep-link / focus helperid (TDD)
+
+**Files:**
+- Create: `src/utils/manageDeeplink.ts`
+- Test: `src/utils/__tests__/manageDeeplink.test.ts`
+
+**Interfaces:**
+- Consumes: midagi varasemast taskist ei tarbi.
+- Produces:
+  - `buildManageLink(workId: string, pageNum: number): string` → `/work/${workId}/manage?focus=${pageNum}`
+  - `parseFocusParam(raw: string | null): number | null` → positiivne täisarv või `null`
+  - `buildBackToEditorPath(workId: string, focus: number | null): string` → `/work/${workId}/${focus ?? 1}`
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+```ts
+// src/utils/__tests__/manageDeeplink.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildManageLink, parseFocusParam, buildBackToEditorPath } from '../manageDeeplink';
+
+describe('buildManageLink', () => {
+  it('ehitab focus-lingi', () => {
+    expect(buildManageLink('abc123', 12)).toBe('/work/abc123/manage?focus=12');
+  });
+});
+
+describe('parseFocusParam', () => {
+  it('võtab vastu positiivse täisarvu', () => {
+    expect(parseFocusParam('12')).toBe(12);
+    expect(parseFocusParam('1')).toBe(1);
+  });
+  it('lükkab tagasi vigase sisendi', () => {
+    expect(parseFocusParam(null)).toBeNull();
+    expect(parseFocusParam('')).toBeNull();
+    expect(parseFocusParam('abc')).toBeNull();
+    expect(parseFocusParam('-1')).toBeNull();
+    expect(parseFocusParam('0')).toBeNull();
+    expect(parseFocusParam('12.5')).toBeNull();
+    expect(parseFocusParam('12abc')).toBeNull();
+  });
+});
+
+describe('buildBackToEditorPath', () => {
+  it('kasutab focus-i kui olemas', () => {
+    expect(buildBackToEditorPath('abc123', 12)).toBe('/work/abc123/12');
+  });
+  it('langeb tagasi lehele 1 kui focus puudub', () => {
+    expect(buildBackToEditorPath('abc123', null)).toBe('/work/abc123/1');
+  });
+});
+```
+
+- [ ] **Step 2: Käivita test, veendu et kukub**
+
+Run: `npm run test -- src/utils/__tests__/manageDeeplink.test.ts`
+Expected: FAIL — "Failed to resolve import '../manageDeeplink'".
+
+- [ ] **Step 3: Kirjuta minimaalne implementatsioon**
+
+```ts
+// src/utils/manageDeeplink.ts
+
+/** Workspace → /manage deep-link konkreetsele lehele. */
+export function buildManageLink(workId: string, pageNum: number): string {
+  return `/work/${workId}/manage?focus=${pageNum}`;
+}
+
+/** Parsib ?focus= väärtuse. Lubatud ainult positiivne täisarv, muidu null. */
+export function parseFocusParam(raw: string | null): number | null {
+  if (raw == null) return null;
+  // Range: ainult puhas positiivne täisarv (mitte "12.5", "12abc", "-1", "0")
+  if (!/^[1-9][0-9]*$/.test(raw.trim())) return null;
+  const n = Number(raw.trim());
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/** /manage → Workspace tagasitee. Parima-püüde: focus või leht 1. */
+export function buildBackToEditorPath(workId: string, focus: number | null): string {
+  return `/work/${workId}/${focus ?? 1}`;
+}
+```
+
+- [ ] **Step 4: Käivita test, veendu et läbib**
+
+Run: `npm run test -- src/utils/__tests__/manageDeeplink.test.ts`
+Expected: PASS (kõik 6 `it`-bloki rohelised).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/manageDeeplink.ts src/utils/__tests__/manageDeeplink.test.ts
+git commit -m "feat: deep-link/focus helperid (manageDeeplink)"
+```
+
+---
+
+### Task 2: ImageViewer — "Halda lehte" nupp + reset-ikoon
+
+**Files:**
+- Modify: `src/components/ImageViewer.tsx` (import rida 2; props interface rida 5-10; reset-nupp rida 181-187; uus nupp ribasse)
+
+**Interfaces:**
+- Consumes: midagi puhast util-i siin ei kutsuta (link ehitatakse Workspace'is, Task 3).
+- Produces: `ImageViewerProps` saab kaks uut välja:
+  - `isAdmin?: boolean`
+  - `onManage?: () => void`
+
+- [ ] **Step 1: Uuenda importe (rida 2)**
+
+Vana:
+```ts
+import { ZoomIn, ZoomOut, RotateCcw, Download, LayoutGrid } from 'lucide-react';
+```
+Uus (eemalda `RotateCcw`, lisa `Maximize2` ja `Scissors`):
+```ts
+import { ZoomIn, ZoomOut, Maximize2, Download, LayoutGrid, Scissors } from 'lucide-react';
+```
+
+- [ ] **Step 2: Lisa propsid interface'i**
+
+Vana:
+```ts
+interface ImageViewerProps {
+  src: string;
+  pageNum?: number;
+  onGridView?: () => void;
+  onNavigate?: (direction: 'prev' | 'next') => void;
+}
+```
+Uus:
+```ts
+interface ImageViewerProps {
+  src: string;
+  pageNum?: number;
+  onGridView?: () => void;
+  onNavigate?: (direction: 'prev' | 'next') => void;
+  isAdmin?: boolean;
+  onManage?: () => void;
+}
+```
+Ja destructuring-rida (rida 11):
+```ts
+const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onNavigate, isAdmin, onManage }) => {
+```
+
+- [ ] **Step 3: Vaheta reset-nupu ikoon (rida 181-187)**
+
+Vana:
+```tsx
+          <button
+            onClick={handleReset}
+            ...
+            title="Taasta vaade"
+          >
+            <RotateCcw size={20} />
+          </button>
+```
+Uus (ainult ikoon muutub `RotateCcw` → `Maximize2`; `title` jääb "Taasta vaade", `onClick`/className samaks):
+```tsx
+          <button
+            onClick={handleReset}
+            ...
+            title="Taasta vaade"
+          >
+            <Maximize2 size={20} />
+          </button>
+```
+> NB: säilita olemasolev `className` täpselt nagu failis on; muutub AINULT ikooni-komponent.
+
+- [ ] **Step 4: Lisa "Halda lehte" nupp (admin-only) grid-nupu kõrvale**
+
+Olemasolev grid-nupp on tingimuslik (`onGridView &&`, rida ~190-198). Lisa selle järele,
+sama className-mustriga nagu teised ribanupud (kopeeri täpne className naabernuppult):
+```tsx
+          {isAdmin && onManage && (
+            <button
+              onClick={onManage}
+              className="<SAMA className nagu naaberribanupul>"
+              title="Halda lehte"
+            >
+              <Scissors size={20} />
+            </button>
+          )}
+```
+> Kopeeri `className` täpselt ühelt olemasolevalt ribanupult (nt download-nupp), et stiil ühtiks.
+
+- [ ] **Step 5: Verifitseeri build + lint**
+
+Run: `npm run build`
+Expected: õnnestub ilma TS-vigadeta (eriti: `RotateCcw` enam ei impordita, uued propsid tüübitud).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/ImageViewer.tsx
+git commit -m "feat: ImageViewer 'Halda lehte' nupp + reset-ikoon Maximize2"
+```
+
+---
+
+### Task 3: Workspace — anna ImageViewerile admin + onManage
+
+**Files:**
+- Modify: `src/pages/Workspace.tsx` (import; `isAdmin` arvutus; `<ImageViewer ...>` rida ~554)
+
+**Interfaces:**
+- Consumes: `buildManageLink` (Task 1); `ImageViewerProps.isAdmin/onManage` (Task 2).
+- Produces: midagi hilisemale taskile ei ekspordi.
+
+- [ ] **Step 1: Impordi helper**
+
+Lisa importide juurde:
+```ts
+import { buildManageLink } from '../utils/manageDeeplink';
+```
+
+- [ ] **Step 2: Arvuta isAdmin**
+
+`useUser()` annab juba `user` (rida 29). Lisa komponendi sees (nt teiste tuletatud
+väärtuste juurde):
+```ts
+const isAdmin = user?.role === 'admin';
+```
+
+- [ ] **Step 3: Anna propsid ImageViewerile (rida ~554)**
+
+Vana:
+```tsx
+<ImageViewer src={currentImageSrc} pageNum={page.page_number} onGridView={handleOpenGridView} onNavigate={(dir) => navigatePage(dir === 'next' ? 1 : -1)} />
+```
+Uus:
+```tsx
+<ImageViewer
+  src={currentImageSrc}
+  pageNum={page.page_number}
+  onGridView={handleOpenGridView}
+  onNavigate={(dir) => navigatePage(dir === 'next' ? 1 : -1)}
+  isAdmin={isAdmin}
+  onManage={() => navigate(buildManageLink(workId!, page.page_number))}
+/>
+```
+> `workId` ja `navigate` on failis juba olemas (rida 38-39); `page.page_number` on
+> kanooniline leheküljenumber, mille järgi Workspace laeb (vt `currentPageNum` sünk
+> rida 195-196).
+
+- [ ] **Step 4: Verifitseeri build**
+
+Run: `npm run build`
+Expected: õnnestub ilma TS-vigadeta.
+
+- [ ] **Step 5: Manuaalne kontroll (jooksev rakendus)**
+
+Run: `npm run dev`, ava admin-kasutajana mõne teose leht (nt `/work/<id>/12`).
+Expected:
+- ImageVieweri ribas on käärid-nupp ("Halda lehte"); reset-nupp on nüüd "mahuta"-ikoon, mitte pööramisnool.
+- Käärid-nupule vajutus viib `/work/<id>/manage?focus=12`.
+- Logi välja (anonüümne) → käärid-nuppu EI ole.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/Workspace.tsx
+git commit -m "feat: Workspace annab ImageViewerile admin + manage-lingi"
+```
+
+---
+
+### Task 4: PageCard — forwardRef + isFocused highlight
+
+**Files:**
+- Modify: `src/pages/manage/PageCard.tsx` (komponendi signatuur; välimine `<div>`; props interface)
+
+**Interfaces:**
+- Consumes: midagi.
+- Produces: `PageCard` on nüüd `forwardRef<HTMLDivElement, PageCardProps>`; `PageCardProps` saab `isFocused?: boolean`.
+
+- [ ] **Step 1: Lisa `isFocused` propsi interface'i**
+
+`PageCardProps`-i lõppu (pärast `onEdit`):
+```ts
+  onEdit: (visiblePageNum: number) => void;
+  isFocused?: boolean;
+```
+
+- [ ] **Step 2: Tee komponent forwardRef-iks ja kinnita ref + highlight välimisele div-ile**
+
+Vana:
+```tsx
+const PageCard: React.FC<PageCardProps> = (p) => {
+  const { t } = useTranslation(['workspace', 'common']);
+  return (
+    <div
+      className={`relative flex flex-col rounded-lg border overflow-hidden bg-white ${
+        p.isSelected ? 'border-primary-500 ring-2 ring-primary-400'
+          : p.isChanged ? 'border-amber-400 ring-1 ring-amber-300' : 'border-gray-200'
+      }`}
+    >
+```
+Uus:
+```tsx
+const PageCard = React.forwardRef<HTMLDivElement, PageCardProps>((p, ref) => {
+  const { t } = useTranslation(['workspace', 'common']);
+  return (
+    <div
+      ref={ref}
+      className={`relative flex flex-col rounded-lg border overflow-hidden bg-white ${
+        p.isFocused ? 'ring-2 ring-blue-500 motion-safe:animate-pulse'
+          : p.isSelected ? 'border-primary-500 ring-2 ring-primary-400'
+          : p.isChanged ? 'border-amber-400 ring-1 ring-amber-300' : 'border-gray-200'
+      }`}
+    >
+```
+
+- [ ] **Step 3: Sulge forwardRef ja lisa displayName**
+
+Faili lõpus, komponendi sulgemisel: vana `};` (mis lõpetab `const PageCard = ... => { ... };`)
+asenda nii, et `forwardRef` callback ja komponent oleksid korrektselt suletud:
+```tsx
+});
+
+PageCard.displayName = 'PageCard';
+
+export default PageCard;
+```
+> NB: kontrolli olemasolevat eksporti — kui failis on `export default PageCard;` juba
+> olemas, ära dubleeri, lisa ainult `displayName` rida enne seda. Asenda komponendi
+> keha lõpetav `};` → `});`.
+
+- [ ] **Step 4: Verifitseeri build**
+
+Run: `npm run build`
+Expected: õnnestub; `forwardRef` tüübid korras.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/manage/PageCard.tsx
+git commit -m "feat: PageCard forwardRef + isFocused highlight"
+```
+
+---
+
+### Task 5: WorkManage — focus scroll/highlight + fookus-teadlik tagasinupp
+
+**Files:**
+- Modify: `src/pages/WorkManage.tsx` (importid; `useSearchParams`; refid + highlight-olek; effect; tagasinupp rida 578; `PageCard` render rida ~698-714)
+- Modify: `src/locales/et/workspace.json` (manage blokk, rida ~69)
+- Modify: `src/locales/en/workspace.json` (manage blokk, rida ~69)
+
+**Interfaces:**
+- Consumes: `parseFocusParam`, `buildBackToEditorPath` (Task 1); `PageCard` `ref` + `isFocused` (Task 4); `visibleNumByFile` (olemas, rida ~256).
+- Produces: midagi hilisemale taskile ei ekspordi.
+
+- [ ] **Step 1: Lisa i18n võti (et)**
+
+`src/locales/et/workspace.json` `manage` blokki, `backToWork` järele:
+```json
+    "backToWork": "Tagasi teosele",
+    "backToPage": "Tagasi lehele {{n}}",
+```
+
+- [ ] **Step 2: Lisa i18n võti (en)**
+
+`src/locales/en/workspace.json` `manage` blokki:
+```json
+    "backToWork": "Back to work",
+    "backToPage": "Back to page {{n}}",
+```
+
+- [ ] **Step 3: Uuenda importe WorkManage.tsx-s**
+
+```ts
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { parseFocusParam, buildBackToEditorPath } from '../utils/manageDeeplink';
+```
+(lisa `useSearchParams` olemasolevasse react-router-dom importi; lisa util-import.)
+
+- [ ] **Step 4: Loe focus + lisa refid/olek (komponendi sees, teiste hookide juurde)**
+
+```ts
+const [searchParams] = useSearchParams();
+const focus = parseFocusParam(searchParams.get('focus'));
+const focusedCardRef = useRef<HTMLDivElement | null>(null);
+const [highlightedNum, setHighlightedNum] = useState<number | null>(null);
+const handledFocusRef = useRef<number | null>(null);
+```
+> `useRef`/`useState` on failis tõenäoliselt juba imporditud; kui ei, lisa `react` importi.
+
+- [ ] **Step 5: Lisa fookus-effect (rakendub AINULT esmasel laadimisel)**
+
+Pärast seda kui `visibleSorted` / `visibleNumByFile` on arvutatud ja lehed laetud
+(`!loading` seisus). Lisa effect:
+```ts
+useEffect(() => {
+  if (focus == null) return;
+  if (loading) return;                       // oota kuni lehed laetud
+  if (handledFocusRef.current === focus) return; // ainult kord (sh StrictMode)
+  // Kontrolli, et fookus-leht on nähtavas listis
+  const exists = Object.values(visibleNumByFile).includes(focus);
+  if (!exists) { handledFocusRef.current = focus; return; }
+  handledFocusRef.current = focus;
+  // Keri pärast renderit (aspect-[3/4] → kõrgused stabiilsed, üks rAF piisab)
+  requestAnimationFrame(() => {
+    focusedCardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  });
+  setHighlightedNum(focus);
+  const tid = setTimeout(() => setHighlightedNum(null), 2000);
+  return () => clearTimeout(tid);
+}, [focus, loading, visibleNumByFile]);
+```
+> Kohenda `loading` muutuja nimi olemasoleva laadimisoleku järgi failis (otsi `setLoading`/`loading`).
+
+- [ ] **Step 6: Tee tagasinupp fookus-teadlikuks (rida 578)**
+
+Vana:
+```tsx
+          <button
+            onClick={() => navigate(`/work/${workId}/1`)}
+            className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+          >
+            <ArrowLeft size={16} />
+            {t('manage.backToWork')}
+          </button>
+```
+Uus:
+```tsx
+          <button
+            onClick={() => navigate(buildBackToEditorPath(workId!, focus))}
+            className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+          >
+            <ArrowLeft size={16} />
+            {focus != null ? t('manage.backToPage', { n: focus }) : t('manage.backToWork')}
+          </button>
+```
+
+- [ ] **Step 7: Anna ref + isFocused fookus-kaardile (PageCard render, rida ~698-714)**
+
+`visibleSorted.map((page) => { ... })` sees, kus `vNum = visibleNumByFile[page.filename]`:
+```tsx
+                    const vNum = visibleNumByFile[page.filename];
+                    const isFocused = focus != null && vNum === focus;
+                    return (
+                      <PageCard
+                        key={page.filename}
+                        ref={isFocused ? focusedCardRef : undefined}
+                        isFocused={isFocused && highlightedNum === focus}
+                        workId={workId!}
+                        filename={page.filename}
+                        ...ülejäänud propsid muutumata...
+                      />
+                    );
+```
+> Säilita kõik olemasolevad propsid; lisa AINULT `ref` ja `isFocused`.
+
+- [ ] **Step 8: Verifitseeri build**
+
+Run: `npm run build`
+Expected: õnnestub ilma TS-vigadeta.
+
+- [ ] **Step 9: Manuaalne kontroll**
+
+Run: `npm run dev` (admin). Workspace lehel `/work/<id>/12` → vajuta käärid-nuppu.
+Expected:
+- `/manage?focus=12` avaneb, kerib lehele 12, kaart vilgub ~2s (reduced-motion korral staatiline ring).
+- Ülaserva tagasinupp ütleb "Tagasi lehele 12" → viib `/work/<id>/12`.
+- Ava `/work/<id>/manage` ilma `?focus` → ei keri/vilgu; nupp "Tagasi teosele" → leht 1.
+- `/work/<id>/manage?focus=abc` → tavavaade, ei crash, nupp "Tagasi teosele".
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/pages/WorkManage.tsx src/locales/et/workspace.json src/locales/en/workspace.json
+git commit -m "feat: WorkManage focus scroll/highlight + fookus-teadlik tagasinupp"
+```
+
+---
+
+### Task 6: WorkManage — grid veeru-reguleerija
+
+**Files:**
+- Modify: `src/pages/WorkManage.tsx` (veergude olek; slider UI; grid `<div>` rida ~697)
+
+**Interfaces:**
+- Consumes: midagi.
+- Produces: midagi.
+
+- [ ] **Step 1: Lisa veergude olek + konstandid**
+
+Komponendi sees:
+```ts
+const MIN_COLS = 3;
+const MAX_COLS = 10;
+const [gridCols, setGridCols] = useState(5);
+```
+
+- [ ] **Step 2: Lisa slider UI grid-i kohale**
+
+Grid-ploki (rida ~697 `<div className="grid ...">`) ette lisa reguleerija (muster
+`ThumbnailGrid.tsx:93-113` järgi, +/- nupud + range):
+```tsx
+                <div className="flex items-center gap-2 px-4 pt-2 text-sm text-gray-600">
+                  <button
+                    onClick={() => setGridCols((c) => Math.max(c - 1, MIN_COLS))}
+                    disabled={gridCols <= MIN_COLS}
+                    className="px-2 py-0.5 border rounded disabled:opacity-40"
+                    title="Suuremad pisipildid"
+                  >−</button>
+                  <input
+                    type="range"
+                    min={MIN_COLS}
+                    max={MAX_COLS}
+                    value={MAX_COLS + MIN_COLS - gridCols}
+                    onChange={(e) => setGridCols(MAX_COLS + MIN_COLS - Number(e.target.value))}
+                  />
+                  <button
+                    onClick={() => setGridCols((c) => Math.min(c + 1, MAX_COLS))}
+                    disabled={gridCols >= MAX_COLS}
+                    className="px-2 py-0.5 border rounded disabled:opacity-40"
+                    title="Väiksemad pisipildid"
+                  >+</button>
+                </div>
+```
+> Slider on "tagurpidi" (vasak = vähem veerge = suuremad pildid), nagu `ThumbnailGrid`.
+
+- [ ] **Step 3: Tee grid dünaamiliseks (rida ~697)**
+
+Vana:
+```tsx
+                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3 p-4">
+```
+Uus (eemalda fikseeritud `grid-cols-*`, kasuta inline-stiili):
+```tsx
+                <div
+                  className="grid gap-3 p-4"
+                  style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
+                >
+```
+
+- [ ] **Step 4: Verifitseeri build**
+
+Run: `npm run build`
+Expected: õnnestub.
+
+- [ ] **Step 5: Manuaalne kontroll**
+
+Run: `npm run dev` (admin) → `/work/<id>/manage`.
+Expected: slideriga/nuppudega muutub veergude arv 3–10 vahel; −/+ nupud lukustuvad
+piiridel; pisipildid suurenevad/vähenevad vastavalt.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/WorkManage.tsx
+git commit -m "feat: WorkManage grid veeru-reguleerija (3-10)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Deep-link Workspace→/manage (spec §1) → Task 2 + 3. ✓
+- Focus scroll + highlight, parser, StrictMode guard, reduced-motion, init-only (spec §2) → Task 5 (+ helper Task 1, PageCard Task 4). ✓
+- Tagasitee, olemasolev nupp fookus-teadlikuks, parima-püüde (spec §3) → Task 5 + helper Task 1. ✓
+- Grid ergonoomika 3–10 (spec §4) → Task 6. ✓
+- ImageViewer Scissors + reset-ikoon Maximize2 (spec §1 ikoonid) → Task 2. ✓
+- Admin-gate (spec privileegid) → Task 2 (`isAdmin && onManage`) + Task 3 (`isAdmin`); /manage oma kaitse muutumatu. ✓
+- Backend muutmata → ükski task ei puuduta serverit. ✓
+
+**Test-infra märkus:** projektis pole React-komponentide testimist (vitest `node`),
+seega puhas loogika (`manageDeeplink.ts`) on TDD-ga kaetud (Task 1), komponendi-ühendus
+verifitseeritakse käsitsi (Task 3/5/6 manuaalsed sammud). See vastab olemasolevale
+muster — `src/utils/__tests__/` testib puhast loogikat, mitte komponente.
+
+**Placeholder scan:** ei "TBD"/"TODO"; igas koodisammus täielik kood. ImageVieweri uue
+nupu `className` on tahtlik "kopeeri naaberribanupult" (faili stiil pole konstandina
+eraldatud) — verifitseeritav buildiga + manuaalselt.
+
+**Type consistency:** `buildManageLink/parseFocusParam/buildBackToEditorPath` signatuurid
+identsed Task 1 definitsiooni ja Task 3/5 kasutuse vahel. `ImageViewerProps.isAdmin/onManage`
+(Task 2) = Workspace kasutus (Task 3). `PageCardProps.isFocused` + `forwardRef<HTMLDivElement>`
+(Task 4) = WorkManage `ref`/`isFocused` kasutus (Task 5). `MIN_COLS/MAX_COLS` = 3/10 nii
+Global Constraints kui Task 6.

--- a/docs/superpowers/specs/2026-06-27-context-to-manage-deeplink-design.md
+++ b/docs/superpowers/specs/2026-06-27-context-to-manage-deeplink-design.md
@@ -1,0 +1,156 @@
+# Disain: kontekstist `/manage`-isse — lehe-haldus käeulatusse
+
+**Kuupäev:** 2026-06-27
+**Staatus:** kinnitatud disain, ootab implementatsiooniplaani
+
+## Probleem
+
+Arhiividokumentide üleslaadijad (peamine tagasiside-allikas) töötavad sageli
+**topeltlehekülgedega**, mida on vaja **poolitada** (sage) ja vahel sirgendada/kärpida
+(harvem). Tööd tehes jääb silma, et lahtiolev leht vajab parandust, aga:
+
+1. `/manage` ei ava seda lehte, kus kasutaja oli — peab käsitsi otsima.
+2. Pisipildid on väikesed → ei näe kohe, kus oldi / mis viga on.
+3. Kogu `/manage` kogemus pole nii mugav kui Workspace'i grid-view.
+
+## Mittelahendus (tahtlikult välistatud)
+
+Operatsioonide killustamine üle pindade — nt crop ImageViewerisse, aga poolita ainult
+`/manage`-is. Kuna **poolitamine on kõige sagedasem** ja kasutaja peas tähendab
+"paranda see leht" just poolitamist, tekitaks osaline operatsioonide komplekt ühel pinnal
+*suurema* segaduse ("miks ma siin croppida saan, aga poolitada ei"). Seetõttu:
+
+- Ei dubleerita ühtki operatsiooni.
+- Ei tooda struktuuri-loogikat (poolita/reorder/kustuta/re-OCR) aktiivsesse
+  tekstisessiooni (Workspace'i).
+- Ei muudeta privileege: `/manage` jääb admin-only; Workspace jääb anonüümselt vaadatavaks.
+
+**Põhimõte:** `/manage` jääb ainsaks koduks kõigile lehe-operatsioonidele. Teeme ta
+*kontekstist kättesaadavaks* ja *ergonoomiliseks*.
+
+## Lahendus
+
+### 1. Deep-link kontekstist (Workspace → `/manage`)
+
+ImageVieweris **admin-only nupp** ("Halda lehte"), mis navigeerib:
+
+```
+/work/:workId/manage?focus=<pageNum>
+```
+
+- `pageNum` = kanoniseeritud leheküljenumber, **mille järgi Workspace praegust lehte
+  laeb** (source of truth). Praktikas `currentPageNum` / `page.page_number`; kui see
+  mingis seisus puudub/nihkes, fallback URL-i `:pageNum` paramile.
+- Query-param, sest marsruut `/work/:workId/manage` ei võta lehe-segmenti. Laiendatav
+  (nt `?focus=12&mode=...`), kui `/manage` kunagi keerukamaks läheb.
+- Nupp **tööriista-stiilis** (mitte prominentne) — adminile käeulatuses, aga ei
+  konkureeri lugemise/toimetamise põhitegevusega. Nähtav ainult kui
+  `user?.role === 'admin'` (sama gate nagu `/manage` ise).
+- **Asukoht ja ikoon:** lisandub olemasolevasse ImageVieweri tööriistaribasse
+  (`ZoomIn` · `ZoomOut` · reset · `LayoutGrid` · `Download`). Ikoon **`Scissors`**
+  (seob nupu pildiredaktoriga, mida admin juba tunneb; "lõika/poolita" = sagedaseim
+  toiming), title "Halda lehte".
+- **Seotud parandus — reset-nupu ikoon:** praegu kasutab reset-nupp (`handleReset`,
+  title "Taasta vaade") ikooni **`RotateCcw`**, mis näeb välja nagu pööramine ja eksitab.
+  Vahetada **`Maximize2`** (loeb kui "mahuta/lähtesta vaade"). `RotateCcw`/`RotateCw`
+  jäävad reserveeritud pildiredaktori *päris* pööramisele — reset'i jaoks neid kasutada
+  oleks topelt-eksitav.
+
+### 2. Fookus `/manage`-is
+
+`WorkManage` loeb `useSearchParams()` → `focus`.
+
+- **`focus` parsimine:** ainult positiivne täisarv. `focus=abc`, `focus=-1`,
+  `focus=12.5`, puuduv → tavavaade, ei scrolli, ei crashi.
+- Pärast lehtede laadimist (`visibleSorted` valmis): leiab kaardi, mille
+  `visibleNumByFile[filename] === focus`. **`filename`** on selle koodibaasi
+  kanooniline lehevõti (`draftPositions`, `selectedFiles`, `visibleNumByFile` kõik
+  võtmestatud `filename`-iga); kuvanimi (`imageName`/`lehekylje_pilt`) on eraldi.
+- **Kerib vaatesse** (`scrollIntoView({ behavior: 'smooth', block: 'center' })`).
+  `PageCard` pildiala on `aspect-[3/4]` (fikseeritud kuvasuhe → kaardikõrgused ei
+  reflow'gi piltide laadimisel), seega üks `requestAnimationFrame` pärast esmast
+  renderit on scrolli jaoks piisav; layout-effect tantsu pole vaja.
+- **Tõstab esile** lühikese efektiga (ring/glow ~2s, siis hääbub). Austab
+  `prefers-reduced-motion`: animatsiooni asemel staatiline lühike outline/taust.
+- **Fookus rakendub AINULT esmasel lehtede laadimisel.** `handledFocusRef` guard
+  väldib korduvat käivitumist (sh React StrictMode topelt-effect). Hilisemad
+  salvestamata reorder-muudatused EI käivita uut scroll'i ega muuda highlight'i.
+- **EI ava** automaatselt pildiredaktorit (kasutaja otsus: ohutum, vähem üllatav).
+  Kasutaja vajutab ise edasi (poolita/crop/rotate).
+- Servajuhud: kui `focus` puudub või ei leita vastet → tavaline `/manage` vaade,
+  ilma fookuseta (graatsiline degradatsioon).
+
+### 3. Tagasitee (`/manage` → Workspace)
+
+**Olemasoleva tagasinupu fookus-teadlikuks tegemine — EI lisata uut nuppu.**
+`WorkManage.tsx:578` on juba lehe ülaservas tagasinupp (`ArrowLeft` +
+`manage.backToWork`), aga see navigeerib praegu **alati `/work/${workId}/1`**
+(leht 1, ükskõik kust tuldi — latentne puudus selle voo jaoks).
+
+Muudatus:
+- `focus` olemas → tagasinupp viib `/work/:workId/<focus>` (õige leht); silt
+  konkreetsem, nt "← Tagasi lehele {n}".
+- `focus` puudub (tuldi mujalt) → senine käitumine ja silt (`manage.backToWork`,
+  leht 1).
+- **Parima-püüde link.** Poolitamise järel numeratsioon võib nihkuda, aga tagasi-leht
+  jääb kehtivaks (poolitatud lehe esimene pool kannab sama numbrit). Kui leht on
+  vahepeal kustutatud või numeratsioon muutunud, käitub Workspace oma tavapärase
+  puuduv-leht-loogika järgi (graatsiline degradatsioon) — me ei püüa seda ennustada.
+- **Tahtlik valik — EI tee "elegantset" varianti** (jäta failivõti meelde → arvuta
+  jooksev nähtav number). Põhjus: `/manage` kuvab **salvestamata** draft-positsioone,
+  Workspace navigeerib **salvestatud** järjekorra järgi. Nähtava numbri arvutamine
+  draft'ist võiks saata kasutaja valele salvestatud lehele. Lihtne `focus`-number =
+  saabumishetke salvestatud number, mis vastab sellele, mida Workspace kasutab —
+  salvestamata muudatuste korral hoopis õigem.
+
+### 4. Grid-ergonoomika
+
+Praegu `WorkManage` grid on fikseeritud: `grid-cols-3 sm:grid-cols-4 md:grid-cols-5`.
+
+Toome `ThumbnailGrid`-i juba olemasoleva **veeru-reguleerimise** loogika `/manage`-isse:
+
+- Veergude arvu reguleerija (min 3, max 10 — sama vahemik nagu `ThumbnailGrid`/Workspace
+  grid-view, vt `Workspace.tsx` `gridCols`). Käsitsi/kiire klikkimine ei vii väljapoole
+  3–10 (clamp).
+- Vähem veerge = suuremad pisipildid → näeb kohe lehe seisu (viltu/topelt).
+- Olek lokaalne `WorkManage`-is (`useState`), võib hiljem püsistada `user_settings`-i,
+  aga see EI ole selle skoobi osa (YAGNI).
+- `ThumbnailGrid`-il on slider juba olemas (`MIN_COLS`/`MAX_COLS`, `cols`/`onColsChange`).
+  Implementatsiooniplaan otsustab: kas eraldada slider väikeseks jagatud komponendiks
+  või replikeerida (väike, ~10 rida). Kumbki sobib; ei kirjuta uut loogikat nullist.
+
+## Mõjutatud failid
+
+| Fail | Muudatus |
+|------|----------|
+| `src/components/ImageViewer.tsx` | Admin-only "Halda lehte" nupp (`Scissors`) ribasse → `?focus=` link; reset-nupu ikoon `RotateCcw` → `Maximize2` |
+| `src/pages/Workspace.tsx` | Annab ImageViewerile admin-lipu + workId/pageNum (kui pole juba) |
+| `src/pages/WorkManage.tsx` | `useSearchParams` focus; scrollIntoView+highlight; **olemasolev** tagasinupp fookus-teadlikuks; veeru-reguleerija |
+| `src/pages/manage/PageCard.tsx` | `ref` + highlight-klass (forwardRef või wrapper) |
+| `src/locales/{et,en}/*.json` | Uued sildid: "Halda lehte", "Tagasi toimetajasse", veeru-reguleerija |
+
+Backend muudatusi **ei vaja** — kõik operatsioonid on juba `/manage`-is olemas.
+
+## Testid
+
+- ImageVieweri "Halda lehte" nupp nähtav ainult adminile; mitte-admin ei näe nuppu;
+  otselingi puhul jääb `/manage` olemasoleva admin-kaitse alla (`WorkManage.tsx:117`).
+- Nupp navigeerib õige `?focus=<pageNum>` URL-iga.
+- `WorkManage` fookus: õige kaart keritakse vaatesse + esiletõst.
+- `focus` vigane string / negatiivne / mittetäisarv → ei scrolli, ei crashi, tavavaade.
+- `focus` viitab lehele, mida pole nähtavas listis → tavavaade.
+- Highlight rakendub ainult ühele kaardile ja kaob pärast timeout'i.
+- Tagasitee (olemasolev nupp): kui `focus` olemas → `/work/:workId/<focus>` (mitte
+  leht 1); kui `focus` puudub → senine käitumine (leht 1, `manage.backToWork`).
+- Veeru-reguleerija muudab grid-veergude arvu vahemikus 3–10; ei välju vahemikust.
+
+## Riskid ja leevendus
+
+- **Numeratsiooni nihe poolitamisel** → tagasitee kasutab `focus` numbrit, mis jääb
+  kehtivaks (esimene pool). Madal risk.
+- **`focus` vs hilisem draft-reorder** → fookus rakendub AINULT esmasel laadimisel
+  (`handledFocusRef` guard). Hilisemad salvestamata reorder-muudatused ei käivita uut
+  scroll'i ega kerimist tagasi fookuskaardile. Probleem pole "degradeerumine", vaid
+  "ära fokuseeri korduvalt" — guard lahendab. Madal risk.
+- **Privileegide leke** → "Halda lehte" nupp range admin-gate taga; `/manage` ise
+  juba kontrollib rolli (`WorkManage.tsx:117-123`).

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { ZoomIn, ZoomOut, RotateCcw, Download, LayoutGrid } from 'lucide-react';
+import { ZoomIn, ZoomOut, Maximize2, Download, LayoutGrid, Scissors } from 'lucide-react';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 
 interface ImageViewerProps {
@@ -7,9 +7,11 @@ interface ImageViewerProps {
   pageNum?: number;
   onGridView?: () => void;
   onNavigate?: (direction: 'prev' | 'next') => void;
+  isAdmin?: boolean;
+  onManage?: () => void;
 }
 
-const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onNavigate }) => {
+const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onNavigate, isAdmin, onManage }) => {
   const [scale, setScale] = useState(1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
@@ -183,7 +185,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
             className="p-2 text-white hover:bg-white/20 rounded transition-colors"
             title="Taasta vaade"
           >
-            <RotateCcw size={20} />
+            <Maximize2 size={20} />
           </button>
           {onGridView && (
             <>
@@ -196,6 +198,15 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
                 <LayoutGrid size={20} />
               </button>
             </>
+          )}
+          {isAdmin && onManage && (
+            <button
+              onClick={onManage}
+              className="p-2 text-white hover:bg-white/20 rounded transition-colors"
+              title="Halda lehte"
+            >
+              <Scissors size={20} />
+            </button>
           )}
           <div className="w-px bg-white/20 mx-1"></div>
           <button

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -69,6 +69,7 @@
   "manage": {
     "title": "Page management",
     "backToWork": "Back to work",
+    "backToPage": "Back to page {{n}}",
     "manageWork": "Manage work",
     "pages": "Pages",
     "pagesCount_one": "page",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -69,6 +69,7 @@
   "manage": {
     "title": "Lehekülgede haldus",
     "backToWork": "Tagasi teosele",
+    "backToPage": "Tagasi lehele {{n}}",
     "manageWork": "Halda teost",
     "pages": "Leheküljed",
     "pagesCount_one": "lehekülg",

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -259,12 +259,15 @@ const WorkManage: React.FC = () => {
   // Nähtav (effective) järjekord: draft kui olemas, muidu serveri page_num.
   // Iga lehe nähtav number on tema indeks selles järjestuses + 1.
   // useMemo: tagab stabiilse identiteedi, et fookus-effect ei käivitu iga renderi järel.
-  const visiblePages: VisiblePage[] = useMemo(() => {
-    const sorted = [...pages].sort(
+  const visibleSorted = useMemo(() => {
+    return [...pages].sort(
       (a, b) => (draftPositions[a.filename] ?? a.page_num) - (draftPositions[b.filename] ?? b.page_num)
     );
-    return sorted.map((p, i) => ({ filename: p.filename, visiblePageNum: i + 1 }));
   }, [pages, draftPositions]);
+
+  const visiblePages: VisiblePage[] = useMemo(() => {
+    return visibleSorted.map((p, i) => ({ filename: p.filename, visiblePageNum: i + 1 }));
+  }, [visibleSorted]);
 
   const visibleNumByFile: Record<string, number> = useMemo(() => {
     const map: Record<string, number> = {};

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -120,6 +120,10 @@ const WorkManage: React.FC = () => {
   const [imageToken, setImageToken] = useState<{ exp: number; sig: string } | null>(null);
   const [editorTarget, setEditorTarget] = useState<{ index: number; tab: 'edit' | 'split' } | null>(null);
 
+  const MIN_COLS = 3;
+  const MAX_COLS = 10;
+  const [gridCols, setGridCols] = useState(5);
+
   const isAdmin = user?.role === 'admin';
 
   useEffect(() => {
@@ -720,7 +724,31 @@ const WorkManage: React.FC = () => {
                   </div>
                 )}
 
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3 p-4">
+                <div className="flex items-center gap-2 px-4 pt-2 text-sm text-gray-600">
+                  <button
+                    onClick={() => setGridCols((c) => Math.max(c - 1, MIN_COLS))}
+                    disabled={gridCols <= MIN_COLS}
+                    className="px-2 py-0.5 border rounded disabled:opacity-40"
+                    title="Suuremad pisipildid"
+                  >−</button>
+                  <input
+                    type="range"
+                    min={MIN_COLS}
+                    max={MAX_COLS}
+                    value={MAX_COLS + MIN_COLS - gridCols}
+                    onChange={(e) => setGridCols(MAX_COLS + MIN_COLS - Number(e.target.value))}
+                  />
+                  <button
+                    onClick={() => setGridCols((c) => Math.min(c + 1, MAX_COLS))}
+                    disabled={gridCols >= MAX_COLS}
+                    className="px-2 py-0.5 border rounded disabled:opacity-40"
+                    title="Väiksemad pisipildid"
+                  >+</button>
+                </div>
+                <div
+                  className="grid gap-3 p-4"
+                  style={{ gridTemplateColumns: `repeat(${gridCols}, 1fr)` }}
+                >
                   {visibleSorted.map((page) => {
                     const vNum = visibleNumByFile[page.filename];
                     const isFocused = focus != null && vNum === focus;

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { parseFocusParam, buildBackToEditorPath } from '../utils/manageDeeplink';
@@ -258,12 +258,19 @@ const WorkManage: React.FC = () => {
 
   // Nähtav (effective) järjekord: draft kui olemas, muidu serveri page_num.
   // Iga lehe nähtav number on tema indeks selles järjestuses + 1.
-  const visibleSorted = [...pages].sort(
-    (a, b) => (draftPositions[a.filename] ?? a.page_num) - (draftPositions[b.filename] ?? b.page_num)
-  );
-  const visiblePages: VisiblePage[] = visibleSorted.map((p, i) => ({ filename: p.filename, visiblePageNum: i + 1 }));
-  const visibleNumByFile: Record<string, number> = {};
-  visiblePages.forEach((vp) => { visibleNumByFile[vp.filename] = vp.visiblePageNum; });
+  // useMemo: tagab stabiilse identiteedi, et fookus-effect ei käivitu iga renderi järel.
+  const visiblePages: VisiblePage[] = useMemo(() => {
+    const sorted = [...pages].sort(
+      (a, b) => (draftPositions[a.filename] ?? a.page_num) - (draftPositions[b.filename] ?? b.page_num)
+    );
+    return sorted.map((p, i) => ({ filename: p.filename, visiblePageNum: i + 1 }));
+  }, [pages, draftPositions]);
+
+  const visibleNumByFile: Record<string, number> = useMemo(() => {
+    const map: Record<string, number> = {};
+    visiblePages.forEach((vp) => { map[vp.filename] = vp.visiblePageNum; });
+    return map;
+  }, [visiblePages]);
 
   // Fookus-effect: kerib ja tõstab esile fookus-kaardi ainult esmasel laadimisel.
   // handledFocusRef guard väldib korduvat kerimist ka React StrictMode kahekordse
@@ -737,6 +744,7 @@ const WorkManage: React.FC = () => {
                     max={MAX_COLS}
                     value={MAX_COLS + MIN_COLS - gridCols}
                     onChange={(e) => setGridCols(MAX_COLS + MIN_COLS - Number(e.target.value))}
+                    aria-label="Veergude arv"
                   />
                   <button
                     onClick={() => setGridCols((c) => Math.min(c + 1, MAX_COLS))}

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
+import { parseFocusParam, buildBackToEditorPath } from '../utils/manageDeeplink';
 import {
   ArrowLeft,
   Plus,
@@ -52,6 +53,11 @@ const WorkManage: React.FC = () => {
   const { workId } = useParams<{ workId: string }>();
   const navigate = useNavigate();
   const { user, authToken } = useUser();
+  const [searchParams] = useSearchParams();
+  const focus = parseFocusParam(searchParams.get('focus'));
+  const focusedCardRef = useRef<HTMLDivElement | null>(null);
+  const [highlightedNum, setHighlightedNum] = useState<number | null>(null);
+  const handledFocusRef = useRef<number | null>(null);
 
   const [activeTab, setActiveTab] = useState<ActiveTab>('pages');
   const [pages, setPages] = useState<PageInfo[]>([]);
@@ -254,6 +260,26 @@ const WorkManage: React.FC = () => {
   const visiblePages: VisiblePage[] = visibleSorted.map((p, i) => ({ filename: p.filename, visiblePageNum: i + 1 }));
   const visibleNumByFile: Record<string, number> = {};
   visiblePages.forEach((vp) => { visibleNumByFile[vp.filename] = vp.visiblePageNum; });
+
+  // Fookus-effect: kerib ja tõstab esile fookus-kaardi ainult esmasel laadimisel.
+  // handledFocusRef guard väldib korduvat kerimist ka React StrictMode kahekordse
+  // effect-käivituse ja kasutaja hilisemate järjekorra-muudatuste korral.
+  useEffect(() => {
+    if (focus == null) return;
+    if (loading) return;                           // oota kuni lehed laetud
+    if (handledFocusRef.current === focus) return; // ainult kord (sh StrictMode)
+    // Kontrolli, et fookus-leht on nähtavas listis
+    const exists = Object.values(visibleNumByFile).includes(focus);
+    if (!exists) { handledFocusRef.current = focus; return; }
+    handledFocusRef.current = focus;
+    // Keri pärast renderit (aspect-[3/4] → kõrgused stabiilsed, üks rAF piisab)
+    requestAnimationFrame(() => {
+      focusedCardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    });
+    setHighlightedNum(focus);
+    const tid = setTimeout(() => setHighlightedNum(null), 2000);
+    return () => clearTimeout(tid);
+  }, [focus, loading, visibleNumByFile]);
 
   // Mitme lehe asukoht erineb salvestatud (serveri) järjekorrast
   const changedCount = pages.filter((p) => (draftPositions[p.filename] ?? p.page_num) !== p.page_num).length;
@@ -576,11 +602,11 @@ const WorkManage: React.FC = () => {
         {/* Navigatsioon tagasi */}
         <div className="flex items-center gap-3 mb-6">
           <button
-            onClick={() => navigate(`/work/${workId}/1`)}
+            onClick={() => navigate(buildBackToEditorPath(workId!, focus))}
             className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
           >
             <ArrowLeft size={16} />
-            {t('manage.backToWork')}
+            {focus != null ? t('manage.backToPage', { n: focus }) : t('manage.backToWork')}
           </button>
         </div>
 
@@ -697,9 +723,12 @@ const WorkManage: React.FC = () => {
                 <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3 p-4">
                   {visibleSorted.map((page) => {
                     const vNum = visibleNumByFile[page.filename];
+                    const isFocused = focus != null && vNum === focus;
                     return (
                       <PageCard
                         key={page.filename}
+                        ref={isFocused ? focusedCardRef : undefined}
+                        isFocused={isFocused && highlightedNum === focus}
                         workId={workId!}
                         filename={page.filename}
                         imageName={page.lehekylje_pilt.split('/').pop() ?? ''}

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -23,10 +23,12 @@ import LoginModal from '../components/LoginModal';
 import { getLabel } from '../utils/metadataUtils';
 import { ErrorBanner } from '../components/ErrorBanner';
 import { FILE_API_URL, MEILI_HOST, MEILI_INDEX } from '../config';
+import { buildManageLink } from '../utils/manageDeeplink';
 
 const Workspace: React.FC = () => {
   const { t } = useTranslation(['workspace', 'common', 'auth']);
   const { user, authToken, logout, sessionExpired, clearSessionExpired } = useUser();
+  const isAdmin = user?.role === 'admin';
   const { collections, selectedCollection, setSelectedCollection } = useCollection();
   const index = useMeiliIndex();
   const [viewerToken, setViewerToken] = useState<string | null>(null);
@@ -551,7 +553,14 @@ const Workspace: React.FC = () => {
         <div className="w-full h-1/2 md:w-1/2 md:h-full border-b md:border-b-0 md:border-r border-gray-300 relative bg-slate-900">
           {/* Lisame errori käsitluse pildile, juhuks kui pildiserver ei tööta */}
           {page.image_url ? (
-            <ImageViewer src={currentImageSrc} pageNum={page.page_number} onGridView={handleOpenGridView} onNavigate={(dir) => navigatePage(dir === 'next' ? 1 : -1)} />
+            <ImageViewer
+              src={currentImageSrc}
+              pageNum={page.page_number}
+              onGridView={handleOpenGridView}
+              onNavigate={(dir) => navigatePage(dir === 'next' ? 1 : -1)}
+              isAdmin={isAdmin}
+              onManage={() => navigate(buildManageLink(workId!, page.page_number))}
+            />
           ) : (
             <div className="flex items-center justify-center h-full text-white/50">
               Pilt puudub

--- a/src/pages/manage/PageCard.tsx
+++ b/src/pages/manage/PageCard.tsx
@@ -18,6 +18,7 @@ interface PageCardProps {
   thumbCacheBust: number;
   onToggle: (filename: string, shiftKey: boolean) => void;
   onEdit: (visiblePageNum: number) => void;
+  isFocused?: boolean;
 }
 
 const statusColor = (status: string) => {
@@ -28,12 +29,14 @@ const statusColor = (status: string) => {
   }
 };
 
-const PageCard: React.FC<PageCardProps> = (p) => {
+const PageCard = React.forwardRef<HTMLDivElement, PageCardProps>((p, ref) => {
   const { t } = useTranslation(['workspace', 'common']);
   return (
     <div
+      ref={ref}
       className={`relative flex flex-col rounded-lg border overflow-hidden bg-white ${
-        p.isSelected ? 'border-primary-500 ring-2 ring-primary-400'
+        p.isFocused ? 'ring-2 ring-blue-500 motion-safe:animate-pulse'
+          : p.isSelected ? 'border-primary-500 ring-2 ring-primary-400'
           : p.isChanged ? 'border-amber-400 ring-1 ring-amber-300' : 'border-gray-200'
       }`}
     >
@@ -104,6 +107,8 @@ const PageCard: React.FC<PageCardProps> = (p) => {
       </div>
     </div>
   );
-};
+});
+
+PageCard.displayName = 'PageCard';
 
 export default React.memo(PageCard);

--- a/src/utils/__tests__/manageDeeplink.test.ts
+++ b/src/utils/__tests__/manageDeeplink.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { buildManageLink, parseFocusParam, buildBackToEditorPath } from '../manageDeeplink';
+
+describe('buildManageLink', () => {
+  it('ehitab focus-lingi', () => {
+    expect(buildManageLink('abc123', 12)).toBe('/work/abc123/manage?focus=12');
+  });
+});
+
+describe('parseFocusParam', () => {
+  it('võtab vastu positiivse täisarvu', () => {
+    expect(parseFocusParam('12')).toBe(12);
+    expect(parseFocusParam('1')).toBe(1);
+  });
+  it('lükkab tagasi vigase sisendi', () => {
+    expect(parseFocusParam(null)).toBeNull();
+    expect(parseFocusParam('')).toBeNull();
+    expect(parseFocusParam('abc')).toBeNull();
+    expect(parseFocusParam('-1')).toBeNull();
+    expect(parseFocusParam('0')).toBeNull();
+    expect(parseFocusParam('12.5')).toBeNull();
+    expect(parseFocusParam('12abc')).toBeNull();
+  });
+});
+
+describe('buildBackToEditorPath', () => {
+  it('kasutab focus-i kui olemas', () => {
+    expect(buildBackToEditorPath('abc123', 12)).toBe('/work/abc123/12');
+  });
+  it('langeb tagasi lehele 1 kui focus puudub', () => {
+    expect(buildBackToEditorPath('abc123', null)).toBe('/work/abc123/1');
+  });
+});

--- a/src/utils/manageDeeplink.ts
+++ b/src/utils/manageDeeplink.ts
@@ -1,0 +1,18 @@
+/** Workspace → /manage deep-link konkreetsele lehele. */
+export function buildManageLink(workId: string, pageNum: number): string {
+  return `/work/${workId}/manage?focus=${pageNum}`;
+}
+
+/** Parsib ?focus= väärtuse. Lubatud ainult positiivne täisarv, muidu null. */
+export function parseFocusParam(raw: string | null): number | null {
+  if (raw == null) return null;
+  // Range: ainult puhas positiivne täisarv (mitte "12.5", "12abc", "-1", "0")
+  if (!/^[1-9][0-9]*$/.test(raw.trim())) return null;
+  const n = Number(raw.trim());
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+/** /manage → Workspace tagasitee. Parima-püüde: focus või leht 1. */
+export function buildBackToEditorPath(workId: string, focus: number | null): string {
+  return `/work/${workId}/${focus ?? 1}`;
+}


### PR DESCRIPTION
## Mida

Admin saab tekstiredaktorist (ImageViewer) hüpata otse `/manage`-isse **täpselt sellele lehele**, kus ta oli — viltuse/topeltlehe parandamiseks ilma konteksti kaotamata. `/manage` jääb ainsaks koduks kõigile lehe-operatsioonidele (poolita/crop/rotate/reorder/kustuta/re-OCR); see PR teeb selle ainult kontekstist kättesaadavaks ja ergonoomilisemaks. **Backend muutmata.**

### Käitumine
- **ImageViewer** (admin): käärid-nupp "Halda lehte" → `/work/:id/manage?focus=N`. Reset-nupu eksitav `RotateCcw` ikoon → `Maximize2` (loeb kui "mahuta vaade", mitte pööra).
- **/manage**: kerib fookus-lehele + lühike esiletõst (~2s, `prefers-reduced-motion` aware); ainult esmasel laadimisel (`handledFocusRef` guard, ei rescroll'i reorderil).
- **Tagasinupp**: olemasolev ülaserva nupp muudetud fookus-teadlikuks — `focus` korral viib õigele lehele (varem ALATI lehele 1), muidu senine käitumine.
- **Grid ergonoomika**: veeru-reguleerija 3–10 (suuremad pisipildid), `ThumbnailGrid` mustri järgi.

### Disain / plaan
- Spec: `docs/superpowers/specs/2026-06-27-context-to-manage-deeplink-design.md`
- Plaan: `docs/superpowers/plans/2026-06-27-context-to-manage-deeplink.md`

## Testid
- Puhas loogika (`src/utils/manageDeeplink.ts`) on vitest-iga kaetud (`buildManageLink`/`parseFocusParam`/`buildBackToEditorPath`). Kogu suite: **485/485 roheline**.
- Komponendi-ühendus verifitseeritud `npm run build`-iga (projektis pole React-komponentide testimise infrat).

## Tähelepanu väärt
- Mobiilivaade tahtlikult skoobist väljas (read-only; admin haldab desktopil).
- Tagasitee on **parima-püüde** (`focus`-number); kustutamise/reorderi järel langeb Workspace tavapärasele puuduv-leht-loogikale.
- Lõpp-review (opus) leidis ühe vea — fookus-highlight ei hääbunud (memo puudus) — **parandatud** commitis `375af0f` (`useMemo` `visibleNumByFile`).
- **Pärast merge'i**: `npm run build` + `rsync dist/` serverisse + manuaalne test (ainult frontend, backend-deploy pole vaja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)