### PR TITLE
docs: document nginx /sitemap.xml exact-match proxy rule

### DIFF
--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -188,6 +188,17 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Sitemap: dünaamiline XML backendist. KOHUSTUSLIK exact-match (`= `),
+    # muidu langeb `location /` SPA-fallbacki ja Google saab HTML-i
+    # ("Your Sitemap appears to be an HTML page"). NB: robots.txt keelab
+    # `/api/`, seega sitemap PEAB olema serveeritav juurtee alt (mitte
+    # `/api/files/sitemap.xml`).
+    location = /sitemap.xml {
+        proxy_pass http://127.0.0.1:8002/sitemap.xml;
+        proxy_set_header Host $host;
+        add_header Cache-Control "no-cache";
+    }
+
     # API Proxy (Dockerisse)
     location /api/files/ {
         proxy_pass http://127.0.0.1:8002/;


### PR DESCRIPTION
## Taust

Google Search Console raporteeris: *"Your Sitemap appears to be an HTML page."* Põhjus: nginx-il puudus reegel `/sitemap.xml` jaoks, seega päring langes `location /` SPA-fallbacki (`try_files … /index.html`) ja Google sai HTML-i.

Backend genereerib korrektse XML-i (`build_sitemap_xml`), aga see on kättesaadav ainult `/api/files/` proxy-prefiksi alt — mille robots.txt keelab. Seetõttu peab sitemap olema serveeritav juurtee alt exact-match proxy-reegliga.

## Muudatus

Lisab `docs/deployment_guide.md` nginx-näidiskonfigi `location = /sitemap.xml` bloki + selgitava kommentaari, et seda from-scratch reconfig'il mitte unustada.

NB: tegelik prod-fix tehti juba hosti nginx-is (`/etc/nginx/sites-available/vutt`, mis pole gitis); verifitseeritud — Search Console luges 3 323 lehte, staatus Success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)