### PR TITLE
Handle expired sessions on protected works

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -136,7 +136,7 @@ const Header: React.FC<HeaderProps> = ({
       {children}
 
       <LoginModal
-        isOpen={showLoginModal || sessionExpired}
+        isOpen={showLoginModal}
         onClose={() => {
           setShowLoginModal(false);
           clearSessionExpired();

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -126,6 +126,9 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             applySettings(settings);
           } catch {}
         } else {
+          // LocalStorage'is oli token, kuid server ütles, et see enam ei kehti.
+          // Jätame põhjuse alles, et piiratud vaated saaksid pakkuda uuesti sisselogimist.
+          setSessionExpired(true);
           localStorage.removeItem(TOKEN_KEY);
           localStorage.removeItem(STORAGE_KEY);
           localStorage.removeItem(SETTINGS_KEY);
@@ -155,13 +158,12 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         return;
       }
       if (!result) {
-        // Server kinnitas et token on aegunud — degradeeri VAIKSELT anonüümseks,
-        // täpselt nagu initAuth teeb lehe laadimisel/refreshil. Avalik vaade
-        // (teosed, isikud) jääb kättesaadavaks; sisselogimist küsitakse alles
-        // autenditud toimingul (nt salvestus → handleSave 401 → LoginModal).
-        // NB: EI sea setSessionExpired(true) — blokeeriv modaal jättis kasutaja
-        // avalikku sisu vaadates "token expired" akna taha lõksu (ainult hard
-        // refresh, mis läbib initAuth vaikse tee, päästis).
+        // Server kinnitas, et token on aegunud — degradeeri anonüümseks,
+        // kuid jäta UI-le teadmine, et põhjus oli sessiooni aegumine.
+        // NB: sessionExpired EI tohi avada globaalset blokeerivat modaali;
+        // vaated kasutavad seda kontekstipõhiselt (nt piiratud teose juures
+        // näidatakse "logi uuesti sisse", avalik sisu jääb kättesaadavaks).
+        setSessionExpired(true);
         setUser(null);
         setAuthToken(null);
         clearUserToken();
@@ -195,6 +197,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       if (data.status === 'success' && data.user && data.token) {
         setUser(data.user);
         setAuthToken(data.token);
+        setSessionExpired(false);
         localStorage.setItem(STORAGE_KEY, JSON.stringify(data.user));
         localStorage.setItem(TOKEN_KEY, data.token);
         if (data.meili_token) {
@@ -226,6 +229,7 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
     setUser(null);
     setAuthToken(null);
+    setSessionExpired(false);
     clearUserToken();
     setUserSettings({});
     localStorage.removeItem(STORAGE_KEY);

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -56,6 +56,12 @@
     "notLoggedIn": "You must be logged in to save.",
     "tokenMissing": "You must be logged in to save. Please log out and log in again."
   },
+  "errors": {
+    "accessDenied": "Access denied.",
+    "sessionExpiredProtectedWork": "Your session has expired. Please sign in again to view this work.",
+    "loginRequiredProtectedWork": "This work belongs to a restricted collection. Please sign in to view it.",
+    "pageNotFound": "Page not found. The pages of this document may have been reordered or deleted. Try going to the beginning of the work."
+  },
   "management": {
     "title": "Work management",
     "deleteWork": "Delete work",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -56,6 +56,12 @@
     "notLoggedIn": "Salvestamiseks pead olema sisse logitud.",
     "tokenMissing": "Salvestamiseks pead olema sisse logitud. Palun logi välja ja uuesti sisse."
   },
+  "errors": {
+    "accessDenied": "Ligipääs keelatud.",
+    "sessionExpiredProtectedWork": "Sinu sessioon on aegunud. Selle teose vaatamiseks logi uuesti sisse.",
+    "loginRequiredProtectedWork": "See teos asub piiratud ligipääsuga kollektsioonis. Vaatamiseks logi sisse.",
+    "pageNotFound": "Lehekülge ei leitud. Võimalik, et dokumendi lehekülgi on vahepeal ümber tõstetud või kustutatud. Proovi minna teose avalehele."
+  },
   "management": {
     "title": "Teose haldus",
     "deleteWork": "Kustuta teos",

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -41,6 +41,7 @@ const Workspace: React.FC = () => {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [errorRequiresLogin, setErrorRequiresLogin] = useState(false);
   const [page, setPage] = useState<Page | null>(null);
   const [work, setWork] = useState<Work | undefined>(undefined);
   const [editorChanges, setEditorChanges] = useState(false);
@@ -146,6 +147,7 @@ const Workspace: React.FC = () => {
       }
       setLoading(true);
       setError(null);
+      setErrorRequiresLogin(false);
       try {
         let [pageData, workData] = await Promise.all([
           getPage(effectiveIndex, workId, currentPageNum),
@@ -169,14 +171,23 @@ const Workspace: React.FC = () => {
             }
             return; // effectiveIndex uuendub → useEffect käivitub uuesti
           } else if (r.status === 403) {
-            setError(t('errors.accessDenied', { defaultValue: "Ligipääs keelatud." }));
+            if (sessionExpired) {
+              setError(t('errors.sessionExpiredProtectedWork'));
+              setErrorRequiresLogin(true);
+              setShowLoginModal(true);
+            } else if (!user) {
+              setError(t('errors.loginRequiredProtectedWork'));
+              setErrorRequiresLogin(true);
+            } else {
+              setError(t('errors.accessDenied', { defaultValue: "Ligipääs keelatud." }));
+            }
             setLoading(false);
             return;
           }
         }
 
         if (!pageData) {
-          setError("Lehekülge ei leitud. Võimalik, et dokumendi lehekülgi on vahepeal ümber tõstetud või kustutatud. Proovi minna teose avalehele.");
+          setError(t('errors.pageNotFound', { defaultValue: "Lehekülge ei leitud. Võimalik, et dokumendi lehekülgi on vahepeal ümber tõstetud või kustutatud. Proovi minna teose avalehele." }));
         } else {
           setPage(pageData);
           setCurrentStatus(pageData.status);
@@ -211,7 +222,7 @@ const Workspace: React.FC = () => {
       }
     };
     loadData();
-  }, [effectiveIndex, workId, currentPageNum, navigate, viewerToken, authToken, t]);
+  }, [effectiveIndex, workId, currentPageNum, navigate, viewerToken, authToken, sessionExpired, user, t]);
 
   // Metaandmete modaali avamine
   const openMetaModal = () => {
@@ -334,12 +345,22 @@ const Workspace: React.FC = () => {
             Debug: WorkID: {workId}, Page: {currentPageNum}
           </div>
           <div className="flex gap-3 justify-center">
-            <button
-              onClick={() => navigate(`/work/${workId}/1`, { replace: true })}
-              className="px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 transition-colors"
-            >
-              {t('workspace:navigation.toFirstPage', 'Mine teose algusesse')}
-            </button>
+            {errorRequiresLogin ? (
+              <button
+                onClick={() => setShowLoginModal(true)}
+                className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 transition-colors"
+              >
+                <LogIn size={16} />
+                {t('auth:login.title')}
+              </button>
+            ) : (
+              <button
+                onClick={() => navigate(`/work/${workId}/1`, { replace: true })}
+                className="px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 transition-colors"
+              >
+                {t('workspace:navigation.toFirstPage', 'Mine teose algusesse')}
+              </button>
+            )}
             <button
               onClick={() => navigate('/')}
               className="px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300 transition-colors"
@@ -661,12 +682,12 @@ const Workspace: React.FC = () => {
 
       {/* Login modaal (sessioon aegunud või käsitsi avatud) */}
       <LoginModal
-        isOpen={showLoginModal || sessionExpired}
+        isOpen={showLoginModal}
         onClose={() => {
           setShowLoginModal(false);
           clearSessionExpired();
         }}
-        message={sessionExpired ? t('auth:sessionExpired') : undefined}
+        message={sessionExpired ? t('errors.sessionExpiredProtectedWork') : undefined}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- preserve session-expired state after token expiry without globally blocking public views
- show targeted login-required/session-expired messaging when protected work loading fails
- add Estonian and English workspace error translations

## Test
- npm run build