### PR TITLE
fix(map): isolate Leaflet stacking context so it stays under modals

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -355,6 +355,14 @@ hr.page-break::before {
   background: transparent;
 }
 
+/* Leaflet seab sisemistele kihtidele/kontrollidele z-index kuni 1000. Ilma oma
+   stacking-kontekstita ulatuvad need modaalide (nt kollektsiooni valija, z-50) ja
+   muu UI alt välja. isolation: isolate hoiab kõik Leafleti z-indeksid kaardi enda
+   konteksti sees, nii et kaart püsib modaalide all. */
+.leaflet-container {
+  isolation: isolate;
+}
+
 .vutt-map-marker {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Probleem
Seoste-kaardi (ja teiste Leaflet-kaartide) sisemised z-indeksid (Leaflet seab kihtidele/kontrollidele kuni `z-index: 1000`) ulatusid kollektsiooni valija modaali (`CollectionPicker`, `z-50`) alt välja — kaart kuvati modaali peal.

## Lahendus
`.leaflet-container { isolation: isolate }` (`src/index.css`) loob kaardile oma stacking-konteksti, nii et Leafleti z-indeksid jäävad kaardi sisse ega konkureeri modaalide/päisega. Mõjutab kõiki kaarte (PersonsMap, PlacesDetail, /map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)