### PR TITLE
fix(prosopo): selgita seoste-kaardi tühja teadet kollektsioonifiltri korral

### DIFF
--- a/server/prosopography/ops.py
+++ b/server/prosopography/ops.py
@@ -166,6 +166,20 @@ def _persons_in_collection(collection_id: str) -> set:
     }
 
 
+def _person_collections(person_id: str) -> list:
+    """Kollektsioonid (teose ENDA omad, ilma hierarhia laienduseta), kuhu isiku
+    teosed kuuluvad. Dedup, esmaesinemise järjekord säilib. Kasutatakse
+    seoste-kaardi vihjes, kui valitud kollektsioon isiku võrgustiku välja filtreerib."""
+    wc = _load_work_collections()
+    ptw = _load_person_to_works()
+    result: list = []
+    for entry in ptw.get(person_id, ()):
+        for cid in wc.get(entry.get("work_id"), ()):
+            if cid not in result:
+                result.append(cid)
+    return result
+
+
 def _load_person_aliases() -> dict:
     if os.path.exists(PERSON_ALIASES_FILE):
         try:
@@ -956,12 +970,26 @@ def get_person_map_markers(
         markers_by_place.values(),
         key=lambda m: (-m["count"], (m.get("place_key") or "").lower()),
     )
-    return {
+    response = {
         "markers": markers,
         "total_persons": len(entries),
         "mapped_persons": sum(m["count"] for m in markers),
         "without_coordinates": without_coordinates,
     }
+    # Seoste-kaardi vihje jaoks: fookus-isiku nimi + kollektsioonid, kuhu ta ise
+    # kuulub. Frontend kuvab nende põhjal selgituse, kui valitud kollektsioon
+    # isiku võrgustiku tühjaks filtreeris.
+    if related_to:
+        focus_label = next(
+            (e.get("label") for e in _load_index().get("entries", []) if e.get("id") == related_to),
+            None,
+        )
+        response["focus"] = {
+            "id": related_to,
+            "label": focus_label,
+            "collections": _person_collections(related_to),
+        }
+    return response
 
 
 def _structured_relation_ids(person: Optional[dict]) -> list[str]:

--- a/src/locales/en/prosopography.json
+++ b/src/locales/en/prosopography.json
@@ -248,7 +248,12 @@
     "markerCount": "{{count}} places",
     "mappedCount": "{{mapped}} / {{total}} persons on map",
     "withoutCoordinates": "{{count}} persons without coordinates",
-    "shiftedMarker": "Marker slightly shifted to avoid overlap."
+    "shiftedMarker": "Marker slightly shifted to avoid overlap.",
+    "thisPerson": "This person",
+    "collectionHintNamed": "{{name}} belongs to a different collection than the one currently selected (“{{selected}}”). Switch collection to see their relations.",
+    "collectionHintGeneric": "The selected collection (“{{selected}}”) contains none of this person's relations.",
+    "switchToCollection": "Open “{{name}}”",
+    "showAllCollections": "Show all collections"
   },
   "place": {
     "searchPlaceholder": "Search city, parish, region…",

--- a/src/locales/et/prosopography.json
+++ b/src/locales/et/prosopography.json
@@ -248,7 +248,12 @@
     "markerCount": "{{count}} kohta",
     "mappedCount": "{{mapped}} / {{total}} isikut kaardil",
     "withoutCoordinates": "{{count}} isikul puudub koordinaat",
-    "shiftedMarker": "Marker on kattuvuse vältimiseks veidi nihutatud."
+    "shiftedMarker": "Marker on kattuvuse vältimiseks veidi nihutatud.",
+    "thisPerson": "See isik",
+    "collectionHintNamed": "{{name}} kuulub teise kollektsiooni kui praegu valitud („{{selected}}\"). Tema seoste nägemiseks vaheta kollektsiooni.",
+    "collectionHintGeneric": "Valitud kollektsioonis („{{selected}}\") pole selle isiku seoseid.",
+    "switchToCollection": "Ava „{{name}}\"",
+    "showAllCollections": "Näita kõiki kollektsioone"
   },
   "place": {
     "searchPlaceholder": "Otsi linna, kihelkonda, piirkonda…",

--- a/src/prosopography/components/PersonsMap.tsx
+++ b/src/prosopography/components/PersonsMap.tsx
@@ -5,6 +5,7 @@ import { LatLngBoundsExpression, divIcon } from 'leaflet';
 import { MapContainer, Marker, Popup, TileLayer, useMap } from 'react-leaflet';
 import { Loader2, MapPin, Users } from 'lucide-react';
 import { fetchPersonMapMarkers } from '../services/prosopographyService';
+import { useCollection } from '../../contexts/CollectionContext';
 import type { ProsopoMapMarker, ProsopoMapResponse } from '../types';
 
 interface PersonsMapProps {
@@ -98,6 +99,7 @@ const FitMapToMarkers: React.FC<{ markers: ProsopoMapMarker[]; focusPlace?: stri
 
 const PersonsMap: React.FC<PersonsMapProps> = ({ filters, token, focusPlace }) => {
   const { t, i18n } = useTranslation(['prosopography', 'common']);
+  const { setSelectedCollection, getCollectionName } = useCollection();
   const lang = i18n.language?.slice(0, 2) ?? 'et';
   const [data, setData] = useState<ProsopoMapResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -136,9 +138,50 @@ const PersonsMap: React.FC<PersonsMapProps> = ({ filters, token, focusPlace }) =
   }
 
   if (!data || data.markers.length === 0) {
+    // Vihje: kui seoste-kaart on tühi valitud kollektsiooni tõttu, selgita miks
+    // ja paku kollektsiooni vahetamist (vt fix: related_to + kollektsioon).
+    const selected = filters.related_to ? filters.collection : undefined;
+    const focusName = data?.focus?.label || t('map.thisPerson', 'See isik');
+    const otherCollections = (data?.focus?.collections ?? []).filter(c => c !== selected);
+    const lng = lang === 'en' ? 'en' : 'et';
+
     return (
-      <div className="h-[420px] bg-white border border-gray-200 rounded-xl flex items-center justify-center text-gray-400 text-sm">
-        {t('map.noMarkers', 'Kaardile kantavaid päritolukohti ei leitud.')}
+      <div className="min-h-[420px] bg-white border border-gray-200 rounded-xl flex flex-col items-center justify-center gap-3 text-center px-6 py-10">
+        <MapPin size={22} className="text-gray-300" />
+        <p className="text-gray-500 text-sm">{t('map.noMarkers', 'Kaardile kantavaid päritolukohti ei leitud.')}</p>
+        {selected && (
+          <div className="max-w-md space-y-3">
+            <p className="text-sm text-gray-600">
+              {otherCollections.length > 0
+                ? t('map.collectionHintNamed', '{{name}} kuulub teise kollektsiooni kui praegu valitud („{{selected}}"). Tema seoste nägemiseks vaheta kollektsiooni.', {
+                    name: focusName,
+                    selected: getCollectionName(selected, lng),
+                  })
+                : t('map.collectionHintGeneric', 'Valitud kollektsioonis („{{selected}}") pole selle isiku seoseid.', {
+                    selected: getCollectionName(selected, lng),
+                  })}
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              {otherCollections.map(c => (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => setSelectedCollection(c)}
+                  className="rounded-full border border-primary-300 bg-primary-50 px-3 py-1.5 text-xs font-medium text-primary-700 hover:bg-primary-100 transition-colors"
+                >
+                  {t('map.switchToCollection', 'Ava „{{name}}"', { name: getCollectionName(c, lng) })}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => setSelectedCollection(null)}
+                className="rounded-full border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+              >
+                {t('map.showAllCollections', 'Näita kõiki kollektsioone')}
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/prosopography/types.ts
+++ b/src/prosopography/types.ts
@@ -91,6 +91,13 @@ export interface ProsopoMapResponse {
   total_persons: number;
   mapped_persons: number;
   without_coordinates: number;
+  // Ainult related_to päringul: fookus-isiku nimi + kollektsioonid, kuhu ta kuulub.
+  // Kasutatakse tühja-teate vihjes, kui valitud kollektsioon võrgustiku välja filtreeris.
+  focus?: {
+    id: string;
+    label: string | null;
+    collections: string[];
+  };
 }
 
 export interface HistoricalDate {

--- a/tests/test_work_collections.py
+++ b/tests/test_work_collections.py
@@ -121,6 +121,59 @@ def test_list_persons_collection_filters(tmp_path):
     assert res["total"] == 1
 
 
+def test_person_collections_returns_works_own_collections(tmp_path):
+    ops = _ops(tmp_path)
+    wc_file = tmp_path / "work_collections_index.json"
+    ptw_file = tmp_path / "ptw.json"
+    # w1 → c-child, w2 → c-other; tagastatakse teose ENDA kollektsioonid (ilma hierarhia laienduseta)
+    wc_file.write_text(json.dumps({"w1": ["c-child"], "w2": ["c-other"]}), encoding="utf-8")
+    ptw_file.write_text(json.dumps({
+        "vutt:Pmulti":  [{"work_id": "w1", "role": "creator"}, {"work_id": "w2", "role": "mentioned"}],
+        "vutt:Pnowork": [],
+    }), encoding="utf-8")
+
+    with mock.patch.object(ops, "WORK_COLLECTIONS_INDEX_FILE", str(wc_file)), \
+         mock.patch.object(ops, "PERSON_TO_WORKS_FILE", str(ptw_file)):
+        assert ops._person_collections("vutt:Pmulti") == ["c-child", "c-other"]
+        assert ops._person_collections("vutt:Pnowork") == []
+        assert ops._person_collections("vutt:Punknown") == []
+
+
+def test_map_markers_includes_focus_for_related_to(tmp_path):
+    ops = _ops(tmp_path)
+    wc_file = tmp_path / "work_collections_index.json"
+    ptw_file = tmp_path / "ptw.json"
+    idx_file = tmp_path / "idx.json"
+    # Fookus-isik kuulub 'c-other'-isse, kuid valitud on 'parent' (c-other pole järglane)
+    wc_file.write_text(json.dumps({"w1": ["c-other"]}), encoding="utf-8")
+    ptw_file.write_text(json.dumps({"vutt:Pfocus": [{"work_id": "w1", "role": "creator"}]}), encoding="utf-8")
+    idx_file.write_text(json.dumps({"entries": [
+        {"id": "vutt:Pfocus", "label": "Focus Inimene", "sort_name": "focus", "record_status": "published"},
+    ]}), encoding="utf-8")
+
+    with mock.patch.object(ops, "WORK_COLLECTIONS_INDEX_FILE", str(wc_file)), \
+         mock.patch.object(ops, "PERSON_TO_WORKS_FILE", str(ptw_file)), \
+         mock.patch.object(ops, "PROSOPOGRAPHY_INDEX_FILE", str(idx_file)), \
+         mock.patch.object(ops, "get_person_relation_network_ids", return_value=["vutt:Pfocus"]), \
+         mock.patch("server.cache.get_cached_collections", return_value=COLLECTIONS):
+        res = ops.get_person_map_markers(related_to="vutt:Pfocus", collection="parent")
+
+    assert res["focus"]["id"] == "vutt:Pfocus"
+    assert res["focus"]["label"] == "Focus Inimene"
+    assert res["focus"]["collections"] == ["c-other"]
+    # 'parent' ei hõlma 'c-other'-it → kõik filtreeritakse välja
+    assert res["markers"] == []
+
+
+def test_map_markers_no_focus_without_related_to(tmp_path):
+    ops = _ops(tmp_path)
+    idx_file = tmp_path / "idx.json"
+    idx_file.write_text(json.dumps({"entries": []}), encoding="utf-8")
+    with mock.patch.object(ops, "PROSOPOGRAPHY_INDEX_FILE", str(idx_file)):
+        res = ops.get_person_map_markers()
+    assert "focus" not in res
+
+
 def test_save_work_metadata_updates_collections_even_when_call_ptw_false(tmp_path):
     metadata_ops = importlib.import_module("server.metadata_ops")
     ops = importlib.import_module("server.prosopography.ops")


### PR DESCRIPTION
## Probleem

`/persons?view=map&related_to=<id>` kuvas mõne isiku puhul **"Kaardile kantavaid päritolukohti ei leitud"**, kuigi isikul on kindlasti kaardile kantav päritolukoht.

**Juur:** seoste-kaart ristub *globaalselt valitud* kollektsiooniga. Kui isiku teosed kuuluvad teise kollektsiooni kui valitud, jääb ristumine tühjaks. Nt Adam Koljo (`vutt:P5mbvp8`) teosed on `vennastekoguduse-materjalid`-es, aga sisenedes oli valitud `universitas-dorpatensis-1` → tühi.

Käitumine ise on **õige** (kollektsiooniline skoop kehtib teadlikult ka seoste-kaardil, see pole uus — lisatud 2026-06-10 `d37c7b0`/`8c8de24`). Eksitav oli ainult **teade**: kasutaja ei mõistnud, et põhjus on valitud kollektsioon.

## Lahendus — selgitav vihje

Tühja seoste-kaardi korral (kui `related_to` + kollektsioon on aktiivne) kuvatakse nüüd, **miks** on tühi, ja pakutakse tegevusnuppe:

> *{Isik} kuulub teise kollektsiooni kui praegu valitud („{X}"). Tema seoste nägemiseks vaheta kollektsiooni.*
>
> **[ Ava „{isiku kollektsioon}" ]  [ Näita kõiki kollektsioone ]**

## Muudatused

- **`server/prosopography/ops.py`** — uus `_person_collections()`; `get_person_map_markers` tagastab `related_to` korral `focus={id, label, collections}`.
- **`src/prosopography/components/PersonsMap.tsx`** — tühi seisund nimetab isiku kollektsiooni + nupud (`setSelectedCollection`).
- **`src/prosopography/types.ts`** — `ProsopoMapResponse.focus`.
- **`src/locales/{et,en}/prosopography.json`** — 5 uut `map.*` võtit.
- **`tests/test_work_collections.py`** — 3 uut testi.

## Märkused

- **Skoop:** ainult kollektsioonifiltri (sisseloginud kasutaja) juht. Kaitstud-töö (anon/õiguseta) juhtu **ei puudutatud** — see on juba `Workspace.tsx`-is (`loginRequiredProtectedWork` / `sessionExpiredProtectedWork` / `accessDenied`).
- **Deploy nõuab mõlemat kihti:** backend `docker compose build --no-cache backend` + frontend `npm run build` & `rsync dist/`.

## Test
- `npm run typecheck` ✅
- `pytest tests/ -k "prosop or person or map or collection"` → 117 passed (sh 3 uut) ✅
- Brauseris veel kontrollimata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)