### PR TITLE
Fix manage page thumbnail 403 retries

### DIFF
--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -206,19 +206,29 @@ const WorkManage: React.FC = () => {
     if (isAdmin) loadPages();
   }, [workId, authToken, isAdmin]);
 
+  // Pildi viewer-token piiratud teoste thumbnailide jaoks. Server-tokeni TTL on 1h
+  // (public.py), seega värskendame seda perioodiliselt — muidu aeguks token pikalt
+  // lahti oleval manage-lehel ja thumbid jääksid 403-lõputusse retry'sse (token on
+  // src-is, PageThumb ei küsi seda ise uuesti). Värske token → src muutub → reload.
   useEffect(() => {
     if (!workId || !authToken || !isAdmin) return;
-    fetchWithTimeout(`${FILE_API_URL}/work/${workId}/viewer-token`, {
-      headers: getAuthHeaders(authToken),
-      timeout: 10000,
-    })
-      .then(r => r.ok ? r.json() : null)
-      .then(d => {
-        if (d?.image_exp && d?.image_sig) {
-          setImageToken({ exp: d.image_exp, sig: d.image_sig });
-        }
+    let cancelled = false;
+    const fetchToken = () => {
+      fetchWithTimeout(`${FILE_API_URL}/work/${workId}/viewer-token`, {
+        headers: getAuthHeaders(authToken),
+        timeout: 10000,
       })
-      .catch(() => {});
+        .then(r => r.ok ? r.json() : null)
+        .then(d => {
+          if (!cancelled && d?.image_exp && d?.image_sig) {
+            setImageToken({ exp: d.image_exp, sig: d.image_sig });
+          }
+        })
+        .catch(() => {});
+    };
+    fetchToken();
+    const timer = setInterval(fetchToken, 45 * 60 * 1000); // 45 min < 1h TTL
+    return () => { cancelled = true; clearInterval(timer); };
   }, [workId, authToken, isAdmin]);
 
   // Re-OCR koondstaatus: laeb korra (näitab .ocr-ootel märke), pollib ainult aktiivse batchi ajal.

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -778,6 +778,7 @@ const WorkManage: React.FC = () => {
                         isSelected={selectedFiles.has(page.filename)}
                         isChanged={(draftPositions[page.filename] ?? page.page_num) !== page.page_num}
                         thumbCacheBust={thumbCacheBust}
+                        imageToken={imageToken}
                         onToggle={handleToggle}
                         onEdit={() => setEditorTarget({ index: page.page_num - 1, tab: 'edit' })}
                       />

--- a/src/pages/manage/PageCard.tsx
+++ b/src/pages/manage/PageCard.tsx
@@ -16,6 +16,7 @@ interface PageCardProps {
   isSelected: boolean;
   isChanged: boolean;
   thumbCacheBust: number;
+  imageToken?: { exp: number; sig: string } | null;
   onToggle: (filename: string, shiftKey: boolean) => void;
   onEdit: (visiblePageNum: number) => void;
   isFocused?: boolean;
@@ -31,6 +32,7 @@ const statusColor = (status: string) => {
 
 const PageCard = React.forwardRef<HTMLDivElement, PageCardProps>((p, ref) => {
   const { t } = useTranslation(['workspace', 'common']);
+  const imageTokenQuery = p.imageToken ? `&exp=${p.imageToken.exp}&sig=${p.imageToken.sig}` : '';
   return (
     <div
       ref={ref}
@@ -89,7 +91,7 @@ const PageCard = React.forwardRef<HTMLDivElement, PageCardProps>((p, ref) => {
         )}
         <PageThumb
           workId={p.workId}
-          src={`${IMAGE_BASE_URL}/${p.workId}/_thumbs/_thumb_${p.imageName}?v=${p.thumbCacheBust}`}
+          src={`${IMAGE_BASE_URL}/${p.workId}/_thumbs/_thumb_${p.imageName}?v=${p.thumbCacheBust}${imageTokenQuery}`}
           className="w-full h-full object-cover"
         />
         {/* Nähtav number — all vasakul */}

--- a/src/pages/manage/PageThumb.tsx
+++ b/src/pages/manage/PageThumb.tsx
@@ -50,10 +50,11 @@ const PageThumb: React.FC<{ workId: string; src: string; className: string }> = 
             setTokenQuery(`&exp=${d.image_exp}&sig=${d.image_sig}`);
             return;
           }
-        }
-        // Kui server ütleb päriselt "ei" (nt õigust pole), pole mõtet iga retry'ga tokenit uuesti küsida.
-        // Võrgu/timeout'i catch jätab lipu false'iks, et järgmine taustakatse prooviks uuesti.
-        if (r.status === 401 || r.status === 403 || r.status === 404) {
+          // 200, aga token puudub (nt avalik teos) → tokenist pole abi, ära küsi iga retry'ga uuesti.
+          tokenTriedRef.current = true;
+        } else if (r.status === 401 || r.status === 403 || r.status === 404) {
+          // Server ütleb päriselt "ei" (õigust pole / teost pole) → ära küsi iga retry'ga uuesti.
+          // Võrgu/timeout'i catch jätab lipu false'iks, et järgmine taustakatse prooviks uuesti.
           tokenTriedRef.current = true;
         }
       } catch { /* transientne võrgutõrge — järgmine retry proovib tokenit uuesti */ }

--- a/src/pages/manage/PageThumb.tsx
+++ b/src/pages/manage/PageThumb.tsx
@@ -28,6 +28,7 @@ const PageThumb: React.FC<{ workId: string; src: string; className: string }> = 
   }, [src]);
 
   const imgSrc = buildThumbUrl(src, tokenQuery, nonce);
+  const srcHasImageToken = src.includes('exp=') && src.includes('sig=');
 
   const scheduleReload = (delay: number) => {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -36,8 +37,7 @@ const PageThumb: React.FC<{ workId: string; src: string; className: string }> = 
 
   const handleError = async () => {
     // 1) Esimene viga: ehk piiratud teos → proovi signeeritud viewer-tokenit.
-    if (!tokenTriedRef.current && workId) {
-      tokenTriedRef.current = true;
+    if (!srcHasImageToken && !tokenTriedRef.current && workId) {
       try {
         const r = await fetchWithTimeout(`${FILE_API_URL}/work/${workId}/viewer-token`, {
           headers: getAuthHeaders(authToken),
@@ -46,11 +46,17 @@ const PageThumb: React.FC<{ workId: string; src: string; className: string }> = 
         if (r.ok) {
           const d = await r.json();
           if (d.image_exp && d.image_sig) {
+            tokenTriedRef.current = true;
             setTokenQuery(`&exp=${d.image_exp}&sig=${d.image_sig}`);
             return;
           }
         }
-      } catch { /* kukub allolevasse transientse retry-loogikasse */ }
+        // Kui server ütleb päriselt "ei" (nt õigust pole), pole mõtet iga retry'ga tokenit uuesti küsida.
+        // Võrgu/timeout'i catch jätab lipu false'iks, et järgmine taustakatse prooviks uuesti.
+        if (r.status === 401 || r.status === 403 || r.status === 404) {
+          tokenTriedRef.current = true;
+        }
+      } catch { /* transientne võrgutõrge — järgmine retry proovib tokenit uuesti */ }
     }
     // 2) Transientne viga (aeglane ühendus / serveri thumb-genereerimise viivitus):
     //    JÄTKA proovimist kasvava (kuni ~5s) viivitusega — <img> jääb monteerituks,


### PR DESCRIPTION
## Kokkuvõte
- lisa manage-lehe pisipiltide URL-idele teose viewer-token (`exp`/`sig`), kui see on juba `WorkManage`-is olemas
- väldi olukorda, kus `PageThumb` jätkab lõputult 403 retry'd ilma tokenita
- luba transientse viewer-token fetchi vea korral järgmisel retry'l tokenit uuesti küsida

## Diagnoos
Networkis nähtud URL-id olid kujul `...?v=...&retry=56` ja said 403 `Keelatud`. Piiratud teoste pildiserver ootab aga `exp` ja `sig` query-parameetreid. `WorkManage` küsis tokeni juba ette, kuid thumbnail-grid ei kasutanud seda.

## Kontroll
- `npm run typecheck`
- `npm run build`
