### PR TITLE
feat: context-aware title on Workspace error card

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -62,6 +62,7 @@
   "errors": {
     "connectionFailed": "Failed to connect to server",
     "unknownError": "Unknown error",
+    "loginRequiredTitle": "Login required",
     "loginFailed": "Login failed",
     "boundaryTitle": "Something went wrong",
     "boundaryDescription": "An unexpected error occurred in the application. Try reloading the page.",

--- a/src/locales/et/common.json
+++ b/src/locales/et/common.json
@@ -62,6 +62,7 @@
   "errors": {
     "connectionFailed": "Serveriga ühendamine ebaõnnestus",
     "unknownError": "Tundmatu viga",
+    "loginRequiredTitle": "Sisselogimine vajalik",
     "loginFailed": "Sisselogimine ebaõnnestus",
     "boundaryTitle": "Midagi läks valesti",
     "boundaryDescription": "Rakenduses tekkis ootamatu viga. Proovige lehekülge uuesti laadida.",

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -353,8 +353,12 @@ const Workspace: React.FC = () => {
       <>
       <div className="h-screen w-screen flex items-center justify-center bg-gray-50">
         <div className="text-center max-w-md p-8 bg-white rounded-lg shadow-sm border border-gray-200">
-          <div className="text-red-500 mb-4 flex justify-center"><AlertTriangle size={48} /></div>
-          <h2 className="text-xl font-bold text-gray-800 mb-2">{t('common:errors.unknownError')}</h2>
+          <div className={`mb-4 flex justify-center ${errorRequiresLogin ? 'text-primary-500' : 'text-red-500'}`}>
+            {errorRequiresLogin ? <LogIn size={48} /> : <AlertTriangle size={48} />}
+          </div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">
+            {errorRequiresLogin ? t('common:errors.loginRequiredTitle') : t('common:errors.unknownError')}
+          </h2>
           <p className="text-gray-600 mb-6">{error || t('common:errors.unknownError')}</p>
           <div className="text-xs bg-gray-100 p-2 rounded mb-4 text-left font-mono overflow-auto max-h-32">
             Debug: WorkID: {workId}, Page: {currentPageNum}


### PR DESCRIPTION
Kui veaolek on sisselogimise vajadus (`errorRequiresLogin`), näitab veakaart nüüd "Sisselogimine vajalik" / "Login required" + login-ikooni, mitte üldist punast "Tundmatu viga" pealkirja.

Järg PR #76-le (väljalogitud kasutaja piiratud teosel).

- ✅ typecheck puhas
- ✅ JSON valid (et + en `errors.loginRequiredTitle`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)