### PR TITLE
feat: markdown notes editor for prosopography notes & biography

### DIFF
--- a/docs/superpowers/plans/2026-06-29-markdown-notes-editor.md
+++ b/docs/superpowers/plans/2026-06-29-markdown-notes-editor.md
@@ -1,0 +1,850 @@
+# Markdown Notes Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reusable, discoverable markdown editor (toolbar + preview) and a safe markdown renderer, then wire them into the prosopography Notes and Biography fields.
+
+**Architecture:** Two domain-neutral components in `src/components/`: `MarkdownEditor` (textarea + formatting toolbar + write/preview tabs + link popover) and `MarkdownView` (react-markdown render with a strict element allow-list). All text-transform logic lives in pure, unit-tested helpers (`markdownEditorHelpers.ts`). No backend, data model, or migration changes — `notes`/`biography` stay plain markdown strings.
+
+**Tech Stack:** React 19 + TypeScript, `react-markdown` (existing), `remark-gfm` (new), Tailwind, lucide-react icons, vitest (node env), react-i18next.
+
+## Global Constraints
+
+- **Markdown only — no raw HTML.** Do NOT use `rehype-raw`. Raw HTML must stay escaped.
+- **Rendered DOM is allow-listed** to: `p, strong, em, del, a, ul, ol, li, h1, h2, h3, blockquote, code, br`, with `unwrapDisallowed`.
+- **Components are domain-neutral** (`src/components/`) — no person/prosopography coupling. API takes only text in/out.
+- **i18n in `common` namespace** (default NS) under key `markdownEditor`; add to BOTH `src/locales/et/common.json` and `src/locales/en/common.json`.
+- **Tests are `.test.ts` only** (vitest `include: ['src/**/*.test.ts']`, `environment: 'node'`) — pure functions, no DOM. React components are verified by `npm run typecheck` + manual QA.
+- **Frontend gate:** `npm run typecheck` (= `tsc --noEmit`), not just `build`.
+- **v1 scope:** toolbar buttons only ADD syntax (no toggle/removal). No tables/footnotes/tasklists UI. No keyboard shortcuts.
+- Tailwind brand classes in this repo: `primary-500/600/700`.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/components/markdownEditorHelpers.ts` — pure text-transform functions
+- `src/components/__tests__/markdownEditorHelpers.test.ts` — unit tests
+- `src/components/MarkdownView.tsx` — safe markdown renderer
+- `src/components/MarkdownEditor.tsx` — toolbar + preview + link popover
+
+**Modify:**
+- `package.json` — add `remark-gfm` dependency
+- `src/index.css` — add `.vutt-md` styles
+- `src/locales/et/common.json` — add `markdownEditor` block
+- `src/locales/en/common.json` — add `markdownEditor` block
+- `src/prosopography/pages/PersonEditPage.tsx` — Biography + Notes textareas → `MarkdownEditor`
+- `src/prosopography/pages/PersonDetailPage.tsx` — Notes `<p>` + Biography `<ReactMarkdown>` → `MarkdownView`
+
+---
+
+## Task 1: Pure text-transform helpers
+
+**Files:**
+- Create: `src/components/markdownEditorHelpers.ts`
+- Test: `src/components/__tests__/markdownEditorHelpers.test.ts`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces:
+  - `interface SelectionResult { text: string; start: number; end: number }`
+  - `interface LinkPrefill { linkText: string; url: string; focusField: 'text' | 'url' }`
+  - `applyWrap(text: string, start: number, end: number, marker: string, placeholder: string): SelectionResult`
+  - `applyLinePrefix(text: string, start: number, end: number, prefix: string, options?: { skipIfPresent?: boolean }): SelectionResult`
+  - `looksLikeUrl(s: string): boolean`
+  - `linkPrefillFromSelection(selected: string): LinkPrefill`
+  - `insertLink(text: string, start: number, end: number, label: string, url: string): SelectionResult`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/__tests__/markdownEditorHelpers.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  applyWrap,
+  applyLinePrefix,
+  looksLikeUrl,
+  linkPrefillFromSelection,
+  insertLink,
+} from '../markdownEditorHelpers';
+
+describe('applyWrap', () => {
+  it('wraps a non-empty selection and keeps the inner text selected', () => {
+    const r = applyWrap('Fischer', 0, 7, '**', 'paks');
+    expect(r.text).toBe('**Fischer**');
+    expect(r.start).toBe(2);
+    expect(r.end).toBe(9);
+  });
+
+  it('inserts a placeholder when the selection is empty and selects it', () => {
+    const r = applyWrap('', 0, 0, '**', 'paks');
+    expect(r.text).toBe('**paks**');
+    expect(r.start).toBe(2);
+    expect(r.end).toBe(6);
+  });
+
+  it('wraps in the middle of existing text', () => {
+    const r = applyWrap('a b c', 2, 3, '*', 'x');
+    expect(r.text).toBe('a *b* c');
+    expect(r.start).toBe(3);
+    expect(r.end).toBe(4);
+  });
+});
+
+describe('applyLinePrefix', () => {
+  it('adds a heading prefix to the current line', () => {
+    const r = applyLinePrefix('Title\nbody', 0, 0, '## ');
+    expect(r.text).toBe('## Title\nbody');
+  });
+
+  it('prefixes every selected line for a list', () => {
+    const r = applyLinePrefix('a\nb\nc', 0, 5, '- ', { skipIfPresent: true });
+    expect(r.text).toBe('- a\n- b\n- c');
+  });
+
+  it('skips lines that already have the prefix (no duplication)', () => {
+    const r = applyLinePrefix('- a\nb\nc', 0, 7, '- ', { skipIfPresent: true });
+    expect(r.text).toBe('- a\n- b\n- c');
+  });
+});
+
+describe('looksLikeUrl', () => {
+  it('detects http/https/www', () => {
+    expect(looksLikeUrl('https://archive.org/x')).toBe(true);
+    expect(looksLikeUrl('  http://x ')).toBe(true);
+    expect(looksLikeUrl('www.example.com')).toBe(true);
+  });
+  it('rejects plain text', () => {
+    expect(looksLikeUrl('Johann Fischer')).toBe(false);
+  });
+});
+
+describe('linkPrefillFromSelection', () => {
+  it('prefills URL field when selection is a URL (focus on text)', () => {
+    const p = linkPrefillFromSelection('https://archive.org/very/long');
+    expect(p.url).toBe('https://archive.org/very/long');
+    expect(p.linkText).toBe('');
+    expect(p.focusField).toBe('text');
+  });
+  it('prefills link text when selection is plain text (focus on url)', () => {
+    const p = linkPrefillFromSelection('Johann Fischer');
+    expect(p.linkText).toBe('Johann Fischer');
+    expect(p.url).toBe('');
+    expect(p.focusField).toBe('url');
+  });
+  it('focuses text field when selection is empty', () => {
+    const p = linkPrefillFromSelection('');
+    expect(p.focusField).toBe('text');
+  });
+});
+
+describe('insertLink', () => {
+  it('replaces a selection with a markdown link', () => {
+    const r = insertLink('Johann Fischer', 0, 14, 'Johann Fischer', 'http://x');
+    expect(r.text).toBe('[Johann Fischer](http://x)');
+    expect(r.start).toBe(r.end);
+  });
+  it('falls back to url as label when label empty', () => {
+    const r = insertLink('', 0, 0, '', 'http://x');
+    expect(r.text).toBe('[http://x](http://x)');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/components/__tests__/markdownEditorHelpers.test.ts`
+Expected: FAIL — `Cannot find module '../markdownEditorHelpers'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/components/markdownEditorHelpers.ts`:
+
+```ts
+// Puhtad tekstiteisendused MarkdownEditor jaoks. DOM-vabad, unit-testitavad.
+
+export interface SelectionResult {
+  text: string;
+  start: number;
+  end: number;
+}
+
+export interface LinkPrefill {
+  linkText: string;
+  url: string;
+  focusField: 'text' | 'url';
+}
+
+// Mähib valiku sümmeetrilise markeriga (** paksule, * kursiivile).
+// Tühja valiku korral lisab markeri + kohahoidja ja valib kohahoidja.
+export function applyWrap(
+  text: string,
+  start: number,
+  end: number,
+  marker: string,
+  placeholder: string,
+): SelectionResult {
+  const selected = text.slice(start, end);
+  if (selected.length === 0) {
+    const inserted = `${marker}${placeholder}${marker}`;
+    const newText = text.slice(0, start) + inserted + text.slice(end);
+    const selStart = start + marker.length;
+    return { text: newText, start: selStart, end: selStart + placeholder.length };
+  }
+  const inserted = `${marker}${selected}${marker}`;
+  const newText = text.slice(0, start) + inserted + text.slice(end);
+  const innerStart = start + marker.length;
+  return { text: newText, start: innerStart, end: innerStart + selected.length };
+}
+
+// Lisab rea-prefiksi (nt "## " või "- ") iga valikus oleva rea algusesse.
+// skipIfPresent: jätab vahele read, mis juba prefiksiga algavad (väldib topeldamist).
+export function applyLinePrefix(
+  text: string,
+  start: number,
+  end: number,
+  prefix: string,
+  options?: { skipIfPresent?: boolean },
+): SelectionResult {
+  const lineStart = text.lastIndexOf('\n', start - 1) + 1; // 0 kui puudub
+  let lineEnd = text.indexOf('\n', end);
+  if (lineEnd === -1) lineEnd = text.length;
+
+  const block = text.slice(lineStart, lineEnd);
+  const newBlock = block
+    .split('\n')
+    .map(line => (options?.skipIfPresent && line.startsWith(prefix) ? line : prefix + line))
+    .join('\n');
+
+  const newText = text.slice(0, lineStart) + newBlock + text.slice(lineEnd);
+  return { text: newText, start: lineStart, end: lineStart + newBlock.length };
+}
+
+const URL_RE = /^(https?:\/\/|www\.)/i;
+
+export function looksLikeUrl(s: string): boolean {
+  return URL_RE.test(s.trim());
+}
+
+// Eeltäidab lingi-popoveri praeguse valiku põhjal.
+export function linkPrefillFromSelection(selected: string): LinkPrefill {
+  const trimmed = selected.trim();
+  if (trimmed && looksLikeUrl(trimmed)) {
+    return { linkText: '', url: trimmed, focusField: 'text' };
+  }
+  return { linkText: selected, url: '', focusField: trimmed ? 'url' : 'text' };
+}
+
+// Lisab markdown-lingi [label](url), asendades valiku. Kursor jääb lingi järele.
+export function insertLink(
+  text: string,
+  start: number,
+  end: number,
+  label: string,
+  url: string,
+): SelectionResult {
+  const safeUrl = url.trim();
+  const safeLabel = label || safeUrl || 'link';
+  const inserted = `[${safeLabel}](${safeUrl})`;
+  const newText = text.slice(0, start) + inserted + text.slice(end);
+  const cursor = start + inserted.length;
+  return { text: newText, start: cursor, end: cursor };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/components/__tests__/markdownEditorHelpers.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/markdownEditorHelpers.ts src/components/__tests__/markdownEditorHelpers.test.ts
+git commit -m "feat: markdown editor text-transform helpers + tests"
+```
+
+---
+
+## Task 2: MarkdownView renderer + remark-gfm + CSS
+
+**Files:**
+- Modify: `package.json` (add `remark-gfm`)
+- Create: `src/components/MarkdownView.tsx`
+- Modify: `src/index.css` (append `.vutt-md` block)
+
+**Interfaces:**
+- Consumes: `react-markdown` (existing), `remark-gfm` (new)
+- Produces: `MarkdownView` (default export), props `{ content: string; className?: string }`. Renders `null` when `content` is blank.
+
+- [ ] **Step 1: Install remark-gfm**
+
+Run: `npm install remark-gfm@^4.0.0`
+Expected: `package.json` dependencies now include `remark-gfm`; `node_modules/remark-gfm` exists.
+
+- [ ] **Step 2: Create the component**
+
+Create `src/components/MarkdownView.tsx`:
+
+```tsx
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// Piiratud, turvaline markdown-renderdus (märkmed, elulugu jms).
+// Ainult markdown — toores HTML escape'itud (ei kasuta rehype-raw'd).
+// Renderduv DOM on allow-listitud; keelatud elementide tekst säilib (unwrapDisallowed).
+const ALLOWED_ELEMENTS = [
+  'p', 'strong', 'em', 'del', 'a',
+  'ul', 'ol', 'li',
+  'h1', 'h2', 'h3',
+  'blockquote', 'code', 'br',
+];
+
+interface MarkdownViewProps {
+  content: string;
+  className?: string;
+}
+
+const MarkdownView: React.FC<MarkdownViewProps> = ({ content, className }) => {
+  if (!content || !content.trim()) return null;
+  return (
+    <div className={['vutt-md', className].filter(Boolean).join(' ')}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        allowedElements={ALLOWED_ELEMENTS}
+        unwrapDisallowed
+        components={{
+          a: ({ node: _node, ...props }) => (
+            <a {...props} target="_blank" rel="noopener noreferrer" />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownView;
+```
+
+- [ ] **Step 3: Append `.vutt-md` styles**
+
+Append to the end of `src/index.css`:
+
+```css
+/* Markdown-renderdus märkmete/eluloo väljadel (.vutt-md) */
+.vutt-md {
+  overflow-wrap: break-word;
+}
+.vutt-md h1 { font-size: 1.5rem; font-weight: 700; margin: 0.5rem 0; }
+.vutt-md h2 { font-size: 1.25rem; font-weight: 700; margin: 0.5rem 0; }
+.vutt-md h3 { font-size: 1.1rem; font-weight: 600; margin: 0.5rem 0; }
+.vutt-md p { margin: 0 0 0.75rem; }
+.vutt-md p:last-child { margin-bottom: 0; }
+.vutt-md ul { list-style: disc; padding-left: 1.5rem; margin: 0 0 0.75rem; }
+.vutt-md ol { list-style: decimal; padding-left: 1.5rem; margin: 0 0 0.75rem; }
+.vutt-md li { margin: 0.15rem 0; }
+.vutt-md a { color: #2563eb; text-decoration: underline; overflow-wrap: anywhere; }
+.vutt-md blockquote { border-left: 3px solid #e5e7eb; padding-left: 0.75rem; color: #4b5563; margin: 0 0 0.75rem; }
+.vutt-md strong { font-weight: 700; }
+.vutt-md em { font-style: italic; }
+.vutt-md code { background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors. (If react-markdown v10 types reject `node` in the `a` component, the `node: _node` rename keeps it unused-safe; confirm clean.)
+
+- [ ] **Step 5: Build sanity**
+
+Run: `npm run build`
+Expected: build succeeds (confirms `remark-gfm` resolves in the bundle).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json src/components/MarkdownView.tsx src/index.css
+git commit -m "feat: MarkdownView safe renderer (remark-gfm + allow-list) + .vutt-md styles"
+```
+
+---
+
+## Task 3: MarkdownEditor component + i18n
+
+**Files:**
+- Create: `src/components/MarkdownEditor.tsx`
+- Modify: `src/locales/et/common.json`
+- Modify: `src/locales/en/common.json`
+
+**Interfaces:**
+- Consumes: `markdownEditorHelpers` (Task 1), `MarkdownView` (Task 2), `react-i18next`, `lucide-react`
+- Produces: `MarkdownEditor` (default export), props:
+  `{ value: string; onChange: (value: string) => void; placeholder?: string; minRows?: number; id?: string; disabled?: boolean }`
+
+- [ ] **Step 1: Add Estonian i18n keys**
+
+In `src/locales/et/common.json`, add a top-level `"markdownEditor"` block (sibling of `"buttons"`):
+
+```json
+  "markdownEditor": {
+    "bold": "Paks",
+    "italic": "Kursiiv",
+    "heading": "Pealkiri",
+    "link": "Lisa link",
+    "list": "Loend",
+    "help": "Vormindusabi",
+    "write": "Kirjuta",
+    "preview": "Eelvaade",
+    "helpText": "Toetab markdownit: **paks**, *kursiiv*, # Pealkiri, [link](url), - loend",
+    "linkText": "Lingi tekst",
+    "linkUrl": "URL",
+    "emptyPreview": "Pole midagi näidata",
+    "boldPlaceholder": "paks tekst",
+    "italicPlaceholder": "kursiiv"
+  },
+```
+
+- [ ] **Step 2: Add English i18n keys**
+
+In `src/locales/en/common.json`, add the matching block:
+
+```json
+  "markdownEditor": {
+    "bold": "Bold",
+    "italic": "Italic",
+    "heading": "Heading",
+    "link": "Insert link",
+    "list": "List",
+    "help": "Formatting help",
+    "write": "Write",
+    "preview": "Preview",
+    "helpText": "Supports markdown: **bold**, *italic*, # Heading, [link](url), - list",
+    "linkText": "Link text",
+    "linkUrl": "URL",
+    "emptyPreview": "Nothing to preview",
+    "boldPlaceholder": "bold text",
+    "italicPlaceholder": "italic"
+  },
+```
+
+- [ ] **Step 3: Create the component**
+
+Create `src/components/MarkdownEditor.tsx`:
+
+```tsx
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Bold, Italic, Heading, Link as LinkIcon, List, HelpCircle } from 'lucide-react';
+import MarkdownView from './MarkdownView';
+import {
+  applyWrap,
+  applyLinePrefix,
+  insertLink,
+  linkPrefillFromSelection,
+  type SelectionResult,
+} from './markdownEditorHelpers';
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  minRows?: number;
+  id?: string;
+  disabled?: boolean;
+}
+
+const MAX_HEIGHT = 500;
+
+const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+  value, onChange, placeholder, minRows = 3, id, disabled,
+}) => {
+  const { t } = useTranslation('common');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
+  const [showHelp, setShowHelp] = useState(false);
+
+  // Lingi-popover
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [linkText, setLinkText] = useState('');
+  const [linkUrl, setLinkUrl] = useState('');
+  const savedSel = useRef<{ start: number; end: number }>({ start: 0, end: 0 });
+  const linkFirstFocus = useRef<'text' | 'url'>('text');
+  const linkTextRef = useRef<HTMLInputElement>(null);
+  const linkUrlRef = useRef<HTMLInputElement>(null);
+
+  // Dünaamiline kõrgus: kasvab sisuga kuni MAX_HEIGHT, siis scroll.
+  useLayoutEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta || tab !== 'write') return;
+    ta.style.height = 'auto';
+    const next = Math.min(ta.scrollHeight, MAX_HEIGHT);
+    ta.style.height = `${next}px`;
+    ta.style.overflowY = ta.scrollHeight > MAX_HEIGHT ? 'auto' : 'hidden';
+  }, [value, tab]);
+
+  const getSel = () => {
+    const ta = textareaRef.current;
+    return {
+      start: ta?.selectionStart ?? value.length,
+      end: ta?.selectionEnd ?? value.length,
+    };
+  };
+
+  const applyResult = (res: SelectionResult) => {
+    onChange(res.text);
+    requestAnimationFrame(() => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      ta.focus();
+      ta.setSelectionRange(res.start, res.end);
+    });
+  };
+
+  const handleBold = () => {
+    const { start, end } = getSel();
+    applyResult(applyWrap(value, start, end, '**', t('markdownEditor.boldPlaceholder')));
+  };
+  const handleItalic = () => {
+    const { start, end } = getSel();
+    applyResult(applyWrap(value, start, end, '*', t('markdownEditor.italicPlaceholder')));
+  };
+  const handleHeading = () => {
+    const { start, end } = getSel();
+    applyResult(applyLinePrefix(value, start, end, '## '));
+  };
+  const handleList = () => {
+    const { start, end } = getSel();
+    applyResult(applyLinePrefix(value, start, end, '- ', { skipIfPresent: true }));
+  };
+
+  const openLinkPopover = () => {
+    const { start, end } = getSel();
+    savedSel.current = { start, end };
+    const prefill = linkPrefillFromSelection(value.slice(start, end));
+    setLinkText(prefill.linkText);
+    setLinkUrl(prefill.url);
+    linkFirstFocus.current = prefill.focusField;
+    setLinkOpen(true);
+  };
+
+  // Popoveri avamisel fookus esimesele väljale.
+  useLayoutEffect(() => {
+    if (!linkOpen) return;
+    const target = linkFirstFocus.current === 'url' ? linkUrlRef.current : linkTextRef.current;
+    target?.focus();
+  }, [linkOpen]);
+
+  const closeLinkPopover = () => {
+    setLinkOpen(false);
+    requestAnimationFrame(() => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      ta.focus();
+      ta.setSelectionRange(savedSel.current.start, savedSel.current.end);
+    });
+  };
+
+  const confirmLink = () => {
+    const { start, end } = savedSel.current;
+    setLinkOpen(false);
+    applyResult(insertLink(value, start, end, linkText, linkUrl));
+  };
+
+  const toolBtn = 'p-1.5 rounded hover:bg-gray-200 disabled:opacity-40';
+  const editingDisabled = disabled || tab === 'preview';
+
+  return (
+    <div className="markdown-editor">
+      {/* Nupuriba + tabid */}
+      <div className="flex items-center justify-between border border-gray-300 rounded-t bg-gray-50 px-2 py-1">
+        <div className="flex items-center gap-1">
+          <button type="button" onClick={handleBold} disabled={editingDisabled} title={t('markdownEditor.bold')} className={toolBtn}><Bold size={16} /></button>
+          <button type="button" onClick={handleItalic} disabled={editingDisabled} title={t('markdownEditor.italic')} className={toolBtn}><Italic size={16} /></button>
+          <button type="button" onClick={handleHeading} disabled={editingDisabled} title={t('markdownEditor.heading')} className={toolBtn}><Heading size={16} /></button>
+          <button type="button" onClick={openLinkPopover} disabled={editingDisabled} title={t('markdownEditor.link')} className={toolBtn}><LinkIcon size={16} /></button>
+          <button type="button" onClick={handleList} disabled={editingDisabled} title={t('markdownEditor.list')} className={toolBtn}><List size={16} /></button>
+          <button type="button" onClick={() => setShowHelp(v => !v)} title={t('markdownEditor.help')} className={`${toolBtn} text-gray-500`}><HelpCircle size={16} /></button>
+        </div>
+        <div className="flex items-center gap-1 text-xs">
+          <button type="button" onClick={() => setTab('write')} className={`px-2 py-1 rounded ${tab === 'write' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.write')}</button>
+          <button type="button" onClick={() => setTab('preview')} className={`px-2 py-1 rounded ${tab === 'preview' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.preview')}</button>
+        </div>
+      </div>
+
+      {showHelp && (
+        <div className="border-x border-gray-300 bg-blue-50 px-3 py-2 text-xs text-gray-600">
+          {t('markdownEditor.helpText')}
+        </div>
+      )}
+
+      {/* Sisu */}
+      <div className="relative">
+        {tab === 'write' ? (
+          <textarea
+            ref={textareaRef}
+            id={id}
+            value={value}
+            disabled={disabled}
+            placeholder={placeholder}
+            rows={minRows}
+            onChange={e => onChange(e.target.value)}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-b focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y font-mono leading-relaxed block"
+          />
+        ) : (
+          <div className="w-full min-h-[80px] px-3 py-2 text-sm border border-gray-300 rounded-b bg-white">
+            {value.trim()
+              ? <MarkdownView content={value} />
+              : <span className="text-gray-400">{t('markdownEditor.emptyPreview')}</span>}
+          </div>
+        )}
+
+        {linkOpen && (
+          <div
+            className="absolute z-20 top-2 left-2 w-72 bg-white border border-gray-300 rounded shadow-lg p-3 space-y-2"
+            onKeyDown={e => { if (e.key === 'Escape') { e.preventDefault(); closeLinkPopover(); } }}
+          >
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t('markdownEditor.linkText')}</label>
+              <input ref={linkTextRef} type="text" value={linkText} onChange={e => setLinkText(e.target.value)}
+                className="w-full px-2 py-1 text-sm border border-gray-300 rounded outline-none focus:ring-1 focus:ring-primary-500" />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t('markdownEditor.linkUrl')}</label>
+              <input ref={linkUrlRef} type="url" value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder="https://…"
+                className="w-full px-2 py-1 text-sm border border-gray-300 rounded outline-none focus:ring-1 focus:ring-primary-500" />
+            </div>
+            <div className="flex justify-end gap-2 pt-1">
+              <button type="button" onClick={closeLinkPopover} className="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded">{t('buttons.cancel')}</button>
+              <button type="button" onClick={confirmLink} disabled={!linkUrl.trim()} className="px-2 py-1 text-xs bg-primary-600 text-white rounded hover:bg-primary-700 disabled:opacity-40">{t('buttons.apply')}</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownEditor;
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Verify i18n JSON validity**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('src/locales/et/common.json','utf8')); JSON.parse(require('fs').readFileSync('src/locales/en/common.json','utf8')); console.log('ok')"`
+Expected: prints `ok` (both files are valid JSON — no trailing-comma errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MarkdownEditor.tsx src/locales/et/common.json src/locales/en/common.json
+git commit -m "feat: MarkdownEditor (toolbar, preview tabs, link popover, autosize)"
+```
+
+---
+
+## Task 4: Wire into Person pages
+
+**Files:**
+- Modify: `src/prosopography/pages/PersonEditPage.tsx`
+- Modify: `src/prosopography/pages/PersonDetailPage.tsx`
+
+**Interfaces:**
+- Consumes: `MarkdownEditor` (Task 3), `MarkdownView` (Task 2)
+- Produces: nothing (final integration)
+
+- [ ] **Step 1: Import MarkdownEditor in PersonEditPage**
+
+In `src/prosopography/pages/PersonEditPage.tsx`, add after the existing imports (near the top, after the lucide-react import line):
+
+```tsx
+import MarkdownEditor from '../../components/MarkdownEditor';
+```
+
+- [ ] **Step 2: Replace the Biography textarea**
+
+In `src/prosopography/pages/PersonEditPage.tsx`, find the Biography block (currently around lines 592–603):
+
+```tsx
+        {/* ── Elulugu ── */}
+        <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-5">
+          <label className="block text-xs text-gray-500 uppercase tracking-wide mb-2">
+            {t('biography', 'Elulugu')} <span className="font-normal lowercase">(markdown)</span>
+          </label>
+          <textarea
+            value={draft.biography}
+            onChange={e => set({ biography: e.target.value })}
+            rows={8}
+            placeholder={t('form.biographyPlaceholder')}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y font-mono leading-relaxed"
+          />
+        </div>
+```
+
+Replace with:
+
+```tsx
+        {/* ── Elulugu ── */}
+        <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-5">
+          <label className="block text-xs text-gray-500 uppercase tracking-wide mb-2">
+            {t('biography', 'Elulugu')}
+          </label>
+          <MarkdownEditor
+            value={draft.biography}
+            onChange={v => set({ biography: v })}
+            minRows={8}
+            placeholder={t('form.biographyPlaceholder')}
+          />
+        </div>
+```
+
+- [ ] **Step 3: Replace the Notes textarea**
+
+In `src/prosopography/pages/PersonEditPage.tsx`, find the Notes block (currently around lines 836–847):
+
+```tsx
+          <div>
+            <label className="block text-xs text-gray-500 uppercase tracking-wide mb-1">
+              {t('notes', 'Märkmed')}
+            </label>
+            <textarea
+              value={draft.notes}
+              onChange={e => set({ notes: e.target.value })}
+              rows={3}
+              placeholder={t('form.notesPlaceholder')}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y"
+            />
+          </div>
+```
+
+Replace with:
+
+```tsx
+          <div>
+            <label className="block text-xs text-gray-500 uppercase tracking-wide mb-1">
+              {t('notes', 'Märkmed')}
+            </label>
+            <MarkdownEditor
+              value={draft.notes}
+              onChange={v => set({ notes: v })}
+              minRows={3}
+              placeholder={t('form.notesPlaceholder')}
+            />
+          </div>
+```
+
+- [ ] **Step 4: Swap renderers in PersonDetailPage**
+
+In `src/prosopography/pages/PersonDetailPage.tsx`:
+
+(a) Replace the `react-markdown` import at line 4:
+
+```tsx
+import ReactMarkdown from 'react-markdown';
+```
+
+with:
+
+```tsx
+import MarkdownView from '../../components/MarkdownView';
+```
+
+(b) Replace the Biography render block (around lines 638–645):
+
+```tsx
+        {/* ── Elulugu ── */}
+        {person.biography && (
+          <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
+            <CardHeader icon={<BookMarked size={18} />} title={t('biography', 'Elulugu')} />
+            <div className="markdown-preview text-sm text-gray-800 leading-relaxed">
+              <ReactMarkdown>{person.biography}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+```
+
+with:
+
+```tsx
+        {/* ── Elulugu ── */}
+        {person.biography && (
+          <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
+            <CardHeader icon={<BookMarked size={18} />} title={t('biography', 'Elulugu')} />
+            <MarkdownView content={person.biography} className="text-sm text-gray-800 leading-relaxed" />
+          </div>
+        )}
+```
+
+(c) Replace the Notes render (around lines 746–752):
+
+```tsx
+        {/* ── Märkmed ── */}
+        {person.notes && (
+          <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
+            <CardHeader icon={<StickyNote size={18} />} title={t('notes', 'Märkmed')} />
+            <p className="text-sm text-gray-700 whitespace-pre-wrap">{person.notes}</p>
+          </div>
+        )}
+```
+
+with:
+
+```tsx
+        {/* ── Märkmed ── */}
+        {person.notes && (
+          <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
+            <CardHeader icon={<StickyNote size={18} />} title={t('notes', 'Märkmed')} />
+            <MarkdownView content={person.notes} className="text-sm text-gray-700" />
+          </div>
+        )}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors. (Confirms the old `ReactMarkdown` import is fully removed and nothing else references it.)
+
+- [ ] **Step 6: Full test + build**
+
+Run: `npm test && npm run build`
+Expected: all tests pass, build succeeds.
+
+- [ ] **Step 7: Manual QA (browser, `npm run dev`)**
+
+On a person edit page and detail page, confirm:
+- Toolbar visible above Notes and Biography; B/I/H/🔗/• and `?` work.
+- Bold/italic on a selection insert `**…**` / `*…*`; on empty selection insert a placeholder.
+- Heading prefixes the line with `## `; List prefixes selected lines with `- ` and does not duplicate on already-prefixed lines.
+- Link button: with a plain-text selection prefills link text and focuses URL; with a URL selection prefills URL and focuses link text; Esc/Cancel returns focus to the textarea at the saved position; Apply inserts `[text](url)`.
+- Preview tab renders headings/bold/italic/links/lists; bare long URLs are clickable and wrap (no layout overflow).
+- Detail page: Notes and Biography render markdown; a pasted GFM table appears as run-on text (not a table) and is not too confusing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/prosopography/pages/PersonEditPage.tsx src/prosopography/pages/PersonDetailPage.tsx
+git commit -m "feat: use MarkdownEditor/MarkdownView for person notes and biography"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** MarkdownEditor (toolbar B/I/H/link/list, write/preview tabs default Write, `?` help, link popover with prefill + focus mgmt, autosize, undo limitation documented) → Task 3. MarkdownView (remark-gfm, allowedElements, unwrapDisallowed, urlTransform safety, `_blank`/`noopener`, null on blank) → Task 2. `.vutt-md` CSS (`anywhere` links, p-margin, ul/ol padding) → Task 2. Pure helpers + 5 spec test cases → Task 1. Integration into Notes + Biography on both pages → Task 4. Markdown-only/no rehype-raw, common-namespace i18n, domain-neutral API → Global Constraints + respective tasks.
+- **Type consistency:** `SelectionResult`/`LinkPrefill` defined in Task 1 and consumed verbatim in Task 3; `MarkdownView` props `{content, className}` defined Task 2, used Task 3 (preview) and Task 4 (detail page); `MarkdownEditor` props defined Task 3, used Task 4.
+- **No placeholders:** every code step contains full code; every run step has an expected result.
+- **Deferred (per spec YAGNI):** page/work notes fields stay unchanged (API ready only); no toggle-removal, side-by-side preview, tables UI, or keyboard shortcuts.
+```

--- a/docs/superpowers/specs/2026-06-29-markdown-notes-editor-design.md
+++ b/docs/superpowers/specs/2026-06-29-markdown-notes-editor-design.md
@@ -1,0 +1,224 @@
+# Markdown-redaktor märkuste/eluloo väljadele — disain
+
+**Kuupäev:** 2026-06-29
+**Staatus:** kinnitatud disain, ootab implementatsiooniplaani
+
+## Probleem
+
+Prosopograafia isiku **Märkmed** väli (`person.notes`) on praegu vormindamata:
+salvestus tavaline string, kuva `whitespace-pre-wrap`, toimetamine paljas
+`<textarea rows={3}>`. Kasutajad kleebivad sinna mh **hiigelpikki URL-e**, mis
+ajavad paigutuse laiali ja teevad teksti raskesti loetavaks/toimetatavaks.
+
+Soov: lubada **piiratud vormindus** (pealkirjad, paks, kursiiv, lingid, loendid)
+ja teha toimetamine mugavamaks ning **kasutajale selgelt avastatavaks**.
+
+## Olemasolev kontekst (kontrollitud)
+
+- `react-markdown` ^10.1.0 on deps; **juba kasutuses** Eluloo (`biography`)
+  renderdamiseks `PersonDetailPage`-l (`<ReactMarkdown>{person.biography}`).
+- `rehype-raw` ^7.0.0 on deps, **aga ei ole kusagil kasutuses** → praegune
+  `<ReactMarkdown>` escape'ib toore HTML-i (turvaline vaikekäitumine).
+- `remark-gfm` **puudub** → paljad URL-id ei muutu praegu klikitavaks.
+- `@tailwindcss/typography` (`prose`) **puudub**; ainus markdown-CSS on
+  `.markdown-preview p` (`src/index.css:385`). `##` pealkirjad renderduvad seetõttu
+  peaaegu stiilitult (Tailwind base reset võtab pealkirjastiili maha).
+- CodeMirror 6 (`@codemirror/*`) on projektis (transkriptsiooni-editor), aga
+  `VuttMarkupExtension` ei ole siia taaskasutatav: see tunneb XML-tägisid (mitte
+  markdownit) ega tunne pealkirju/linke/loendeid.
+- `notes?: string | null` on tüüpides ka teostel (`src/types.ts:123,240,320`) ja
+  isikul (`src/prosopography/types.ts`). Lehekülje/teose märkuste lahtrid on
+  tuleviku-sihtmärgid.
+
+## Otsused
+
+| Otsus | Valik |
+|-------|-------|
+| Redaktori tüüp | Markdown-nupuriba + eelvaade (mitte WYSIWYG, mitte CodeMirror) |
+| Ulatus nüüd | Märkmed **ja** Elulugu, ühe taaskasutatava komponendiga |
+| Formaat | **Ainult markdown** (toores HTML escape'itud, XSS-kindel) |
+| GFM ulatus | `remark-gfm` autolinkide jaoks, AGA renderdus piiratud `allowedElements`-iga (vt MarkdownView) |
+| Nupud | v1: ainult **lisavad** süntaksit; olemasoleva vormingu eemaldamist (toggle) ei tuvastata |
+| Avastatavus | Nupuriba alati nähtav + "?" spikker + "Eelvaade" lüliti (vaikimisi **Kirjuta**) |
+| Salvestus | Muutusteta — tavaline markdown-string; migratsiooni pole |
+
+## Disainiprintsiip: üldotstarbeline primitiiv
+
+Komponendid elavad `src/components/`-s ja on **domeeni-neutraalsed** — ei tea
+midagi isikust/eluloost/märkmetest. API on lihtsalt tekst sisse/välja. Eesmärk:
+sama komponenti saab hiljem kasutada **lehekülje ja teose märkuste** lahtrites
+(neid kohti praegu ei implementeeri, kuid API ei tohi neid välistada).
+
+## Komponendid
+
+### 1. `MarkdownEditor.tsx` (uus, `src/components/`)
+
+Toimetamiskomponent. Domeeni-neutraalne API:
+
+```ts
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  minRows?: number;          // vaikimisi nt 3; Elulugu kasutab suuremat
+  id?: string;               // <label htmlFor> sidumiseks (label on kutsuja oma)
+  disabled?: boolean;
+}
+```
+
+Paigutus (ülevalt alla):
+- **Nupuriba** (alati nähtav, raamitud): **B** paks, **I** kursiiv, **H** pealkiri,
+  **🔗** link, **•** loend. Ikoonid (lucide-react) + eestikeelsed tooltipid.
+- **"Kirjuta" / "Eelvaade" lüliti** (kaks tabi). **Vaikimisi Kirjuta**; Eelvaade
+  on valikuline kontroll, mitte põhivaade. Kitsas vormiveerus eelistatud
+  kõrvuti-vaatele.
+- **Tekstiala** markdown-lähtetekstiga (font-mono, `resize-y`), `minRows`.
+- **"?" spikker** — väike popover lühikese süntaksi-näidisega.
+
+Nupukäitumine (manipuleerib `selectionStart/End`, kutsub `onChange`, taastab
+valiku). **v1: nupud ainult lisavad süntaksit; olemasoleva vormingu eemaldamist
+ei tuvastata** (nt **paks** valiku peal nupp ei eemalda `**`-e):
+- **Paks**: mähib valiku `**…**` (või lisab `**paks**` kohahoidja, kui valikut pole).
+- **Kursiiv**: `*…*`.
+- **Pealkiri**: lisab rea algusesse `## `.
+- **Loend**: lisab `- ` igale valitud reale, **mis seda veel ei alga** (väldib
+  topeldamist; ei eemalda olemasolevat prefiksit).
+- **Link** (hiigellinkide lahendus): avab pisi-popoveri kahe väljaga — "Lingi tekst"
+  ja "URL"; lisab `[tekst](url)`. Pikk URL kaob lühikese sõna taha.
+  **Valiku eeltäide:**
+  - kui valik näeb välja nagu URL (algab `http://`/`https://`/`www.`) → URL-väli =
+    valik, lingitekst tühi (fookus lingitekstil);
+  - muidu → lingitekst = valik, URL-väli tühi.
+
+**Testitavus:** kogu tekstiteisendus eraldatakse puhasteks funktsioonideks
+`src/components/markdownEditorHelpers.ts`-i, nt:
+
+```ts
+applyWrap(text, start, end, marker): { text, start, end }   // paks/kursiiv
+applyLinePrefix(text, start, end, prefix): { text, start, end } // pealkiri/loend
+insertLink(text, start, end, label, url): { text, start, end }
+```
+
+Need on DOM-vabad ja unit-testitavad.
+
+**Käitumisdetailid (DOM-pool):**
+
+- **Dünaamiline kõrgus:** `useLayoutEffect` seab kõrguse `scrollHeight` järgi
+  (kasvab sisuga). Alampiir = `minRows`, ülempiir ~500px → seejärel
+  `overflow-y-auto`. Ei lisata uut sõltuvust (mitte `react-textarea-autosize`,
+  mitte `field-sizing: content` brauseritoe-lünga tõttu).
+- **Lingi-popoveri fookus / A11y:**
+  - enne popoveri avamist salvestatakse textarea valik (`selectionStart/End`);
+  - avamisel liigub fookus automaatselt esimesele väljale (URL-eeltäite korral
+    "Lingi tekst", muidu samuti esimesele loogilisele väljale);
+  - Tab liigub väljade ja nuppude vahel popoveris;
+  - sulgemine (Salvesta / Loobu / **Esc**) tagastab fookuse textarea-sse **täpselt
+    salvestatud valikule** (insert toimub salvestatud positsioonile).
+- **Undo/Redo piirang (v1, teadlik):** programmiline väärtuse muutmine võib mõnes
+  brauseris lõhkuda textarea natiivse Ctrl/Cmd+Z ajaloo (Undo võib eemaldada
+  oodatust suurema tüki). Aktsepteeritud v1-s. Kui testimisel kriitiline →
+  eelistada lisamis-teel `document.execCommand('insertText', …)`-i (ametlikult
+  deprecated, kuid säilitab natiivse undo-ajaloo) või hallata lihtsat lokaalset
+  undo-stacki komponendi olekus.
+
+### 2. `MarkdownView.tsx` (uus, `src/components/`)
+
+Renderduskomponent:
+
+```ts
+interface MarkdownViewProps {
+  content: string;
+  className?: string;
+}
+```
+
+- `<ReactMarkdown remarkPlugins={[remarkGfm]}>` `.vutt-md` konteineris.
+- **Uus dep: `remark-gfm`** — vajalik paljaste URL-ide autolinkimiseks (vanade
+  märkmete jaoks). NB: gfm lisab ka tabelid, footnote'd, tasklist'id — neid me
+  **ei taha**, seega piiratakse renderdus allow-listiga (allpool).
+- **`allowedElements`** allow-list (tehniliselt piiratud markdown):
+  `p, strong, em, del, a, ul, ol, li, h1, h2, h3, blockquote, code, br`.
+  Pluss **`unwrapDisallowed`** → keelatud element (nt tabel) ei kao tervenisti,
+  vaid säilitab oma tekstisisu.
+- Markdown-only: **ei kasuta `rehype-raw`-i** → toores HTML escape'itud.
+- Kohandatud `a`-komponent: `target="_blank" rel="noopener noreferrer"`.
+- **URL-turvalisus:** react-markdowni vaikimisi `urlTransform` lubab ainult kindlaid
+  protokolle (http, https, mailto, suhtelised); `javascript:` ei kuulu lubatute
+  hulka.
+- **Tühi sisu:** kui `content` on tühi/ainult tühikud → tagastab `null` (ei renderda
+  tühja `.vutt-md` blokki). Sektsiooni kuvamise otsustab kutsuja (nt `person.notes &&`).
+
+### 3. CSS `.vutt-md` (`src/index.css`)
+
+Renderdatud markdowni stiil, kitsalt skoobitud `.vutt-md` alla (et ei lekiks
+transkriptsiooni `.markdown-preview`-sse):
+- pealkirjad h1–h3 (taastab suurused, mille Tailwind reset maha võttis), paks, kursiiv;
+- `.vutt-md p { margin: 0 0 0.75rem; }` (lõiguvahe);
+- `.vutt-md ul, .vutt-md ol { padding-left: 1.5rem; }` + loendi-markerid (`list-style`);
+- `.vutt-md a` — sinine, alla-joonitud, **`overflow-wrap: anywhere`** (väga pikad
+  arhiivi-URL-id murduvad usaldusväärsemalt kui `break-word`);
+- `.vutt-md` üldine **`overflow-wrap: break-word`** muu teksti jaoks.
+
+## Integratsioon
+
+| Koht | Enne | Pärast |
+|------|------|--------|
+| `PersonEditPage` Märkmed | `<textarea rows={3}>` | `<MarkdownEditor minRows={3}>` |
+| `PersonEditPage` Elulugu | `<textarea rows={8}>` + "(markdown)" vihje | `<MarkdownEditor minRows={8}>` |
+| `PersonDetailPage` Märkmed | `<p whitespace-pre-wrap>` | `<MarkdownView>` |
+| `PersonDetailPage` Elulugu | paljas `<ReactMarkdown>` | `<MarkdownView>` (gfm + stiil) |
+
+## Andmed / salvestus
+
+Muutusteta. `notes` ja `biography` jäävad tavalisteks markdown-stringideks.
+**Migratsiooni pole.** Vanad väärtused renderduvad: tavatekst nagu on, paljad
+URL-id muutuvad klikitavaks. Backend ei muutu.
+
+## Turvalisus
+
+Markdown-only, `rehype-raw` väljas → toores HTML escape'itud (XSS-kindel).
+Lingi-URL-id: react-markdowni vaikimisi `urlTransform` lubab ainult kindlaid
+protokolle (http, https, mailto, suhtelised), `javascript:` ei kuulu lubatute
+hulka. `allowedElements` allow-list piirab renderduva DOM-i täiendavalt.
+
+## i18n
+
+Tooltipid (paks/kursiiv/pealkiri/link/loend), "Eelvaade"/"Kirjuta", spikri tekst,
+lingi-popoveri sildid → lisada nii `src/locales/et/` kui `src/locales/en/`
+(prosopography või common namespace).
+
+## Testid ja värav
+
+`markdownEditorHelpers.ts` puhaste funktsioonide unit-testid, sh konkreetsed
+juhtumid:
+1. **Link valikuga** (mitte-URL tekst): `Johann Fischer` → `[Johann Fischer](url)`,
+   lingitekst eeltäidetud valikuga.
+2. **Link ilma valikuta**: lisab kohahoidja `[tekst](url)`, valik lingitekstil.
+3. **Link valik = URL**: valik `https://…` → URL-väli eeltäidetud, lingitekst tühi.
+4. **Mitmerealine loend, osa ridu juba `- ` prefiksiga**: prefiks lisatakse ainult
+   prefiksita ridadele (topeldamist ei teki).
+5. **Paks tühja valikuga** → `**paks**` kohahoidja.
+
+Frontend-värav: `npm run typecheck` (mitte ainult `build`).
+
+**Käsitsi QA (DOM/brauser):**
+- Lingi-popoveri fookus: avaneb fookusega väljal, Tab töötab, Esc/Salvesta/Loobu
+  viib fookuse tagasi textarea-sse.
+- Undo (Ctrl/Cmd+Z) käitumine pärast nupuvajutust — kontrolli, kas piirang on
+  talutav.
+- Dünaamiline kõrgus kasvab sisuga ja peatub ~500px juures (siis scroll).
+- **Kleebitud GFM-tabel** renderdub `unwrapDisallowed` tõttu joosva tekstina (ei
+  kao ära) — visuaalselt vastuvõetav, mitte liiga segadusttekitav.
+
+## YAGNI (teadlikult välja)
+
+Kõrvuti-eelvaade, **tabelid/footnote'd/tasklist'id** (gfm lubab need süntaksina,
+aga `allowedElements` ei renderda neid struktuurina — tekst säilib), pildid,
+värvid, fondisuuruse valik, vormingu-eemaldamise toggle, WYSIWYG,
+CodeMirror-integratsioon, lehekülje/teose märkuste lahtrite tegelik ümberlülitus
+(ainult API valmidus).
+
+## Tuleviku-sihtmärgid (ei implementeeri nüüd)
+
+- Lehekülje märkuste lahter → `<MarkdownEditor>` / `<MarkdownView>`.
+- Teose märkused (`work.notes`) → sama.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "react-router-dom": "^7.9.6",
         "react-zoom-pan-pinch": "^3.7.0",
         "recharts": "^3.5.0",
-        "rehype-raw": "^7.0.0"
+        "rehype-raw": "^7.0.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.2.1",
@@ -4338,6 +4339,44 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -4356,6 +4395,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4577,6 +4717,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -5770,6 +6031,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -5797,6 +6076,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-router-dom": "^7.9.6",
     "react-zoom-pan-pinch": "^3.7.0",
     "recharts": "^3.5.0",
-    "rehype-raw": "^7.0.0"
+    "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.1",

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -38,15 +38,34 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const linkTextRef = useRef<HTMLInputElement>(null);
   const linkUrlRef = useRef<HTMLInputElement>(null);
 
+  // Autosuuruse olek: viimati programmiliselt seatud kõrgus + kas kasutaja on
+  // käsitsi suurust muutnud (siis autosuurus enam ei sekku).
+  const autoHeightRef = useRef<number | null>(null);
+  const userResizedRef = useRef(false);
+
   // Dünaamiline kõrgus: kasvab sisuga kuni MAX_HEIGHT, siis scroll.
+  // Jätame vahele, kui kasutaja on tekstiala käsitsi suurust muutnud.
   useLayoutEffect(() => {
     const ta = textareaRef.current;
-    if (!ta || tab !== 'write') return;
+    if (!ta || tab !== 'write' || userResizedRef.current) return;
     ta.style.height = 'auto';
     const next = Math.min(ta.scrollHeight, MAX_HEIGHT);
     ta.style.height = `${next}px`;
     ta.style.overflowY = ta.scrollHeight > MAX_HEIGHT ? 'auto' : 'hidden';
+    autoHeightRef.current = next;
   }, [value, tab]);
+
+  // Käsitsi suuruse muutmise tuvastus: kui pärast hiire vabastust on tekstiala
+  // kõrgus muutunud võrreldes viimati programmiliselt seatuga, lülitame
+  // autosuuruse välja ja lubame kerimise (et sisu ei jääks peitu).
+  const handleTextareaMouseUp = () => {
+    const ta = textareaRef.current;
+    if (!ta || autoHeightRef.current === null) return;
+    if (Math.abs(ta.offsetHeight - autoHeightRef.current) > 1) {
+      userResizedRef.current = true;
+      ta.style.overflowY = 'auto';
+    }
+  };
 
   const getSel = () => {
     const ta = textareaRef.current;
@@ -116,6 +135,12 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     applyResult(insertLink(value, start, end, linkText, linkUrl));
   };
 
+  // Tabi vahetus sulgeb avatud lingi-popoveri (muidu jääks see kuva üle hõljuma).
+  const switchTab = (next: 'write' | 'preview') => {
+    setLinkOpen(false);
+    setTab(next);
+  };
+
   const toolBtn = 'p-1.5 rounded hover:bg-gray-200 disabled:opacity-40';
   const editingDisabled = disabled || tab === 'preview';
 
@@ -132,8 +157,8 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           <button type="button" onClick={() => setShowHelp(v => !v)} title={t('markdownEditor.help')} className={`${toolBtn} text-gray-500`}><HelpCircle size={16} /></button>
         </div>
         <div className="flex items-center gap-1 text-xs">
-          <button type="button" onClick={() => setTab('write')} className={`px-2 py-1 rounded ${tab === 'write' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.write')}</button>
-          <button type="button" onClick={() => setTab('preview')} className={`px-2 py-1 rounded ${tab === 'preview' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.preview')}</button>
+          <button type="button" onClick={() => switchTab('write')} className={`px-2 py-1 rounded ${tab === 'write' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.write')}</button>
+          <button type="button" onClick={() => switchTab('preview')} className={`px-2 py-1 rounded ${tab === 'preview' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.preview')}</button>
         </div>
       </div>
 
@@ -154,6 +179,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             placeholder={placeholder}
             rows={minRows}
             onChange={e => onChange(e.target.value)}
+            onMouseUp={handleTextareaMouseUp}
             className="w-full px-3 py-2 text-sm border border-gray-300 rounded-b focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y font-mono leading-relaxed block"
           />
         ) : (

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,0 +1,193 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Bold, Italic, Heading, Link as LinkIcon, List, HelpCircle } from 'lucide-react';
+import MarkdownView from './MarkdownView';
+import {
+  applyWrap,
+  applyLinePrefix,
+  insertLink,
+  linkPrefillFromSelection,
+  type SelectionResult,
+} from './markdownEditorHelpers';
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  minRows?: number;
+  id?: string;
+  disabled?: boolean;
+}
+
+const MAX_HEIGHT = 500;
+
+const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+  value, onChange, placeholder, minRows = 3, id, disabled,
+}) => {
+  const { t } = useTranslation('common');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
+  const [showHelp, setShowHelp] = useState(false);
+
+  // Lingi-popover
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [linkText, setLinkText] = useState('');
+  const [linkUrl, setLinkUrl] = useState('');
+  const savedSel = useRef<{ start: number; end: number }>({ start: 0, end: 0 });
+  const linkFirstFocus = useRef<'text' | 'url'>('text');
+  const linkTextRef = useRef<HTMLInputElement>(null);
+  const linkUrlRef = useRef<HTMLInputElement>(null);
+
+  // Dünaamiline kõrgus: kasvab sisuga kuni MAX_HEIGHT, siis scroll.
+  useLayoutEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta || tab !== 'write') return;
+    ta.style.height = 'auto';
+    const next = Math.min(ta.scrollHeight, MAX_HEIGHT);
+    ta.style.height = `${next}px`;
+    ta.style.overflowY = ta.scrollHeight > MAX_HEIGHT ? 'auto' : 'hidden';
+  }, [value, tab]);
+
+  const getSel = () => {
+    const ta = textareaRef.current;
+    return {
+      start: ta?.selectionStart ?? value.length,
+      end: ta?.selectionEnd ?? value.length,
+    };
+  };
+
+  const applyResult = (res: SelectionResult) => {
+    onChange(res.text);
+    requestAnimationFrame(() => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      ta.focus();
+      ta.setSelectionRange(res.start, res.end);
+    });
+  };
+
+  const handleBold = () => {
+    const { start, end } = getSel();
+    applyResult(applyWrap(value, start, end, '**', t('markdownEditor.boldPlaceholder')));
+  };
+  const handleItalic = () => {
+    const { start, end } = getSel();
+    applyResult(applyWrap(value, start, end, '*', t('markdownEditor.italicPlaceholder')));
+  };
+  const handleHeading = () => {
+    const { start, end } = getSel();
+    applyResult(applyLinePrefix(value, start, end, '## '));
+  };
+  const handleList = () => {
+    const { start, end } = getSel();
+    applyResult(applyLinePrefix(value, start, end, '- ', { skipIfPresent: true }));
+  };
+
+  const openLinkPopover = () => {
+    const { start, end } = getSel();
+    savedSel.current = { start, end };
+    const prefill = linkPrefillFromSelection(value.slice(start, end));
+    setLinkText(prefill.linkText);
+    setLinkUrl(prefill.url);
+    linkFirstFocus.current = prefill.focusField;
+    setLinkOpen(true);
+  };
+
+  // Popoveri avamisel fookus esimesele väljale.
+  useLayoutEffect(() => {
+    if (!linkOpen) return;
+    const target = linkFirstFocus.current === 'url' ? linkUrlRef.current : linkTextRef.current;
+    target?.focus();
+  }, [linkOpen]);
+
+  const closeLinkPopover = () => {
+    setLinkOpen(false);
+    requestAnimationFrame(() => {
+      const ta = textareaRef.current;
+      if (!ta) return;
+      ta.focus();
+      ta.setSelectionRange(savedSel.current.start, savedSel.current.end);
+    });
+  };
+
+  const confirmLink = () => {
+    const { start, end } = savedSel.current;
+    setLinkOpen(false);
+    applyResult(insertLink(value, start, end, linkText, linkUrl));
+  };
+
+  const toolBtn = 'p-1.5 rounded hover:bg-gray-200 disabled:opacity-40';
+  const editingDisabled = disabled || tab === 'preview';
+
+  return (
+    <div className="markdown-editor">
+      {/* Nupuriba + tabid */}
+      <div className="flex items-center justify-between border border-gray-300 rounded-t bg-gray-50 px-2 py-1">
+        <div className="flex items-center gap-1">
+          <button type="button" onClick={handleBold} disabled={editingDisabled} title={t('markdownEditor.bold')} className={toolBtn}><Bold size={16} /></button>
+          <button type="button" onClick={handleItalic} disabled={editingDisabled} title={t('markdownEditor.italic')} className={toolBtn}><Italic size={16} /></button>
+          <button type="button" onClick={handleHeading} disabled={editingDisabled} title={t('markdownEditor.heading')} className={toolBtn}><Heading size={16} /></button>
+          <button type="button" onClick={openLinkPopover} disabled={editingDisabled} title={t('markdownEditor.link')} className={toolBtn}><LinkIcon size={16} /></button>
+          <button type="button" onClick={handleList} disabled={editingDisabled} title={t('markdownEditor.list')} className={toolBtn}><List size={16} /></button>
+          <button type="button" onClick={() => setShowHelp(v => !v)} title={t('markdownEditor.help')} className={`${toolBtn} text-gray-500`}><HelpCircle size={16} /></button>
+        </div>
+        <div className="flex items-center gap-1 text-xs">
+          <button type="button" onClick={() => setTab('write')} className={`px-2 py-1 rounded ${tab === 'write' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.write')}</button>
+          <button type="button" onClick={() => setTab('preview')} className={`px-2 py-1 rounded ${tab === 'preview' ? 'bg-white border border-gray-300 font-medium' : 'text-gray-500'}`}>{t('markdownEditor.preview')}</button>
+        </div>
+      </div>
+
+      {showHelp && (
+        <div className="border-x border-gray-300 bg-blue-50 px-3 py-2 text-xs text-gray-600">
+          {t('markdownEditor.helpText')}
+        </div>
+      )}
+
+      {/* Sisu */}
+      <div className="relative">
+        {tab === 'write' ? (
+          <textarea
+            ref={textareaRef}
+            id={id}
+            value={value}
+            disabled={disabled}
+            placeholder={placeholder}
+            rows={minRows}
+            onChange={e => onChange(e.target.value)}
+            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-b focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y font-mono leading-relaxed block"
+          />
+        ) : (
+          <div className="w-full min-h-[80px] px-3 py-2 text-sm border border-gray-300 rounded-b bg-white">
+            {value.trim()
+              ? <MarkdownView content={value} />
+              : <span className="text-gray-400">{t('markdownEditor.emptyPreview')}</span>}
+          </div>
+        )}
+
+        {linkOpen && (
+          <div
+            className="absolute z-20 top-2 left-2 w-72 bg-white border border-gray-300 rounded shadow-lg p-3 space-y-2"
+            onKeyDown={e => { if (e.key === 'Escape') { e.preventDefault(); closeLinkPopover(); } }}
+          >
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t('markdownEditor.linkText')}</label>
+              <input ref={linkTextRef} type="text" value={linkText} onChange={e => setLinkText(e.target.value)}
+                className="w-full px-2 py-1 text-sm border border-gray-300 rounded outline-none focus:ring-1 focus:ring-primary-500" />
+            </div>
+            <div>
+              <label className="block text-xs text-gray-500 mb-1">{t('markdownEditor.linkUrl')}</label>
+              <input ref={linkUrlRef} type="url" value={linkUrl} onChange={e => setLinkUrl(e.target.value)} placeholder="https://…"
+                className="w-full px-2 py-1 text-sm border border-gray-300 rounded outline-none focus:ring-1 focus:ring-primary-500" />
+            </div>
+            <div className="flex justify-end gap-2 pt-1">
+              <button type="button" onClick={closeLinkPopover} className="px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 rounded">{t('buttons.cancel')}</button>
+              <button type="button" onClick={confirmLink} disabled={!linkUrl.trim()} className="px-2 py-1 text-xs bg-primary-600 text-white rounded hover:bg-primary-700 disabled:opacity-40">{t('buttons.apply')}</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownEditor;

--- a/src/components/MarkdownView.tsx
+++ b/src/components/MarkdownView.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+// Piiratud, turvaline markdown-renderdus (märkmed, elulugu jms).
+// Ainult markdown — toores HTML escape'itud (ei kasuta rehype-raw'd).
+// Renderduv DOM on allow-listitud; keelatud elementide tekst säilib (unwrapDisallowed).
+const ALLOWED_ELEMENTS = [
+  'p', 'strong', 'em', 'del', 'a',
+  'ul', 'ol', 'li',
+  'h1', 'h2', 'h3',
+  'blockquote', 'code', 'br',
+];
+
+interface MarkdownViewProps {
+  content: string;
+  className?: string;
+}
+
+const MarkdownView: React.FC<MarkdownViewProps> = ({ content, className }) => {
+  if (!content || !content.trim()) return null;
+  return (
+    <div className={['vutt-md', className].filter(Boolean).join(' ')}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        allowedElements={ALLOWED_ELEMENTS}
+        unwrapDisallowed
+        components={{
+          a: ({ node: _node, ...props }) => (
+            <a {...props} target="_blank" rel="noopener noreferrer" />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownView;

--- a/src/components/__tests__/markdownEditorHelpers.test.ts
+++ b/src/components/__tests__/markdownEditorHelpers.test.ts
@@ -87,4 +87,12 @@ describe('insertLink', () => {
     const r = insertLink('', 0, 0, '', 'http://x');
     expect(r.text).toBe('[http://x](http://x)');
   });
+  it('prepends https:// to protocol-less www. urls (avoids broken relative link)', () => {
+    const r = insertLink('site', 0, 4, 'site', 'www.example.com');
+    expect(r.text).toBe('[site](https://www.example.com)');
+  });
+  it('leaves urls that already have a protocol untouched', () => {
+    const r = insertLink('site', 0, 4, 'site', 'https://www.example.com');
+    expect(r.text).toBe('[site](https://www.example.com)');
+  });
 });

--- a/src/components/__tests__/markdownEditorHelpers.test.ts
+++ b/src/components/__tests__/markdownEditorHelpers.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyWrap,
+  applyLinePrefix,
+  looksLikeUrl,
+  linkPrefillFromSelection,
+  insertLink,
+} from '../markdownEditorHelpers';
+
+describe('applyWrap', () => {
+  it('wraps a non-empty selection and keeps the inner text selected', () => {
+    const r = applyWrap('Fischer', 0, 7, '**', 'paks');
+    expect(r.text).toBe('**Fischer**');
+    expect(r.start).toBe(2);
+    expect(r.end).toBe(9);
+  });
+
+  it('inserts a placeholder when the selection is empty and selects it', () => {
+    const r = applyWrap('', 0, 0, '**', 'paks');
+    expect(r.text).toBe('**paks**');
+    expect(r.start).toBe(2);
+    expect(r.end).toBe(6);
+  });
+
+  it('wraps in the middle of existing text', () => {
+    const r = applyWrap('a b c', 2, 3, '*', 'x');
+    expect(r.text).toBe('a *b* c');
+    expect(r.start).toBe(3);
+    expect(r.end).toBe(4);
+  });
+});
+
+describe('applyLinePrefix', () => {
+  it('adds a heading prefix to the current line', () => {
+    const r = applyLinePrefix('Title\nbody', 0, 0, '## ');
+    expect(r.text).toBe('## Title\nbody');
+  });
+
+  it('prefixes every selected line for a list', () => {
+    const r = applyLinePrefix('a\nb\nc', 0, 5, '- ', { skipIfPresent: true });
+    expect(r.text).toBe('- a\n- b\n- c');
+  });
+
+  it('skips lines that already have the prefix (no duplication)', () => {
+    const r = applyLinePrefix('- a\nb\nc', 0, 7, '- ', { skipIfPresent: true });
+    expect(r.text).toBe('- a\n- b\n- c');
+  });
+});
+
+describe('looksLikeUrl', () => {
+  it('detects http/https/www', () => {
+    expect(looksLikeUrl('https://archive.org/x')).toBe(true);
+    expect(looksLikeUrl('  http://x ')).toBe(true);
+    expect(looksLikeUrl('www.example.com')).toBe(true);
+  });
+  it('rejects plain text', () => {
+    expect(looksLikeUrl('Johann Fischer')).toBe(false);
+  });
+});
+
+describe('linkPrefillFromSelection', () => {
+  it('prefills URL field when selection is a URL (focus on text)', () => {
+    const p = linkPrefillFromSelection('https://archive.org/very/long');
+    expect(p.url).toBe('https://archive.org/very/long');
+    expect(p.linkText).toBe('');
+    expect(p.focusField).toBe('text');
+  });
+  it('prefills link text when selection is plain text (focus on url)', () => {
+    const p = linkPrefillFromSelection('Johann Fischer');
+    expect(p.linkText).toBe('Johann Fischer');
+    expect(p.url).toBe('');
+    expect(p.focusField).toBe('url');
+  });
+  it('focuses text field when selection is empty', () => {
+    const p = linkPrefillFromSelection('');
+    expect(p.focusField).toBe('text');
+  });
+});
+
+describe('insertLink', () => {
+  it('replaces a selection with a markdown link', () => {
+    const r = insertLink('Johann Fischer', 0, 14, 'Johann Fischer', 'http://x');
+    expect(r.text).toBe('[Johann Fischer](http://x)');
+    expect(r.start).toBe(r.end);
+  });
+  it('falls back to url as label when label empty', () => {
+    const r = insertLink('', 0, 0, '', 'http://x');
+    expect(r.text).toBe('[http://x](http://x)');
+  });
+});

--- a/src/components/markdownEditorHelpers.ts
+++ b/src/components/markdownEditorHelpers.ts
@@ -72,6 +72,14 @@ export function linkPrefillFromSelection(selected: string): LinkPrefill {
   return { linkText: selected, url: '', focusField: trimmed ? 'url' : 'text' };
 }
 
+// Normaliseerib lingi-URL-i: protokollita www.-aadressile lisab https://,
+// et markdown ei tekitaks katkist suhtelist linki ([x](www.foo) → href="www.foo").
+export function normalizeLinkUrl(url: string): string {
+  const trimmed = url.trim();
+  if (/^www\./i.test(trimmed)) return `https://${trimmed}`;
+  return trimmed;
+}
+
 // Lisab markdown-lingi [label](url), asendades valiku. Kursor jääb lingi järele.
 export function insertLink(
   text: string,
@@ -80,7 +88,7 @@ export function insertLink(
   label: string,
   url: string,
 ): SelectionResult {
-  const safeUrl = url.trim();
+  const safeUrl = normalizeLinkUrl(url);
   const safeLabel = label || safeUrl || 'link';
   const inserted = `[${safeLabel}](${safeUrl})`;
   const newText = text.slice(0, start) + inserted + text.slice(end);

--- a/src/components/markdownEditorHelpers.ts
+++ b/src/components/markdownEditorHelpers.ts
@@ -1,0 +1,89 @@
+// Puhtad tekstiteisendused MarkdownEditor jaoks. DOM-vabad, unit-testitavad.
+
+export interface SelectionResult {
+  text: string;
+  start: number;
+  end: number;
+}
+
+export interface LinkPrefill {
+  linkText: string;
+  url: string;
+  focusField: 'text' | 'url';
+}
+
+// Mähib valiku sümmeetrilise markeriga (** paksule, * kursiivile).
+// Tühja valiku korral lisab markeri + kohahoidja ja valib kohahoidja.
+export function applyWrap(
+  text: string,
+  start: number,
+  end: number,
+  marker: string,
+  placeholder: string,
+): SelectionResult {
+  const selected = text.slice(start, end);
+  if (selected.length === 0) {
+    const inserted = `${marker}${placeholder}${marker}`;
+    const newText = text.slice(0, start) + inserted + text.slice(end);
+    const selStart = start + marker.length;
+    return { text: newText, start: selStart, end: selStart + placeholder.length };
+  }
+  const inserted = `${marker}${selected}${marker}`;
+  const newText = text.slice(0, start) + inserted + text.slice(end);
+  const innerStart = start + marker.length;
+  return { text: newText, start: innerStart, end: innerStart + selected.length };
+}
+
+// Lisab rea-prefiksi (nt "## " või "- ") iga valikus oleva rea algusesse.
+// skipIfPresent: jätab vahele read, mis juba prefiksiga algavad (väldib topeldamist).
+export function applyLinePrefix(
+  text: string,
+  start: number,
+  end: number,
+  prefix: string,
+  options?: { skipIfPresent?: boolean },
+): SelectionResult {
+  const lineStart = text.lastIndexOf('\n', start - 1) + 1; // 0 kui puudub
+  let lineEnd = text.indexOf('\n', end);
+  if (lineEnd === -1) lineEnd = text.length;
+
+  const block = text.slice(lineStart, lineEnd);
+  const newBlock = block
+    .split('\n')
+    .map(line => (options?.skipIfPresent && line.startsWith(prefix) ? line : prefix + line))
+    .join('\n');
+
+  const newText = text.slice(0, lineStart) + newBlock + text.slice(lineEnd);
+  return { text: newText, start: lineStart, end: lineStart + newBlock.length };
+}
+
+const URL_RE = /^(https?:\/\/|www\.)/i;
+
+export function looksLikeUrl(s: string): boolean {
+  return URL_RE.test(s.trim());
+}
+
+// Eeltäidab lingi-popoveri praeguse valiku põhjal.
+export function linkPrefillFromSelection(selected: string): LinkPrefill {
+  const trimmed = selected.trim();
+  if (trimmed && looksLikeUrl(trimmed)) {
+    return { linkText: '', url: trimmed, focusField: 'text' };
+  }
+  return { linkText: selected, url: '', focusField: trimmed ? 'url' : 'text' };
+}
+
+// Lisab markdown-lingi [label](url), asendades valiku. Kursor jääb lingi järele.
+export function insertLink(
+  text: string,
+  start: number,
+  end: number,
+  label: string,
+  url: string,
+): SelectionResult {
+  const safeUrl = url.trim();
+  const safeLabel = label || safeUrl || 'link';
+  const inserted = `[${safeLabel}](${safeUrl})`;
+  const newText = text.slice(0, start) + inserted + text.slice(end);
+  const cursor = start + inserted.length;
+  return { text: newText, start: cursor, end: cursor };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -385,3 +385,21 @@ hr.page-break::before {
 .markdown-preview p {
   margin-bottom: 1rem;
 }
+
+/* Markdown-renderdus märkmete/eluloo väljadel (.vutt-md) */
+.vutt-md {
+  overflow-wrap: break-word;
+}
+.vutt-md h1 { font-size: 1.5rem; font-weight: 700; margin: 0.5rem 0; }
+.vutt-md h2 { font-size: 1.25rem; font-weight: 700; margin: 0.5rem 0; }
+.vutt-md h3 { font-size: 1.1rem; font-weight: 600; margin: 0.5rem 0; }
+.vutt-md p { margin: 0 0 0.75rem; }
+.vutt-md p:last-child { margin-bottom: 0; }
+.vutt-md ul { list-style: disc; padding-left: 1.5rem; margin: 0 0 0.75rem; }
+.vutt-md ol { list-style: decimal; padding-left: 1.5rem; margin: 0 0 0.75rem; }
+.vutt-md li { margin: 0.15rem 0; }
+.vutt-md a { color: #2563eb; text-decoration: underline; overflow-wrap: anywhere; }
+.vutt-md blockquote { border-left: 3px solid #e5e7eb; padding-left: 0.75rem; color: #4b5563; margin: 0 0 0.75rem; }
+.vutt-md strong { font-weight: 700; }
+.vutt-md em { font-style: italic; }
+.vutt-md code { background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -199,5 +199,21 @@
     "message": "You have unsaved changes. Are you sure you want to leave?",
     "leave": "Leave without saving",
     "stay": "Stay"
+  },
+  "markdownEditor": {
+    "bold": "Bold",
+    "italic": "Italic",
+    "heading": "Heading",
+    "link": "Insert link",
+    "list": "List",
+    "help": "Formatting help",
+    "write": "Write",
+    "preview": "Preview",
+    "helpText": "Supports markdown: **bold**, *italic*, # Heading, [link](url), - list",
+    "linkText": "Link text",
+    "linkUrl": "URL",
+    "emptyPreview": "Nothing to preview",
+    "boldPlaceholder": "bold text",
+    "italicPlaceholder": "italic"
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -209,7 +209,7 @@
     "help": "Formatting help",
     "write": "Write",
     "preview": "Preview",
-    "helpText": "Supports markdown: **bold**, *italic*, # Heading, [link](url), - list",
+    "helpText": "Supports markdown: **bold**, *italic*, ## Heading, [link](url), - list",
     "linkText": "Link text",
     "linkUrl": "URL",
     "emptyPreview": "Nothing to preview",

--- a/src/locales/et/common.json
+++ b/src/locales/et/common.json
@@ -209,7 +209,7 @@
     "help": "Vormindusabi",
     "write": "Kirjuta",
     "preview": "Eelvaade",
-    "helpText": "Toetab markdownit: **paks**, *kursiiv*, # Pealkiri, [link](url), - loend",
+    "helpText": "Toetab markdownit: **paks**, *kursiiv*, ## Pealkiri, [link](url), - loend",
     "linkText": "Lingi tekst",
     "linkUrl": "URL",
     "emptyPreview": "Pole midagi näidata",

--- a/src/locales/et/common.json
+++ b/src/locales/et/common.json
@@ -199,5 +199,21 @@
     "message": "Sul on salvestamata muudatusi. Kas oled kindel, et soovid lahkuda?",
     "leave": "Lahku ilma salvestamata",
     "stay": "Jää"
+  },
+  "markdownEditor": {
+    "bold": "Paks",
+    "italic": "Kursiiv",
+    "heading": "Pealkiri",
+    "link": "Lisa link",
+    "list": "Loend",
+    "help": "Vormindusabi",
+    "write": "Kirjuta",
+    "preview": "Eelvaade",
+    "helpText": "Toetab markdownit: **paks**, *kursiiv*, # Pealkiri, [link](url), - loend",
+    "linkText": "Lingi tekst",
+    "linkUrl": "URL",
+    "emptyPreview": "Pole midagi näidata",
+    "boldPlaceholder": "paks tekst",
+    "italicPlaceholder": "kursiiv"
   }
 }

--- a/src/prosopography/pages/PersonDetailPage.tsx
+++ b/src/prosopography/pages/PersonDetailPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import ReactMarkdown from 'react-markdown';
+import MarkdownView from '../../components/MarkdownView';
 import {
   ArrowLeft, ExternalLink, Edit3, ChevronDown, ChevronRight,
   BookOpen, User, BookMarked, Users, StickyNote, Map, History, RotateCcw, Lock,
@@ -638,9 +638,7 @@ const PersonDetailPage: React.FC = () => {
         {person.biography && (
           <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
             <CardHeader icon={<BookMarked size={18} />} title={t('biography', 'Elulugu')} />
-            <div className="markdown-preview text-sm text-gray-800 leading-relaxed">
-              <ReactMarkdown>{person.biography}</ReactMarkdown>
-            </div>
+            <MarkdownView content={person.biography} className="text-sm text-gray-800 leading-relaxed" />
           </div>
         )}
 
@@ -747,7 +745,7 @@ const PersonDetailPage: React.FC = () => {
         {person.notes && (
           <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
             <CardHeader icon={<StickyNote size={18} />} title={t('notes', 'Märkmed')} />
-            <p className="text-sm text-gray-700 whitespace-pre-wrap">{person.notes}</p>
+            <MarkdownView content={person.notes} className="text-sm text-gray-700" />
           </div>
         )}
 

--- a/src/prosopography/pages/PersonEditPage.tsx
+++ b/src/prosopography/pages/PersonEditPage.tsx
@@ -593,7 +593,7 @@ const PersonEditPage: React.FC = () => {
         {/* ── Elulugu ── */}
         <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-5">
           <label className="block text-xs text-gray-500 uppercase tracking-wide mb-2">
-            {t('biography', 'Elulogo')}
+            {t('biography', 'Elulugu')}
           </label>
           <MarkdownEditor
             value={draft.biography}

--- a/src/prosopography/pages/PersonEditPage.tsx
+++ b/src/prosopography/pages/PersonEditPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useSearchParams, useLocation, Link } from 'reac
 import { useTranslation } from 'react-i18next';
 import { ArrowLeft, ArrowLeftRight, Save, X, Loader2, ImagePlus, Trash2, ExternalLink } from 'lucide-react';
 import Header from '../../components/Header';
+import MarkdownEditor from '../../components/MarkdownEditor';
 import EntityPicker from '../../components/EntityPicker';
 import { FILE_API_URL } from '../../config';
 import { fetchWithTimeout } from '../../utils/fetchWithTimeout';
@@ -592,14 +593,13 @@ const PersonEditPage: React.FC = () => {
         {/* ── Elulugu ── */}
         <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-5">
           <label className="block text-xs text-gray-500 uppercase tracking-wide mb-2">
-            {t('biography', 'Elulugu')} <span className="font-normal lowercase">(markdown)</span>
+            {t('biography', 'Elulogo')}
           </label>
-          <textarea
+          <MarkdownEditor
             value={draft.biography}
-            onChange={e => set({ biography: e.target.value })}
-            rows={8}
+            onChange={v => set({ biography: v })}
+            minRows={8}
             placeholder={t('form.biographyPlaceholder')}
-            className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y font-mono leading-relaxed"
           />
         </div>
 
@@ -837,12 +837,11 @@ const PersonEditPage: React.FC = () => {
             <label className="block text-xs text-gray-500 uppercase tracking-wide mb-1">
               {t('notes', 'Märkmed')}
             </label>
-            <textarea
+            <MarkdownEditor
               value={draft.notes}
-              onChange={e => set({ notes: e.target.value })}
-              rows={3}
+              onChange={v => set({ notes: v })}
+              minRows={3}
               placeholder={t('form.notesPlaceholder')}
-              className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y"
             />
           </div>
         </CollapsibleSection>


### PR DESCRIPTION
## Summary

Adds a reusable, discoverable markdown editor and a safe markdown renderer, then wires them into the prosopography **Notes** and **Biography** fields (edit + detail pages). Markdown only — no raw HTML. No backend / data-model changes; `notes` and `biography` stay plain markdown strings.

Implements the plan in `docs/superpowers/plans/2026-06-29-markdown-notes-editor.md` task-by-task (one commit per task).

## What's included

**New components (`src/components/`, domain-neutral):**
- `markdownEditorHelpers.ts` — pure text-transform helpers (wrap, line-prefix, URL detect, link insert), DOM-free, unit-tested
- `MarkdownView.tsx` — safe renderer: `react-markdown` + `remark-gfm`, strict element allow-list (`unwrapDisallowed`), no `rehype-raw` (raw HTML stays escaped), `_blank`/`noopener` links, `null` on blank
- `MarkdownEditor.tsx` — toolbar (Bold / Italic / Heading / Link / List / `?` help), Write/Preview tabs (default Write), link popover with selection-based prefill + focus management, auto-sizing textarea

**Wiring:**
- `PersonEditPage.tsx` — Biography + Notes `<textarea>` → `MarkdownEditor`
- `PersonDetailPage.tsx` — `<ReactMarkdown>` → `MarkdownView`; Notes `<p whitespace-pre-wrap>` → `MarkdownView`

**Supporting:**
- `.vutt-md` styles in `src/index.css` (link `overflow-wrap: anywhere`, list padding, heading sizes)
- i18n keys under `markdownEditor` in both `locales/{et,en}/common.json`
- `remark-gfm@^4` dependency

## Tests / gates
- ✅ `npx vitest run` — 526 tests pass (incl. 13 new for helpers)
- ✅ `npm run typecheck` — clean
- ✅ `npm run build` — succeeds

## Manual QA to do (browser, `npm run dev`)
- [ ] Toolbar visible above Notes + Biography; all buttons work
- [ ] Bold/Italic on selection inserts `**…**` / `*…*`; empty selection inserts placeholder
- [ ] Heading prefixes line with `## `; List prefixes selected lines with `- ` (no duplication on already-prefixed lines)
- [ ] Link popover: plain-text selection → prefills link text + focuses URL; URL selection → prefills URL + focuses text; Esc/Cancel restores textarea focus at saved position; Apply inserts `[text](url)`
- [ ] Preview tab renders headings/bold/italic/links/lists; long bare URLs wrap (no overflow)
- [ ] Detail page renders markdown for Notes + Biography; a pasted GFM table renders as run-on text (expected — table rendering is out of v1 scope)

## Out of scope (per plan, YAGNI)
Toggle-removal of syntax, side-by-side preview, tables/footnotes/tasklists UI, keyboard shortcuts, page/work-level notes fields.