### PR TITLE
fix: mount LoginModal in Workspace error state

### DIFF
--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -334,8 +334,23 @@ const Workspace: React.FC = () => {
     );
   }
 
+  // Login modaal jagatud nii vea- kui tavavaate vahel. Vearee varajane return
+  // (allpool) jättis modaali muidu monteerimata → "logi sisse" nupp ei avanud
+  // midagi (väljalogitud kasutaja piiratud teosel).
+  const loginModal = (
+    <LoginModal
+      isOpen={showLoginModal}
+      onClose={() => {
+        setShowLoginModal(false);
+        clearSessionExpired();
+      }}
+      message={sessionExpired ? t('errors.sessionExpiredProtectedWork') : undefined}
+    />
+  );
+
   if (error || !page) {
     return (
+      <>
       <div className="h-screen w-screen flex items-center justify-center bg-gray-50">
         <div className="text-center max-w-md p-8 bg-white rounded-lg shadow-sm border border-gray-200">
           <div className="text-red-500 mb-4 flex justify-center"><AlertTriangle size={48} /></div>
@@ -370,6 +385,8 @@ const Workspace: React.FC = () => {
           </div>
         </div>
       </div>
+      {loginModal}
+      </>
     );
   }
 
@@ -681,14 +698,7 @@ const Workspace: React.FC = () => {
       />
 
       {/* Login modaal (sessioon aegunud või käsitsi avatud) */}
-      <LoginModal
-        isOpen={showLoginModal}
-        onClose={() => {
-          setShowLoginModal(false);
-          clearSessionExpired();
-        }}
-        message={sessionExpired ? t('errors.sessionExpiredProtectedWork') : undefined}
-      />
+      {loginModal}
     </div>
   );
 };


### PR DESCRIPTION
## Probleem

Väljalogitud kasutaja avab piiratud kollektsiooni teose (nt `/work/m3do2t/1`) → näeb veakaarti "Logi sisse", aga **"Logi sisse" nupp ei tee midagi**. "Tagasi avalehele" töötab.

## Põhjus

`Workspace.tsx` teeb veaolekus varajase `return`-i (`if (error || !page)`), mis renderdab ainult veakaardi. `<LoginModal>` oli ainult tava-(õnnestumis-)renderduses → veaolekus polnud modaali DOM-is. Nupp seadis `showLoginModal=true`, aga avada polnud midagi. ("Tagasi" on otsene `navigate('/')`.) Viga pärit `b9f9e05`-st.

## Parandus

Modaal tõstetud jagatud `loginModal` elemendiks, renderdatud nii vea- kui tavavaates (DRY).

## Väravad
- ✅ `npm run typecheck` puhas
- ✅ `npm run build` õnnestub

🤖 Generated with [Claude Code](https://claude.com/claude-code)