### PR TITLE
feat: lisa superadmin roll

### DIFF
--- a/docs/superpowers/plans/2026-06-30-superadmin-role.md
+++ b/docs/superpowers/plans/2026-06-30-superadmin-role.md
@@ -1,0 +1,772 @@
+# Superadmin-roll — implementatsiooniplaan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lisada neljas roll `superadmin`, mis sulgeb adminide-vahelise privileegi-eskaleerimise augu ja annab ühele kasutajale unikaalse autoriteedi hallata admine ja kollektsioonistruktuuri.
+
+**Architecture:** Tsentraliseeritud `ROLE_HIERARCHY` + range taseme-helperid `server/auth.py`-s. Üks invariant ("haldad ainult rangelt madalamat taset") rakendub kõigis kirjutusteedes (`update_user_role`, `delete_user`, `admin_reset_password`). Kollektsioonide struktuursed endpointid liiguvad `superadmin`-värava taha. Frontend peegeldab piiranguid mugavuse mõttes, backend jääb ainutõeks.
+
+**Tech Stack:** Python 3.9 / FastAPI (backend), pytest (`.venv/bin/python -m pytest`), React 19 + TypeScript (frontend), vitest + `tsc --noEmit`.
+
+## Global Constraints
+
+- **Pytest käivitamine:** alati `.venv/bin/python -m pytest <path>` (host venv, MITTE Docker).
+- **Frontend gate:** `npm run typecheck` (tsc) JA `npm run test` (vitest) peavad mõlemad läbima.
+- **Python 3.9 compat:** ei kasuta `X | None` süntaksit; kasuta `Optional[...]`.
+- **Range tasemed:** EI KUNAGI `.get(role, 0)` rollitaseme leidmiseks — tundmatu roll ei tohi vaikselt muutuda tasemeks 0. Kasuta `role_level()`, mis viskab tundmatu rolli peal.
+- **Rollide vaikeväärtus** (`.get("role", ...)`) on alati `"contributor"` (valiidne, madalaim) — MITTE `"user"`.
+- **Eriõigus tuleb AINULT rollist** — kustutatakse kõik `username == "meelis"` kõvakood-erandid.
+- Koodikommentaarid eesti keeles (codebase'i konventsioon).
+- Spec: `docs/superpowers/specs/2026-06-29-superadmin-role-design.md`.
+
+---
+
+## File Structure
+
+- `server/auth.py` — lisa `ROLE_HIERARCHY`, `role_level`, `is_valid_role`, `can_manage_user`, `can_assign_role`, `can_change_role`, `has_superadmin`; muuda `require_token`, `update_user_role`, `delete_user`, `verify_user`.
+- `server/routers/admin.py` — `admin_reset_password` kasutab `can_manage_user`.
+- `server/routers/collections.py` — PUT/POST/DELETE → `require_role("superadmin")`.
+- `server/main.py` — lifespan startup-check (`has_superadmin` → WARNING).
+- `tests/test_role_permissions.py` — UUS, tuum-invariandi unit-testid.
+- `tests/test_session_invalidation.py` — paranda olemasolev test, mis uue reegli all katki läheb.
+- `tests/test_admin_role_endpoints.py` — UUS, endpoint-tasandi testid (reset + collections).
+- `src/utils/roleUtils.ts` — UUS, puhtad frontend-helperid.
+- `src/utils/__tests__/roleUtils.test.ts` — UUS, vitest.
+- `src/pages/admin/Users.tsx` — juhtmesta roleUtils, lisa superadmin tugi, tooltip (ehitatakse WIP peale).
+- `src/locales/{et,en}/common.json` — `roles.superadmin`.
+- `src/locales/{et,en}/admin.json` — `users.noPermissionManage` tooltip.
+
+---
+
+## Task 1: Range rolli-helperid (auth.py, puhtad funktsioonid)
+
+**Files:**
+- Modify: `server/auth.py` (lisa moodul-tasandi definitsioonid)
+- Test: `tests/test_role_permissions.py` (UUS)
+
+**Interfaces:**
+- Produces:
+  - `ROLE_HIERARCHY: dict[str,int]` = `{"contributor":0,"editor":1,"admin":2,"superadmin":3}`
+  - `role_level(role: str) -> int` — viskab `ValueError` tundmatu rolli peal
+  - `is_valid_role(role: str) -> bool`
+  - `can_manage_user(actor_role: str, target_role: str) -> bool`
+  - `can_assign_role(actor_role: str, new_role: str) -> bool`
+  - `can_change_role(actor_role: str, target_role: str, new_role: str) -> bool`
+  - `has_superadmin(users: dict) -> bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Loo `tests/test_role_permissions.py`:
+
+```python
+"""Tuum-invariant: rolli-tasemed ja kes-tohib-keda hallata."""
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from server.auth import (
+    ROLE_HIERARCHY,
+    role_level,
+    is_valid_role,
+    can_manage_user,
+    can_assign_role,
+    can_change_role,
+    has_superadmin,
+)
+
+
+def test_hierarchy_has_four_tiers():
+    assert ROLE_HIERARCHY == {"contributor": 0, "editor": 1, "admin": 2, "superadmin": 3}
+
+
+def test_role_level_known():
+    assert role_level("contributor") == 0
+    assert role_level("superadmin") == 3
+
+
+def test_role_level_unknown_raises():
+    # KRIITILINE: tundmatu roll EI TOHI vaikselt muutuda tasemeks 0
+    with pytest.raises(ValueError):
+        role_level("user")
+    with pytest.raises(ValueError):
+        role_level("")
+
+
+def test_is_valid_role():
+    assert is_valid_role("admin") is True
+    assert is_valid_role("superadmin") is True
+    assert is_valid_role("user") is False
+
+
+def test_can_manage_user_strictly_lower():
+    # admin saab hallata editorit/contributorit
+    assert can_manage_user("admin", "editor") is True
+    assert can_manage_user("admin", "contributor") is True
+    # admin EI saa hallata teist admini ega superadmini (augu sulgemine)
+    assert can_manage_user("admin", "admin") is False
+    assert can_manage_user("admin", "superadmin") is False
+    # superadmin saab hallata admini, mitte teist superadmini
+    assert can_manage_user("superadmin", "admin") is True
+    assert can_manage_user("superadmin", "superadmin") is False
+
+
+def test_can_assign_role_ceiling():
+    # admin saab määrata kuni editor, mitte admin/superadmin
+    assert can_assign_role("admin", "editor") is True
+    assert can_assign_role("admin", "contributor") is True
+    assert can_assign_role("admin", "admin") is False
+    assert can_assign_role("admin", "superadmin") is False
+    # superadmin saab määrata kuni admin, mitte superadmin (võrdne tase)
+    assert can_assign_role("superadmin", "admin") is True
+    assert can_assign_role("superadmin", "superadmin") is False
+
+
+def test_can_change_role_requires_both():
+    # admin: tohib editorit puutuda JA contributoriks määrata
+    assert can_change_role("admin", "editor", "contributor") is True
+    # admin: ei tohi editorit adminiks tõsta (lagi)
+    assert can_change_role("admin", "editor", "admin") is False
+    # admin: ei tohi admini puutuda (sihtmärk)
+    assert can_change_role("admin", "admin", "contributor") is False
+    # superadmin: tohib admini editoriks alandada
+    assert can_change_role("superadmin", "admin", "editor") is True
+
+
+def test_has_superadmin():
+    assert has_superadmin({"a": {"role": "admin"}}) is False
+    assert has_superadmin({"a": {"role": "superadmin"}}) is True
+    assert has_superadmin({}) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_role_permissions.py -v`
+Expected: FAIL — `ImportError: cannot import name 'ROLE_HIERARCHY'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`server/auth.py` — lisa moodul-tasandi definitsioonid lähedale faili algusesse (pärast importe/olemasolevaid konstante nagu `SESSION_DURATION`, ENNE funktsioone):
+
+```python
+# =========================================================
+# ROLLIDE HIERARHIA — üks tõeallikas
+# =========================================================
+# contributor < editor < admin < superadmin. Eriõigus tuleb AINULT rollist,
+# mitte kasutajanimest.
+ROLE_HIERARCHY = {"contributor": 0, "editor": 1, "admin": 2, "superadmin": 3}
+
+
+def role_level(role: str) -> int:
+    """Tagastab rolli numbrilise taseme. Viskab ValueError tundmatu rolli peal.
+    EI KUNAGI vaikselt tasemeks 0 — tundmatu roll on viga, mitte madal õigus."""
+    try:
+        return ROLE_HIERARCHY[role]
+    except KeyError:
+        raise ValueError(f"Tundmatu roll: {role!r}")
+
+
+def is_valid_role(role: str) -> bool:
+    """Kas roll on hierarhias? Kasuta API-sisendi valideerimiseks enne role_level-i."""
+    return role in ROLE_HIERARCHY
+
+
+def can_manage_user(actor_role: str, target_role: str) -> bool:
+    """Kas actor tohib target-kasutajat üldse puutuda (reset / kustutus / rollimuutus)?
+    Sihtmärgi praegune tase peab olema RANGELT madalam actor tasemest."""
+    return role_level(target_role) < role_level(actor_role)
+
+
+def can_assign_role(actor_role: str, new_role: str) -> bool:
+    """Kas actor tohib MÄÄRATA rolli new_role? Lagi: rangelt madalam actor tasemest."""
+    return role_level(new_role) < role_level(actor_role)
+
+
+def can_change_role(actor_role: str, target_role: str, new_role: str) -> bool:
+    """Rollimuutus = tohib target-i puutuda JA tohib uut rolli määrata."""
+    return can_manage_user(actor_role, target_role) and can_assign_role(actor_role, new_role)
+
+
+def has_superadmin(users: dict) -> bool:
+    """Kas users-dictis on vähemalt üks superadmin? Startup-checki jaoks."""
+    return any(u.get("role") == "superadmin" for u in users.values())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_role_permissions.py -v`
+Expected: PASS (kõik 8 testi).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/auth.py tests/test_role_permissions.py
+git commit -m "feat(auth): range rolli-hierarhia ja can_manage helperid"
+```
+
+---
+
+## Task 2: Juhtmesta invariant kirjutusteedesse + koRista meelis-häkid (auth.py)
+
+**Files:**
+- Modify: `server/auth.py` — `require_token` (~216), `verify_user` (~140), `update_user_role` (~256), `delete_user` (~303), `auth.py:64` print-näide
+- Test: `tests/test_session_invalidation.py` (paranda olemasolev katki-minev test)
+
+**Interfaces:**
+- Consumes: `role_level`, `is_valid_role`, `can_change_role`, `can_manage_user`, `ROLE_HIERARCHY` (Task 1).
+- Produces: `update_user_role(username, new_role, admin_user) -> (bool, str)` ja `delete_user(username, admin_user) -> (bool, str)` jõustavad invariandi; `superadmin` on valiidne väärtus.
+
+- [ ] **Step 1: Paranda olemasolev test, mis uue reegli all katki läheb**
+
+`tests/test_session_invalidation.py::test_update_user_role_invalidates_sessions` tõstab praegu bob (editor) → admin, mille teeb alice (admin). Uue lae all on see KEELATUD (admin ei saa määrata admini rolli). Muuda test valiidseks rollimuutuseks (alandus editor→contributor, mis säilitab sessiooni-invalideerimise kontrolli). Asenda funktsioon:
+
+```python
+def test_update_user_role_invalidates_sessions(auth):
+    _add_session(auth, "tb", "bob")
+    admin = {"username": "alice", "role": "admin"}
+    # editor -> contributor on valiidne (admin tohib editorit puutuda ja contributoriks määrata)
+    ok, _ = auth.update_user_role("bob", "contributor", admin)
+    assert ok is True
+    # Bob peab uuesti sisse logima — sessioon kustutatud
+    assert "tb" not in auth.sessions
+    # Roll on uuendatud
+```
+
+Lisa samasse faili uus regressioon-test (augu sulgemine):
+
+```python
+def test_admin_cannot_demote_another_admin(auth):
+    # alice (admin) EI tohi teist admini (carol) puutuda
+    auth._users_cache["carol"] = {"name": "Carol", "role": "admin", "allowed_collections": []}
+    _add_session(auth, "tc", "carol")
+    admin = {"username": "alice", "role": "admin"}
+    ok, msg = auth.update_user_role("carol", "editor", admin)
+    assert ok is False
+    # Carol sessioon EI tohi olla invalideeritud (operatsioon blokeeriti)
+    assert "tc" in auth.sessions
+
+
+def test_superadmin_can_demote_admin(auth):
+    auth._users_cache["carol"] = {"name": "Carol", "role": "admin", "allowed_collections": []}
+    root = {"username": "root", "role": "superadmin"}
+    ok, _ = auth.update_user_role("carol", "editor", root)
+    assert ok is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_session_invalidation.py -v`
+Expected: `test_admin_cannot_demote_another_admin` ja `test_superadmin_can_demote_admin` FAIL (invariant pole veel juhtmestatud — `update_user_role` lubab praegu kõik).
+
+- [ ] **Step 3: Juhtmesta invariant + koRista häkid**
+
+**3a.** `server/auth.py` `verify_user` (~rida 140) — paranda default:
+
+```python
+        "role": users[username].get("role", "contributor"),
+```
+
+**3b.** `server/auth.py:64` print-näites asenda demonstratsioon (kosmeetiline, hoia konsistentsus):
+
+```python
+        print('  {"admin": {"password_hash": "<sha256>", "name": "Admin", "role": "contributor"}}')
+```
+
+**3c.** `require_token` (~read 216-221) — asenda inline hierarhia range tasemega:
+
+```python
+    if min_role:
+        # role_level viskab tundmatu rolli peal — fail-closed (500), mitte vaikne madal õigus
+        if role_level(user['role']) < role_level(min_role):
+            return None, {"status": "error", "message": f"Vajab vähemalt '{min_role}' õigusi"}
+```
+
+**3d.** `update_user_role` (~read 268-288) — asenda algusplokk (kuni `save_users` eelseni):
+
+```python
+    # Valideeri sissetulev roll ENNE taseme-arvutust
+    if not is_valid_role(new_role):
+        return False, f"Vigane roll. Lubatud: {', '.join(ROLE_HIERARCHY.keys())}"
+
+    # Admin ei saa oma rolli muuta (lukustumis-kaitse)
+    if username == admin_user["username"]:
+        return False, "Ei saa muuta enda rolli"
+
+    users = load_users()
+    if username not in users:
+        return False, "Kasutajat ei leitud"
+
+    target_current = users[username].get("role", "contributor")
+    # Invariant: tohib target-i puutuda JA tohib uut rolli määrata
+    if not can_change_role(admin_user["role"], target_current, new_role):
+        return False, "Pole õigust seda kasutajat sellele rollile määrata"
+
+    old_role = target_current
+    users[username]["role"] = new_role
+    save_users(users)
+```
+
+(Kustutab `valid_roles = [...]` käsitsi-nimekirja JA `if username == "meelis"` ploki.)
+
+**3e.** `delete_user` (~read 314-330) — asenda algusplokk:
+
+```python
+    # Admin ei saa ennast kustutada (lukustumis-kaitse)
+    if username == admin_user["username"]:
+        return False, "Ei saa kustutada ennast"
+
+    users = load_users()
+    if username not in users:
+        return False, "Kasutajat ei leitud"
+
+    # Invariant: tohib kustutada ainult rangelt madalamat taset
+    if not can_manage_user(admin_user["role"], users[username].get("role", "contributor")):
+        return False, "Pole õigust seda kasutajat kustutada"
+
+    deleted_name = users[username].get("name", username)
+    del users[username]
+    save_users(users)
+```
+
+(Kustutab `if username == "meelis"` ploki.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_session_invalidation.py tests/test_role_permissions.py -v`
+Expected: PASS (kõik).
+
+- [ ] **Step 5: Run broader auth suite for regressions**
+
+Run: `.venv/bin/python -m pytest tests/test_auth_password.py tests/test_password_reset.py tests/test_backend_smoke.py -v`
+Expected: PASS. Kui mõni test eeldab vana käitumist (nt admin tõstab kellegi adminiks), paranda test vastama uuele invariandile (valiidne kombinatsioon või superadmin-actor).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/auth.py tests/test_session_invalidation.py
+git commit -m "feat(auth): jõusta rolli-invariant update/delete; eemalda meelis-häkid; verify_user default contributor"
+```
+
+---
+
+## Task 3: admin_reset_password kasutab can_manage_user
+
+**Files:**
+- Modify: `server/routers/admin.py` (read ~84-106)
+- Test: `tests/test_admin_role_endpoints.py` (UUS)
+
+**Interfaces:**
+- Consumes: `can_manage_user` (Task 1), `backend_env` fixture + TestClient (conftest).
+
+- [ ] **Step 1: Write the failing test**
+
+Loo `tests/test_admin_role_endpoints.py`. Kasuta olemasolevaid `client` + `login` fixtureid ja `backend_env["auth"]` mustrit superadmini lisamiseks (täpselt nagu `test_password_reset_api.py::test_admin_reset_password_teist_admini_keelab_403` lisab admin2). EI muudeta jagatud `conftest.py` seemet. Märkus: admin-ei-saa-admini-resettida on JUBA kaetud `test_password_reset_api.py`-s — siin testime AINULT uut superadmin-teed.
+
+```python
+"""Endpoint-tasandi testid: superadmin-tee resetil ja kollektsioonidel."""
+
+
+def _seed_superadmin(backend_env):
+    auth = backend_env["auth"]
+    users = auth.load_users()
+    users["root"] = {
+        "password_hash": auth.hash_password("rootpass"),
+        "name": "Root",
+        "role": "superadmin",
+        "created_at": "2026-01-01T00:00:00",
+    }
+    auth.save_users(users)
+
+
+def test_superadmin_can_reset_admin(client, login, backend_env):
+    _seed_superadmin(backend_env)
+    token = login("root", "rootpass")
+    r = client.post("/admin/users/reset-password",
+                    json={"username": "admin"},
+                    headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+
+
+def test_admin_can_still_reset_editor(client, login):
+    # Regressioon: helper-asendus ei tohi adminilt editori-reset õigust võtta
+    token = login("admin", "adminpass")
+    r = client.post("/admin/users/reset-password",
+                    json={"username": "editor"},
+                    headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_admin_role_endpoints.py -v`
+Expected: `test_superadmin_can_reset_admin` FAIL — `superadmin` pole veel valiidne `min_role` enne Task 2 helpereid, VÕI reset-loogika kasutab veel vana hierarhiat. (`test_admin_can_still_reset_editor` võib juba pass-ida.) Kui mõlemad juba pass-ivad (Task 1-2 olemas), jätka — Step 3 on käitumist säilitav refaktor.
+
+- [ ] **Step 3: Asenda inline-loogika helperiga**
+
+`server/routers/admin.py` `admin_reset_password` — asenda `role_hierarchy = {...}` plokk (read ~100-103):
+
+```python
+    from ..auth import load_users, can_manage_user
+    ...
+    if target != user["username"] and not can_manage_user(user["role"], users[target].get("role", "contributor")):
+        raise HTTPException(status_code=403, detail="Ei saa lähtestada võrdse või kõrgema õigusega kasutajat")
+```
+
+(Eemalda `role_hierarchy`, `acting_level`, `target_level` read; impordi `can_manage_user` ülemise `from ..auth import ...` reaga koos.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_admin_role_endpoints.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/routers/admin.py tests/test_admin_role_endpoints.py tests/conftest.py
+git commit -m "feat(admin): reset-password kasutab can_manage_user; superadmin saab admini resettida"
+```
+
+---
+
+## Task 4: Kollektsioonide struktuursed endpointid → superadmin
+
+**Files:**
+- Modify: `server/routers/collections.py` — PUT (~92), POST (~196), DELETE (~298)
+- Test: `tests/test_admin_role_endpoints.py` (lisa)
+
+**Interfaces:**
+- Consumes: `require_role("superadmin")`, `backend_env` (`admin` + `root`).
+
+- [ ] **Step 1: Write the failing test**
+
+Lisa `tests/test_admin_role_endpoints.py`-sse (kasutab sama `_seed_superadmin` helperit):
+
+```python
+def test_admin_cannot_create_collection(client, login):
+    token = login("admin", "adminpass")
+    r = client.post("/admin/collections",
+                    json={"id": "x", "name": {"et": "X", "en": "X"}},
+                    headers={"Authorization": f"Bearer {token}"})
+    # require_role("superadmin") ebaõnnestumisel tõstab deps.get_user HTTPException(401)
+    assert r.status_code == 401
+
+
+def test_superadmin_can_create_collection(client, login, backend_env):
+    _seed_superadmin(backend_env)
+    token = login("root", "rootpass")
+    r = client.post("/admin/collections",
+                    json={"id": "testcoll", "name": {"et": "Test", "en": "Test"}},
+                    headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+```
+
+NB: kinnitatud — `require_role` ebaõnnestumisel `deps.get_user` tõstab `HTTPException(401)` (`require_token` tagastab error → `raise HTTPException(status_code=401)`). Seega admin → superadmin-endpoint = **401**. Kui `admin_create_collection` eeldab keha-välju, mida testi payload ei anna, ja jõuab 200/500-ni superadminina, kohanda payload endpointi tegeliku ootuse järgi (vt `collections.py:196` keha-parsimist) — väravakontroll (401 admini puhul) on testi tuum.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_admin_role_endpoints.py -k collection -v`
+Expected: `test_admin_cannot_create_collection` FAIL (praegu `require_role("admin")` lubab admini läbi).
+
+- [ ] **Step 3: Muuda väravad**
+
+`server/routers/collections.py` — kolmel endpointil asenda `require_role("admin")` → `require_role("superadmin")`:
+
+```python
+# rida ~92
+async def admin_update_collection(collection_id: str, request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("superadmin"))):
+# rida ~196
+async def admin_create_collection(request: Request, user=Depends(require_role("superadmin"))):
+# rida ~298
+async def admin_delete_collection(collection_id: str, background_tasks: BackgroundTasks, user=Depends(require_role("superadmin"))):
+```
+
+EI muudeta: `admin_collection_users` (GET, ~176), `admin_collection_works_count` (GET, ~288), ega `editing.py` `bulk_collection` — need jäävad `require_role("admin")`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_admin_role_endpoints.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/routers/collections.py tests/test_admin_role_endpoints.py
+git commit -m "feat(collections): struktuursed CRUD endpointid nõuavad superadmini"
+```
+
+---
+
+## Task 5: Startup-check — hoiata, kui ühtegi superadmini pole
+
+**Files:**
+- Modify: `server/main.py` (lifespan, ~rida 36-42)
+- Test: `tests/test_role_permissions.py` (lisa `has_superadmin` käitumise integratsioon — juba kaetud Task 1-s; siin lisa lifespan-loogika otsene test)
+
+**Interfaces:**
+- Consumes: `has_superadmin`, `load_users` (auth.py).
+
+- [ ] **Step 1: Write the failing test**
+
+Lisa `tests/test_role_permissions.py`-sse funktsioon, mis testib uut `warn_if_no_superadmin` helperit (eraldame lifespan-loogika testitavaks funktsiooniks):
+
+```python
+def test_warn_if_no_superadmin(monkeypatch, caplog):
+    import logging
+    import server.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "load_users", lambda: {"a": {"role": "admin"}})
+    with caplog.at_level(logging.WARNING):
+        present = auth_mod.warn_if_no_superadmin()
+    assert present is False
+    assert any("superadmin" in r.message.lower() for r in caplog.records)
+
+
+def test_warn_if_no_superadmin_present(monkeypatch, caplog):
+    import server.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "load_users", lambda: {"a": {"role": "superadmin"}})
+    present = auth_mod.warn_if_no_superadmin()
+    assert present is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_role_permissions.py -k superadmin -v`
+Expected: FAIL — `warn_if_no_superadmin` puudub.
+
+- [ ] **Step 3: Lisa helper + kutsu lifespan-is**
+
+`server/auth.py` — lisa (vajab moodulis `logger`-it; kui pole, kasuta olemasolevat logimismustrit — kontrolli faili algust, kas `logger = logging.getLogger(...)` on olemas, muidu lisa):
+
+```python
+def warn_if_no_superadmin() -> bool:
+    """Logib WARNING-u, kui üheski kasutajas pole superadmin rolli.
+    Tagastab True, kui superadmin eksisteerib. Ei paranda automaatselt."""
+    users = load_users()
+    if has_superadmin(users):
+        return True
+    logger.warning(
+        "ÜHTEGI superadmin rolliga kasutajat pole — admini- ja kollektsioonihalduse "
+        "funktsioonid on lukus, kuni keegi seemendatakse superadminiks (users.json)."
+    )
+    return False
+```
+
+`server/main.py` lifespan — lisa `build_work_id_cache()` kõrvale (pärast importe), nt pärast `run_git_fsck()`:
+
+```python
+    from .auth import warn_if_no_superadmin
+    warn_if_no_superadmin()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_role_permissions.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/auth.py server/main.py tests/test_role_permissions.py
+git commit -m "feat(auth): startup-hoiatus kui ühtegi superadmini pole"
+```
+
+---
+
+## Task 6: Frontend — roleUtils helperid + Users.tsx + i18n
+
+**Files:**
+- Create: `src/utils/roleUtils.ts`, `src/utils/__tests__/roleUtils.test.ts`
+- Modify: `src/pages/admin/Users.tsx`, `src/locales/{et,en}/common.json`, `src/locales/{et,en}/admin.json`
+
+**Interfaces:**
+- Produces: `ROLE_LEVELS`, `Role`, `roleLevel`, `canManageUser`, `canAssignRole`, `assignableRoles`.
+
+- [ ] **Step 1: Write the failing test**
+
+Loo `src/utils/__tests__/roleUtils.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { roleLevel, canManageUser, canAssignRole, assignableRoles, ROLE_LEVELS } from '../roleUtils';
+
+describe('roleUtils', () => {
+  it('hierarhia neli taset', () => {
+    expect(ROLE_LEVELS).toEqual({ contributor: 0, editor: 1, admin: 2, superadmin: 3 });
+  });
+  it('tundmatu roll = -1 (ei anna õigusi)', () => {
+    expect(roleLevel('user')).toBe(-1);
+    expect(roleLevel('admin')).toBe(2);
+  });
+  it('canManageUser ainult rangelt madalam', () => {
+    expect(canManageUser('admin', 'editor')).toBe(true);
+    expect(canManageUser('admin', 'admin')).toBe(false);
+    expect(canManageUser('superadmin', 'admin')).toBe(true);
+    expect(canManageUser('superadmin', 'superadmin')).toBe(false);
+  });
+  it('canAssignRole lagi', () => {
+    expect(canAssignRole('admin', 'editor')).toBe(true);
+    expect(canAssignRole('admin', 'admin')).toBe(false);
+    expect(canAssignRole('superadmin', 'admin')).toBe(true);
+    expect(canAssignRole('superadmin', 'superadmin')).toBe(false);
+  });
+  it('assignableRoles filter', () => {
+    expect(assignableRoles('admin')).toEqual(['contributor', 'editor']);
+    expect(assignableRoles('superadmin')).toEqual(['contributor', 'editor', 'admin']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- roleUtils`
+Expected: FAIL — `Cannot find module '../roleUtils'`.
+
+- [ ] **Step 3: Loo roleUtils.ts**
+
+`src/utils/roleUtils.ts`:
+
+```ts
+// Rolli-hierarhia frontend-pool. Peegeldab backendi ROLE_HIERARCHY-t.
+// MUGAVUS, MITTE TURVE: kõik piirangud dubleeritakse backendis (can_manage_user jne).
+export const ROLE_LEVELS: Record<string, number> = {
+  contributor: 0,
+  editor: 1,
+  admin: 2,
+  superadmin: 3,
+};
+
+export type Role = 'contributor' | 'editor' | 'admin' | 'superadmin';
+
+const ORDER: Role[] = ['contributor', 'editor', 'admin', 'superadmin'];
+
+/** Tundmatu roll = -1 (ei anna õigusi). EI vaikselt 0 — peegeldab backendi rangust. */
+export function roleLevel(role: string): number {
+  const lvl = ROLE_LEVELS[role];
+  return lvl === undefined ? -1 : lvl;
+}
+
+export function canManageUser(actorRole: string, targetRole: string): boolean {
+  return roleLevel(targetRole) < roleLevel(actorRole);
+}
+
+export function canAssignRole(actorRole: string, newRole: string): boolean {
+  return roleLevel(newRole) < roleLevel(actorRole);
+}
+
+/** Rollid, mida actor tohib määrata (rangelt madalamad), hierarhia järjekorras. */
+export function assignableRoles(actorRole: string): Role[] {
+  return ORDER.filter((r) => canAssignRole(actorRole, r));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- roleUtils`
+Expected: PASS.
+
+- [ ] **Step 5: i18n — lisa superadmin + tooltip**
+
+`src/locales/et/common.json` `roles` blokki lisa:
+```json
+    "superadmin": "Superadministraator"
+```
+`src/locales/en/common.json` `roles` blokki:
+```json
+    "superadmin": "Superadministrator"
+```
+`src/locales/et/admin.json` `users` blokki lisa:
+```json
+    "noPermissionManage": "Sul ei ole õigust hallata sama või kõrgema taseme kasutajat"
+```
+`src/locales/en/admin.json` `users` blokki:
+```json
+    "noPermissionManage": "You don't have permission to manage a user of equal or higher level"
+```
+(NB: jälgi JSON-i komasid — lisa eelmise rea lõppu koma.)
+
+- [ ] **Step 6: Juhtmesta Users.tsx**
+
+`src/pages/admin/Users.tsx` muudatused:
+
+**6a.** Import (faili ülaosa, teiste importide juurde):
+```tsx
+import { ROLE_LEVELS, canManageUser, canAssignRole, assignableRoles, roleLevel } from '../../utils/roleUtils';
+```
+
+**6b.** Kustuta lokaalne `const ROLE_LEVEL: Record<string, number> = { contributor: 0, editor: 1, admin: 2 };` (rida ~35) — kasuta imporditud `ROLE_LEVELS`.
+
+**6c.** `User` tüübi `role` union (rida ~24) → lisa superadmin:
+```tsx
+  role: 'contributor' | 'editor' | 'admin' | 'superadmin';
+```
+
+**6d.** Lehe-väravad: asenda KÕIK `user.role !== 'admin'` / `user?.role === 'admin'` kontrollid taseme-põhisega (superadmin PEAB lehele pääsema). Read ~55, ~61, ~212:
+```tsx
+// rida ~55 (redirect kui pole õigust)
+    if (!userLoading && (!user || roleLevel(user.role) < ROLE_LEVELS.admin)) {
+// rida ~61 (fetch)
+    if (authToken && user && roleLevel(user.role) >= ROLE_LEVELS.admin) {
+// rida ~212 (render guard)
+  if (roleLevel(user.role) < ROLE_LEVELS.admin) return null;
+```
+
+**6e.** `canReset` (rida ~283) → kasuta canManageUser:
+```tsx
+                const canReset = isCurrentUser || canManageUser(user.role, u.role);
+                const canManage = canManageUser(user.role, u.role);
+                const canDelete = !isCurrentUser && canManage;
+```
+
+**6f.** Rolli-select (read ~395-404) — näita select ainult kui `canManage`, muidu staatiline badge; options = `assignableRoles(user.role)`:
+```tsx
+                        {isCurrentUser || !canManage ? (
+                          <span className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs"
+                                title={!isCurrentUser && !canManage ? t('users.noPermissionManage') : undefined}>
+                            {t(`common:roles.${u.role}`)}
+                          </span>
+                        ) : (
+                          <select
+                            value={u.role}
+                            onChange={(e) => handleRoleChange(u.username, e.target.value)}
+                            disabled={isProcessing}
+                            className="text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
+                          >
+                            {assignableRoles(user.role).map((r) => (
+                              <option key={r} value={r}>{t(`common:roles.${r}`)}</option>
+                            ))}
+                          </select>
+                        )}
+```
+
+(Kuna `canManage` ⟹ target on rangelt madalam ⟹ tema praegune roll on alati `assignableRoles(user.role)` hulgas, on `value={u.role}` alati valiidne valik.)
+
+- [ ] **Step 7: Verify typecheck + tests**
+
+Run: `npm run typecheck && npm run test -- roleUtils`
+Expected: tsc puhas (0 viga), vitest PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/utils/roleUtils.ts src/utils/__tests__/roleUtils.test.ts src/pages/admin/Users.tsx src/locales/et/common.json src/locales/en/common.json src/locales/et/admin.json src/locales/en/admin.json
+git commit -m "feat(users): frontend superadmin-roll, rolli-piirangud + tooltip"
+```
+
+---
+
+## Lõppkontroll (pärast kõiki taske)
+
+- [ ] **Backend täissuit:** `.venv/bin/python -m pytest -q` — kõik PASS.
+- [ ] **Frontend:** `npm run typecheck && npm run test` — mõlemad PASS.
+- [ ] **Spec-coverage käsitsi:** kõvakood-meelis eemaldatud (`grep -rn '"meelis"' server/` → tühi); `.get(role, 0)` puudub uutes helperites; verify_user default contributor.
+
+## Deploy (käsitsi, pärast merge'i — vt spec runbook)
+
+1. Backup `state/users.json` serveris.
+2. Muuda Meelise `role` → `superadmin` (`users.json`), atomic.
+3. `git pull && docker compose build --no-cache backend && docker compose up -d backend`.
+4. Frontend: `npm run build` lokaalselt + `rsync -avz dist/ vutt:~/VUTT/dist/`.
+5. Kontrolli: Meelis login; `/admin/users` laeb; admin ei saa admini-rida muuta; superadmin näeb admin-valikut; startup-logis pole "ühtegi superadmini pole" hoiatust.

--- a/docs/superpowers/specs/2026-06-29-superadmin-role-design.md
+++ b/docs/superpowers/specs/2026-06-29-superadmin-role-design.md
@@ -8,12 +8,12 @@
 Praegu on kolm rolli: `contributor(0) < editor(1) < admin(2)`. Adminide vahel on
 **horisontaalse privileegi-eskaleerimise auk**:
 
-1. Iga admin saab teise adminni alandada editoriks (`update_user_role` / `delete_user`
+1. Iga admin saab teise admini alandada editoriks (`update_user_role` / `delete_user`
    ei kontrolli sihtmärgi taset).
 2. Editoriks alandatud kasutaja parooli saab seejärel resettida (`admin_reset_password`
    lubab `target_level < acting_level`).
 
-→ Iga admin saab kahe sammuga üle võtta teise adminni konto.
+→ Iga admin saab kahe sammuga üle võtta teise admini konto.
 
 Parooli-reset ise on JUBA kaitstud (`routers/admin.py:100-103`: `target_level >= acting_level`
 blokeerib), aga `update_user_role` ja `delete_user` **ei ole** — seal ongi auk.
@@ -24,17 +24,17 @@ Lisaks on "superadmin" praegu **kõvakodeeritud häkk**: `auth.py:278` ja `:319`
 ## Eesmärk
 
 Lisada neljas tasand `superadmin`, mis:
-- Annab ühele kasutajale (praegu Meelis) unikaalse autoriteedi hallata adminne.
+- Annab ühele kasutajale (praegu Meelis) unikaalse autoriteedi hallata admine.
 - Sulgeb eskaleerimise augu üldise invariandiga.
 - Koristab kõvakodeeritud `meelis`-erandid.
-- Viib kollektsioonide **struktuurse** halduse superadminni taha.
+- Viib kollektsioonide **struktuurse** halduse superadmini taha.
 
 ## Mitte-eesmärgid (YAGNI)
 
 - **Ei** nihutata olemasolevaid rolle ümber (editor→contributor jne). See muudaks iga
   `require_role(...)` värava semantikat kogu koodibaasis — suur plahvatusraadius. Lükatud
   tagasi.
-- **Ei** tehta in-app "tõsta superadminniks" nuppu. Range invariant ei lubaks superadminnil
+- **Ei** tehta in-app "tõsta superadminiks" nuppu. Range invariant ei lubaks superadminil
   võrdset taset luua. Teine superadmin seemendatakse vajadusel serveris (`users.json`).
 - **Ei** muudeta süsteemi-konfiguratsiooni (taksonoomiad, sõnavarad) — see on niikuinii
   serveri/koodi tasemel, ei puuduta kasutaja-õigusi.
@@ -56,46 +56,113 @@ ROLE_HIERARCHY = {"contributor": 0, "editor": 1, "admin": 2, "superadmin": 3}
 Kõik kohad loevad sellest. `require_role` (`deps.py`) delegeerib `require_token`-ile, mis
 kasutab `ROLE_HIERARCHY`-t → automaatselt toetab `min_role="superadmin"`.
 
-## Autoriseerimise invariant (tuum)
+### Range taseme-lahendus (KRIITILINE)
 
-Üks jagatud helper `auth.py`-s:
+**Ära kasuta `.get(role, 0)`-t taseme leidmiseks.** Tundmatu roll EI TOHI vaikselt
+muutuda contributor-tasemeks (0) — see tekitab ohtlikke servajuhte, eriti `new_role`
+puhul, kui mõni `valid_roles` kontroll vahele jääks. Range helper:
 
 ```python
-def can_manage(actor_role, target_current_role, new_role=None):
-    """Kas actor tohib hallata target-kasutajat (rolli muutus / kustutus / reset)?
-    Reegel 1 (sihtmärk): target praegune tase peab olema RANGELT madalam actor tasemest.
-    Reegel 2 (määramise lagi): kui new_role antud, peab see olema RANGELT madalam actor tasemest.
-    """
-    a = ROLE_HIERARCHY.get(actor_role, 0)
-    if ROLE_HIERARCHY.get(target_current_role, 0) >= a:
-        return False
-    if new_role is not None and ROLE_HIERARCHY.get(new_role, 0) >= a:
-        return False
-    return True
+def role_level(role: str) -> int:
+    try:
+        return ROLE_HIERARCHY[role]
+    except KeyError:
+        raise ValueError(f"Tundmatu roll: {role!r}")
+
+def is_valid_role(role: str) -> bool:
+    return role in ROLE_HIERARCHY
 ```
+
+- `valid_roles` tuleb **otse** `ROLE_HIERARCHY.keys()`-ist, mitte eraldi käsitsi-nimekirjana
+  (`auth.py:269` praegune `['contributor','editor','admin']` kustutatakse).
+- Endpointid valideerivad sissetuleva `new_role` enne `role_level`-i kutsumist
+  (`is_valid_role` → 400, kui vigane), et `role_level` ei viskaks kasutaja-sisendi peal.
+- Salvestatud andmete tundmatu roll (`users.json` rikutud/legacy) → `role_level` viskab →
+  500 + log, mitte vaikne madal õigus.
+
+**Latentne bug, mille range helper paljastab:** `verify_user` (`auth.py:140`) tagastab
+vaikimisi `role="user"` — see **pole hierarhias**. Paranda default → `"contributor"`.
+Sama `auth.py:64` näiteprint ja kõik `.get("role", ...)` defaultid ühtlustada
+`"contributor"`-iks (valiidne, madalaim).
+
+## Autoriseerimise invariant (tuum)
+
+**Üks `can_manage` asemel kolm fokuseeritud helperit** — turvaloogika on loetavam, kui
+"kas tohib puutuda" ja "kas tohib määrata rolli" on lahus:
+
+```python
+def can_manage_user(actor_role, target_role) -> bool:
+    """Kas actor tohib target-kasutajat üldse puutuda (reset / kustutus / rollimuutus)?
+    Sihtmärgi praegune tase peab olema RANGELT madalam actor tasemest."""
+    return role_level(target_role) < role_level(actor_role)
+
+def can_assign_role(actor_role, new_role) -> bool:
+    """Kas actor tohib MÄÄRATA rolli new_role? Lagi: rangelt madalam actor tasemest."""
+    return role_level(new_role) < role_level(actor_role)
+
+def can_change_role(actor_role, target_role, new_role) -> bool:
+    """Rollimuutus = mõlemad: tohib target-i puutuda JA tohib uut rolli määrata."""
+    return can_manage_user(actor_role, target_role) and can_assign_role(actor_role, new_role)
+```
+
+Endpointides selge:
+- **reset / delete:** `can_manage_user(actor, target_current)`
+- **rollimuutus:** `can_change_role(actor, target_current, new_role)`
+- **kasutaja loomine rolli-valikuga** (kui selline tee tekib): `can_assign_role(actor, new_role)`
 
 Tagajärjed:
 - Admin (2) saab hallata contributor/editor (0,1), määrata rolle kuni editor (1). **Ei saa**
-  kedagi adminniks tõsta ega adminni puutuda.
-- Superadmin (3) saab hallata adminne (2), määrata rolle kuni admin (2). **Ei saa** teist
-  superadminni luua (võrdne tase) — see on tahtlik, vt mitte-eesmärgid.
-- Keegi ei saa puutuda superadminni → kõvakodeeritud `meelis`-erandid muutuvad üleliigseks.
+  kedagi admini-tasemele tõsta ega admini puutuda.
+- Superadmin (3) saab hallata admine (2), määrata rolle kuni admin (2). **Ei saa** teist
+  superadmini luua (võrdne tase) — see on tahtlik, vt mitte-eesmärgid.
+- Keegi ei saa puutuda superadmini → kõvakodeeritud `meelis`-erandid muutuvad üleliigseks.
+  **Nimi ise ei anna enam ühtegi eriõigust — eriõigus tuleb AINULT rollist.**
+
+### Kasutaja-loomise / impordi / kutse teede audit
+
+Verifitseeritud: ainus kasutaja-loomise tee on `approve_registration`
+(`registration.py:322`), mis **kõvakodeeritult** seab `role="editor"` — admin EI vali
+rolli loomisel. Seega ükski praegune tee ei luba admini ega superadmini **luua**;
+rolli tõstmine käib ainult `update_user_role`-i kaudu, mille invariant valvab.
+**Kui** loomine muutub tulevikus rolli-valitavaks (nt admini-loodud kasutaja rolliga),
+peab seal olema `can_assign_role(actor, new_role)` lagi. Märgitud, et mitte unustada.
 
 ### Rakenduskohad
 
 | Funktsioon | Praegu | Muudatus |
 |-----------|--------|----------|
-| `update_user_role` (`auth.py:256`) | ei kontrolli sihtmärki | lisa `can_manage(actor, target_current, new_role)` |
-| `delete_user` (`auth.py:303`) | ei kontrolli sihtmärki | lisa `can_manage(actor, target_current)` |
-| `admin_reset_password` (`routers/admin.py:84`) | inline `target_level >= acting_level` | asenda `can_manage(actor, target_current)` |
+| `update_user_role` (`auth.py:256`) | ei kontrolli sihtmärki | `is_valid_role(new_role)` → muidu 400; siis `can_change_role(actor, target_current, new_role)` |
+| `delete_user` (`auth.py:303`) | ei kontrolli sihtmärki | lisa `can_manage_user(actor, target_current)` |
+| `admin_reset_password` (`routers/admin.py:84`) | inline `target_level >= acting_level` | asenda `can_manage_user(actor, target_current)` |
 | `auth.py:278` (`meelis` rolli-keeld) | kõvakood | **kustuta** (invariant katab) |
 | `auth.py:319` (`meelis` delete-keeld) | kõvakood | **kustuta** (invariant katab) |
 
 Säilib: `username == admin_user["username"]` keeld (ei saa muuta/kustutada iseennast) —
 see lukustumis-kaitse jääb mõlemasse funktsiooni.
 
-`update_user_role` `valid_roles` peab nüüd sisaldama `superadmin`-i (et seemendatud
-superadmin oleks valiidne väärtus), aga `can_manage` lagi takistab tavaadminnil seda määrata.
+`valid_roles` tuleb `ROLE_HIERARCHY.keys()`-ist → sisaldab automaatselt `superadmin`-i
+(seemendatud väärtus on valiidne), aga `can_assign_role` lagi takistab tavaadminil seda
+määrata.
+
+### Tokeni / sessiooni roll ja värskus
+
+Verifitseeritud käitumine: sessioon hoiab kasutaja **hetktõmmist** (`create_session`
+salvestab `user` dicti; `require_token` loeb `session["user"]`-ist, **mitte** igal päringul
+värskelt `users.json`-ist). Roll ei ole krüpteeritud tokeni sees — token on läbipaistmatu
+UUID, mis viitab serveri-poolsele sessioonile.
+
+Staleness on kaetud: `update_user_role` JA `delete_user` kutsuvad
+`delete_user_sessions(username)` → sihtkasutaja **kõik** aktiivsed sessioonid
+invalideeritakse kohe, sunnib re-login'i. Seega:
+- Admini → editori alandamisel lõppeb tema kõrgema rolliga sessioon **otsekohe** (mitte
+  kuni 24h tokeni-aegumiseni).
+- Sama kehtib reset-tokenite kohta: `revoke_user_reset_tokens(..., "role_changed")` juba
+  tühistab pooleliolevad reset-tokenid rolli muutusel (race-kaitse).
+
+Järeldus: eraldi `token_version`-it ega tokeni lühendamist ei ole vaja — sessiooni-
+invalideerimine täidab sama eesmärgi. Dokumenteeritud, et invariant ei sõltu sellest,
+et keegi tuleviku-refaktoris session-snapshot'i fresh-lookup'iks vahetaks ilma
+invalideerimist säilitamata.
 
 ## Seemendamine / migratsioon
 
@@ -103,6 +170,25 @@ superadmin oleks valiidne väärtus), aga `can_manage` lagi takistab tavaadminni
   migratsiooniskripti pole vaja. (Roll tuleb niikuinii sealt.)
 - Tulevikus teine superadmin: sama seemendamine serveris.
 - Lukustumis-kaitse: superadmin ei saa iseennast alandada (olemasolev `username == self` keeld).
+
+### Deploy-järjekord (KRIITILINE — locked-out risk)
+
+Kui uus kood läheb peale **enne** `users.json` muutmist, ei pruugi süsteemis olla ühtegi
+superadmini → keegi ei saa enam admine ega kollektsioonide struktuuri hallata. Õige
+järjekord:
+
+1. **Backup** `state/users.json` (host).
+2. **Muuda** Meelise `role` → `superadmin` (`users.json`), atomic.
+3. **Deploy** uus backend (`docker compose build --no-cache backend && up -d backend`).
+4. **Kontrolli:** Meelis login OK; `/admin/users` laeb; rolli-muutus admini peal annab 403;
+   superadmin näeb admini-halduse valikuid.
+5. **Kontrolli invariant:** vähemalt üks superadmin eksisteerib.
+
+### Startup-check
+
+Serveri stardil (nt `rebuild_indices()` kõrval või `load_users` järel) **logi WARNING/ERROR**,
+kui `users.json`-is pole ühtegi `superadmin` rolliga kasutajat. Ei paranda automaatselt —
+annab operaatorile kohe märku, et superadmini halduse-funktsioonid on lukus.
 
 ## Kollektsioonid
 
@@ -117,28 +203,72 @@ Eralda struktuur sisust:
 | `GET /admin/collections/{id}/users` (`collections.py:176`) | `require_role("admin")` | jääb admin (luge-abi) |
 | `GET .../works-count` (`collections.py:288`) | `require_role("admin")` | jääb admin (luge-abi) |
 
+**PUT-i ulatus (leid):** `admin_update_collection` ei muuda ainult struktuuri (description,
+description_long, color, visibility) — see haldab read 153-171 ka **`allowed_users`-t**,
+st kes pääseb piiratud kollektsioonile ligi (kirjutab `users.json` `allowed_collections`,
+invalideerib sessioonid). See on **ligipääsu-kontroll**, mis on superadmini taha viimist
+veelgi rohkem õigustatud. Kõrvalmõju: tavaadmin ei saa enam kollektsiooni description/color
+muuta. **Aktsepteeritud kompromiss v1-s** (kogu PUT → superadmin). Kui kosmeetiliste
+väljade (description/color) muutmine peab jääma adminile, eraldatakse need omaette
+endpointiks hilisemas iteratsioonis — praegu YAGNI.
+
+**`POST /works/bulk-collection` jääb teadlikult adminile:** tööde lisamine olemasolevasse
+kollektsiooni on sisu-kureerimine, mitte kollektsioonistruktuuri haldus.
+
 ## Frontend (`src/pages/admin/Users.tsx`)
 
 Ehitatakse olemasoleva committimata WIP **peale** (kebab-menüü portal/fixed-positsioneerimine —
 rolliteemaga mitteseotud, ei klobestata).
 
+**Backend on ainutõde.** Frontend-piirangud on AINULT kasutusmugavuse jaoks; kõik reeglid
+dubleeritakse backendis (`can_manage_user` / `can_change_role`). Frontendi keelu möödaminek
+(nt käsitsi API-päring) lööb backendi 403-sse.
+
 - Rolli-dropdown näitab ainult valikuid `level < minu_tase` (admin: contributor/editor;
   superadmin: +admin). `superadmin` valikut dropdownis **ei ole** (ei saa määrata).
 - Rea tegevused (rolli muutus / kustuta / reset) **disabled**, kui
   `target_level >= minu_tase`.
+- **Disabled tegevus näitab tooltip'i/seletust**, nt "Sul ei ole õigust hallata sama või
+  kõrgema taseme kasutajat" — muidu admin näeb halli nuppu ega tea, kas see on bug või
+  õiguste piirang.
 - `superadmin` rolli-badge.
-- i18n: `et` + `en`, rolli-nimi ja badge.
+- i18n: `et` + `en`, rolli-nimi, badge ja tooltip-tekst.
 
 Kasutaja taseme võrdluseks on frontendil vaja sama hierarhiat — väike konstant
 (`ROLE_LEVELS`) frontendi pool, peegeldab backendi oma.
 
 ## Testid
 
-`pytest` invariandi-maatriks (`can_manage`):
+`pytest` invariandi-maatriks (`role_level` / `can_manage_user` / `can_assign_role` /
+`can_change_role`):
+
+**Tuum-invariant:**
 - Iga `(actor_role × target_current_role × new_role)` lubatud/keelatud kombinatsioon.
-- Regressioon: admin **ei saa** adminni alandada ega kustutada (augu sulgemine).
-- Superadmin saab adminni hallata; ei saa superadminni puutuda.
-- Iseenda haldamise keeld säilib.
+- Regressioon (augu sulgemine): admin **ei saa** admini alandada ega kustutada.
+- Superadmin saab admini hallata/resettida; **ei saa** superadmini puutuda.
+- Superadmin **ei saa** määrata `superadmin` rolli (võrdne tase).
+- Iseenda haldamise keeld säilib (`username == self`).
+
+**Range taseme-käsitlus:**
+- Tundmatu roll `users.json`-is → `role_level` viskab; ei anta vaikimisi contributor-õigusi
+  (käitumine: 500 + log, mitte vaikne madal õigus).
+- Tundmatu `new_role` API payloadis → 400 (`is_valid_role` enne `role_level`-i).
+- `verify_user` default → `"contributor"` (mitte `"user"`), kontrollitud.
+
+**`meelis`-erandi regressioon:**
+- Kasutajanimi ise ei anna enam ühtegi eriõigust — eriõigus tuleb ainult rollist
+  (test: `admin` rolliga "meelis" käitub nagu tavaadmin; `superadmin` rolliga suvaline nimi
+  käitub nagu superadmin).
+
+**Endpoint-tasand:**
+- Kollektsioonide create/update/delete: admin → 403, superadmin → läbi.
+- `bulk-collection`: admin → läbi (jääb adminile).
+- Reset: admin saab editorit resettida, admini mitte; superadmin saab admini resettida,
+  superadmini mitte.
+
+**Tokeni staleness:**
+- Rolli muutus → sihtkasutaja sessioonid invalideeritud (kõrgema rolliga sessioon lõpeb
+  kohe). Teadlikult testitud/dokumenteeritud käitumine.
 
 ## Plahvatusraadius
 

--- a/docs/superpowers/specs/2026-06-29-superadmin-role-design.md
+++ b/docs/superpowers/specs/2026-06-29-superadmin-role-design.md
@@ -1,0 +1,151 @@
+# Superadmin-roll — disain
+
+**Kuupäev:** 2026-06-29
+**Staatus:** kinnitatud disain, ootab implementatsiooniplaani
+
+## Probleem
+
+Praegu on kolm rolli: `contributor(0) < editor(1) < admin(2)`. Adminide vahel on
+**horisontaalse privileegi-eskaleerimise auk**:
+
+1. Iga admin saab teise adminni alandada editoriks (`update_user_role` / `delete_user`
+   ei kontrolli sihtmärgi taset).
+2. Editoriks alandatud kasutaja parooli saab seejärel resettida (`admin_reset_password`
+   lubab `target_level < acting_level`).
+
+→ Iga admin saab kahe sammuga üle võtta teise adminni konto.
+
+Parooli-reset ise on JUBA kaitstud (`routers/admin.py:100-103`: `target_level >= acting_level`
+blokeerib), aga `update_user_role` ja `delete_user` **ei ole** — seal ongi auk.
+
+Lisaks on "superadmin" praegu **kõvakodeeritud häkk**: `auth.py:278` ja `:319` keelavad
+`username == "meelis"` rolli muutmise/kustutamise erikorras, ilma päris rollita.
+
+## Eesmärk
+
+Lisada neljas tasand `superadmin`, mis:
+- Annab ühele kasutajale (praegu Meelis) unikaalse autoriteedi hallata adminne.
+- Sulgeb eskaleerimise augu üldise invariandiga.
+- Koristab kõvakodeeritud `meelis`-erandid.
+- Viib kollektsioonide **struktuurse** halduse superadminni taha.
+
+## Mitte-eesmärgid (YAGNI)
+
+- **Ei** nihutata olemasolevaid rolle ümber (editor→contributor jne). See muudaks iga
+  `require_role(...)` värava semantikat kogu koodibaasis — suur plahvatusraadius. Lükatud
+  tagasi.
+- **Ei** tehta in-app "tõsta superadminniks" nuppu. Range invariant ei lubaks superadminnil
+  võrdset taset luua. Teine superadmin seemendatakse vajadusel serveris (`users.json`).
+- **Ei** muudeta süsteemi-konfiguratsiooni (taksonoomiad, sõnavarad) — see on niikuinii
+  serveri/koodi tasemel, ei puuduta kasutaja-õigusi.
+
+## Rollimudel
+
+```
+contributor(0) < editor(1) < admin(2) < superadmin(3)
+```
+
+Hierarhia on praegu defineeritud inline mitmes kohas (`auth.py:217` `require_token`,
+`auth.py:269` `valid_roles`, `routers/admin.py:100` `admin_reset_password`). **Tsentraliseeri**
+üheks tõeallikaks `auth.py`-s:
+
+```python
+ROLE_HIERARCHY = {"contributor": 0, "editor": 1, "admin": 2, "superadmin": 3}
+```
+
+Kõik kohad loevad sellest. `require_role` (`deps.py`) delegeerib `require_token`-ile, mis
+kasutab `ROLE_HIERARCHY`-t → automaatselt toetab `min_role="superadmin"`.
+
+## Autoriseerimise invariant (tuum)
+
+Üks jagatud helper `auth.py`-s:
+
+```python
+def can_manage(actor_role, target_current_role, new_role=None):
+    """Kas actor tohib hallata target-kasutajat (rolli muutus / kustutus / reset)?
+    Reegel 1 (sihtmärk): target praegune tase peab olema RANGELT madalam actor tasemest.
+    Reegel 2 (määramise lagi): kui new_role antud, peab see olema RANGELT madalam actor tasemest.
+    """
+    a = ROLE_HIERARCHY.get(actor_role, 0)
+    if ROLE_HIERARCHY.get(target_current_role, 0) >= a:
+        return False
+    if new_role is not None and ROLE_HIERARCHY.get(new_role, 0) >= a:
+        return False
+    return True
+```
+
+Tagajärjed:
+- Admin (2) saab hallata contributor/editor (0,1), määrata rolle kuni editor (1). **Ei saa**
+  kedagi adminniks tõsta ega adminni puutuda.
+- Superadmin (3) saab hallata adminne (2), määrata rolle kuni admin (2). **Ei saa** teist
+  superadminni luua (võrdne tase) — see on tahtlik, vt mitte-eesmärgid.
+- Keegi ei saa puutuda superadminni → kõvakodeeritud `meelis`-erandid muutuvad üleliigseks.
+
+### Rakenduskohad
+
+| Funktsioon | Praegu | Muudatus |
+|-----------|--------|----------|
+| `update_user_role` (`auth.py:256`) | ei kontrolli sihtmärki | lisa `can_manage(actor, target_current, new_role)` |
+| `delete_user` (`auth.py:303`) | ei kontrolli sihtmärki | lisa `can_manage(actor, target_current)` |
+| `admin_reset_password` (`routers/admin.py:84`) | inline `target_level >= acting_level` | asenda `can_manage(actor, target_current)` |
+| `auth.py:278` (`meelis` rolli-keeld) | kõvakood | **kustuta** (invariant katab) |
+| `auth.py:319` (`meelis` delete-keeld) | kõvakood | **kustuta** (invariant katab) |
+
+Säilib: `username == admin_user["username"]` keeld (ei saa muuta/kustutada iseennast) —
+see lukustumis-kaitse jääb mõlemasse funktsiooni.
+
+`update_user_role` `valid_roles` peab nüüd sisaldama `superadmin`-i (et seemendatud
+superadmin oleks valiidne väärtus), aga `can_manage` lagi takistab tavaadminnil seda määrata.
+
+## Seemendamine / migratsioon
+
+- Meelis → `superadmin`: **ühekordne `users.json` käsitsi-muudatus serveris**. Üks väli,
+  migratsiooniskripti pole vaja. (Roll tuleb niikuinii sealt.)
+- Tulevikus teine superadmin: sama seemendamine serveris.
+- Lukustumis-kaitse: superadmin ei saa iseennast alandada (olemasolev `username == self` keeld).
+
+## Kollektsioonid
+
+Eralda struktuur sisust:
+
+| Endpoint | Praegu | Muudatus |
+|----------|--------|----------|
+| `PUT /admin/collections/{id}` (`collections.py:92`) | `require_role("admin")` | `require_role("superadmin")` |
+| `POST /admin/collections` (`collections.py:196`) | `require_role("admin")` | `require_role("superadmin")` |
+| `DELETE /admin/collections/{id}` (`collections.py:298`) | `require_role("admin")` | `require_role("superadmin")` |
+| `POST /works/bulk-collection` (`editing.py:196`) | `require_role("admin")` | **jääb admin** (sisu-kureerimine) |
+| `GET /admin/collections/{id}/users` (`collections.py:176`) | `require_role("admin")` | jääb admin (luge-abi) |
+| `GET .../works-count` (`collections.py:288`) | `require_role("admin")` | jääb admin (luge-abi) |
+
+## Frontend (`src/pages/admin/Users.tsx`)
+
+Ehitatakse olemasoleva committimata WIP **peale** (kebab-menüü portal/fixed-positsioneerimine —
+rolliteemaga mitteseotud, ei klobestata).
+
+- Rolli-dropdown näitab ainult valikuid `level < minu_tase` (admin: contributor/editor;
+  superadmin: +admin). `superadmin` valikut dropdownis **ei ole** (ei saa määrata).
+- Rea tegevused (rolli muutus / kustuta / reset) **disabled**, kui
+  `target_level >= minu_tase`.
+- `superadmin` rolli-badge.
+- i18n: `et` + `en`, rolli-nimi ja badge.
+
+Kasutaja taseme võrdluseks on frontendil vaja sama hierarhiat — väike konstant
+(`ROLE_LEVELS`) frontendi pool, peegeldab backendi oma.
+
+## Testid
+
+`pytest` invariandi-maatriks (`can_manage`):
+- Iga `(actor_role × target_current_role × new_role)` lubatud/keelatud kombinatsioon.
+- Regressioon: admin **ei saa** adminni alandada ega kustutada (augu sulgemine).
+- Superadmin saab adminni hallata; ei saa superadminni puutuda.
+- Iseenda haldamise keeld säilib.
+
+## Plahvatusraadius
+
+Väike ja lokaalne:
+- `auth.py`: hierarhia tsentraliseerimine, `can_manage`, kahe kõvakood-erandi kustutus,
+  `update_user_role`/`delete_user` valvurid.
+- `routers/admin.py`: reset kasutab `can_manage`-i.
+- `routers/collections.py`: kolm väravat → `superadmin`.
+- `src/pages/admin/Users.tsx` + i18n: UI-piirangud.
+- Andmed: üks `users.json` väli serveris (käsitsi).

--- a/server/access_ops.py
+++ b/server/access_ops.py
@@ -1,4 +1,5 @@
 from .cache import get_cached_collections
+from .auth import is_at_least
 from typing import Optional
 
 
@@ -26,7 +27,7 @@ def can_read_work(work_metadata: dict, user: Optional[dict]) -> bool:
         return True
     if user is None:
         return False
-    if user.get("role") == "admin":
+    if is_at_least(user.get("role", "contributor"), "admin"):
         return True
     allowed = set(user.get("allowed_collections", []))
     work_collections = set(work_metadata.get("collections", []))

--- a/server/auth.py
+++ b/server/auth.py
@@ -45,6 +45,13 @@ def is_valid_role(role: str) -> bool:
     return role in ROLE_HIERARCHY
 
 
+def is_at_least(role: str, min_role: str) -> bool:
+    """Kas roll on vähemalt min_role tasemel? Taseme-põhine võimekuse-kontroll.
+    KASUTA seda täpse `role == "admin"` võrdluse asemel — superadmin loeb adminiks
+    (ja administ kõrgemaks), muidu kukub superadmin admin-funktsioonidest välja."""
+    return role_level(role) >= role_level(min_role)
+
+
 def can_manage_user(actor_role: str, target_role: str) -> bool:
     """Kas actor tohib target-kasutajat üldse puutuda (reset / kustutus / rollimuutus)?
     Sihtmärgi praegune tase peab olema RANGELT madalam actor tasemest."""

--- a/server/auth.py
+++ b/server/auth.py
@@ -7,10 +7,13 @@ import hashlib
 import uuid
 import threading
 import time
+import logging
 import bcrypt
 from datetime import datetime
 from .config import USERS_FILE, SESSION_DURATION
 from .utils import atomic_write_json
+
+logger = logging.getLogger(__name__)
 
 # Sessioonide hoidla (token -> user info)
 # NB: Serveri restart kustutab kõik sessioonid
@@ -19,6 +22,61 @@ _sessions_lock = threading.Lock()
 
 # Sessioonide puhastamise intervall (sekundites)
 SESSION_CLEANUP_INTERVAL = 300  # 5 minutit
+
+# =========================================================
+# ROLLIDE HIERARHIA — üks tõeallikas
+# =========================================================
+# contributor < editor < admin < superadmin. Eriõigus tuleb AINULT rollist,
+# mitte kasutajanimest.
+ROLE_HIERARCHY = {"contributor": 0, "editor": 1, "admin": 2, "superadmin": 3}
+
+
+def role_level(role: str) -> int:
+    """Tagastab rolli numbrilise taseme. Viskab ValueError tundmatu rolli peal.
+    EI KUNAGI vaikselt tasemeks 0 — tundmatu roll on viga, mitte madal õigus."""
+    try:
+        return ROLE_HIERARCHY[role]
+    except KeyError:
+        raise ValueError(f"Tundmatu roll: {role!r}")
+
+
+def is_valid_role(role: str) -> bool:
+    """Kas roll on hierarhias? Kasuta API-sisendi valideerimiseks enne role_level-i."""
+    return role in ROLE_HIERARCHY
+
+
+def can_manage_user(actor_role: str, target_role: str) -> bool:
+    """Kas actor tohib target-kasutajat üldse puutuda (reset / kustutus / rollimuutus)?
+    Sihtmärgi praegune tase peab olema RANGELT madalam actor tasemest."""
+    return role_level(target_role) < role_level(actor_role)
+
+
+def can_assign_role(actor_role: str, new_role: str) -> bool:
+    """Kas actor tohib MÄÄRATA rolli new_role? Lagi: rangelt madalam actor tasemest."""
+    return role_level(new_role) < role_level(actor_role)
+
+
+def can_change_role(actor_role: str, target_role: str, new_role: str) -> bool:
+    """Rollimuutus = tohib target-i puutuda JA tohib uut rolli määrata."""
+    return can_manage_user(actor_role, target_role) and can_assign_role(actor_role, new_role)
+
+
+def has_superadmin(users: dict) -> bool:
+    """Kas users-dictis on vähemalt üks superadmin? Startup-checki jaoks."""
+    return any(u.get("role") == "superadmin" for u in users.values())
+
+
+def warn_if_no_superadmin() -> bool:
+    """Logib WARNING-u, kui üheski kasutajas pole superadmin rolli.
+    Tagastab True, kui superadmin eksisteerib. Ei paranda automaatselt."""
+    users = load_users()
+    if has_superadmin(users):
+        return True
+    logger.warning(
+        "ÜHTEGI superadmin rolliga kasutajat pole — admini- ja kollektsioonihalduse "
+        "funktsioonid on lukus, kuni keegi seemendatakse superadminiks (users.json)."
+    )
+    return False
 
 
 def _cleanup_expired_sessions():
@@ -61,7 +119,7 @@ def _load_users_from_file():
     if not os.path.exists(USERS_FILE):
         print(f"HOIATUS: Kasutajate fail puudub: {USERS_FILE}")
         print("Loo users.json fail koos kasutajatega. Näide:")
-        print('  {"admin": {"password_hash": "<sha256>", "name": "Admin", "role": "admin"}}')
+        print('  {"admin": {"password_hash": "<sha256>", "name": "Admin", "role": "contributor"}}')
         print("Parooli hashi saad: echo -n 'parool' | sha256sum")
         return {}
 
@@ -137,7 +195,7 @@ def verify_user(username, password):
     return {
         "username": username,
         "name": users[username]["name"],
-        "role": users[username].get("role", "user"),
+        "role": users[username].get("role", "contributor"),
         "allowed_collections": users[username].get("allowed_collections", []),
     }
 
@@ -210,14 +268,9 @@ def require_token(data, min_role=None):
         user = session["user"]
 
     # Rollide hierarhia kontroll
-    # contributor = kaastööline (muudatused vajavad ülevaatust)
-    # editor = toimetaja (muudatused rakenduvad kohe, saab kinnitada)
-    # admin = administraator (kõik õigused)
     if min_role:
-        role_hierarchy = {'contributor': 0, 'editor': 1, 'admin': 2}
-        user_level = role_hierarchy.get(user['role'], 0)
-        required_level = role_hierarchy.get(min_role, 0)
-        if user_level < required_level:
+        # role_level viskab tundmatu rolli peal — fail-closed, mitte vaikne madal õigus
+        if role_level(user['role']) < role_level(min_role):
             return None, {"status": "error", "message": f"Vajab vähemalt '{min_role}' õigusi"}
 
     return user, None
@@ -259,31 +312,31 @@ def update_user_role(username, new_role, admin_user):
 
     Args:
         username: Muudetava kasutaja kasutajanimi
-        new_role: Uus roll ('contributor', 'editor', 'admin')
+        new_role: Uus roll ('contributor', 'editor', 'admin', 'superadmin')
         admin_user: Admin kasutaja, kes muudatuse teeb
 
     Returns:
         (success: bool, message: str)
     """
-    # Kontrolli rolli kehtivust
-    valid_roles = ['contributor', 'editor', 'admin']
-    if new_role not in valid_roles:
-        return False, f"Vigane roll. Lubatud: {', '.join(valid_roles)}"
+    # Valideeri sissetulev roll ENNE taseme-arvutust
+    if not is_valid_role(new_role):
+        return False, f"Vigane roll. Lubatud: {', '.join(ROLE_HIERARCHY.keys())}"
 
-    # Admin ei saa oma rolli muuta
+    # Admin ei saa oma rolli muuta (lukustumis-kaitse)
     if username == admin_user["username"]:
         return False, "Ei saa muuta enda rolli"
-
-    # Superadmini rolli ei saa muuta
-    if username == "meelis":
-        return False, "Selle kasutaja rolli ei saa muuta"
 
     users = load_users()
 
     if username not in users:
         return False, "Kasutajat ei leitud"
 
-    old_role = users[username].get("role", "contributor")
+    target_current = users[username].get("role", "contributor")
+    # Invariant: tohib target-i puutuda JA tohib uut rolli määrata
+    if not can_change_role(admin_user["role"], target_current, new_role):
+        return False, "Pole õigust seda kasutajat sellele rollile määrata"
+
+    old_role = target_current
     users[username]["role"] = new_role
     save_users(users)
 
@@ -311,20 +364,19 @@ def delete_user(username, admin_user):
     Returns:
         (success: bool, message: str)
     """
-    # Admin ei saa ennast kustutada
+    # Admin ei saa ennast kustutada (lukustumis-kaitse)
     if username == admin_user["username"]:
         return False, "Ei saa kustutada ennast"
-
-    # Superadmini ei saa kustutada
-    if username == "meelis":
-        return False, "Seda kasutajat ei saa kustutada"
 
     users = load_users()
 
     if username not in users:
         return False, "Kasutajat ei leitud"
 
-    # Eemalda kasutaja
+    # Invariant: tohib kustutada ainult rangelt madalamat taset
+    if not can_manage_user(admin_user["role"], users[username].get("role", "contributor")):
+        return False, "Pole õigust seda kasutajat kustutada"
+
     deleted_name = users[username].get("name", username)
     del users[username]
     save_users(users)

--- a/server/main.py
+++ b/server/main.py
@@ -39,6 +39,8 @@ async def lifespan(app: FastAPI):
         raise SystemExit(1)
     build_work_id_cache()
     run_git_fsck()
+    from .auth import warn_if_no_superadmin
+    warn_if_no_superadmin()
     threading.Thread(target=rebuild_indices, daemon=True).start()
     threading.Thread(target=metadata_watcher_loop, daemon=True).start()
     threading.Thread(target=_keepwarm_loop, daemon=True).start()

--- a/server/meilisearch_ops.py
+++ b/server/meilisearch_ops.py
@@ -493,7 +493,8 @@ def generate_meili_token(user=None, ttl_seconds: int = 3600) -> str:
 
     base_filter = "is_public = true"
 
-    if user and user.get("role") == "admin":
+    from .auth import is_at_least  # lokaalne: väldib import-järjekorra üllatusi suures moodulis
+    if user and is_at_least(user.get("role", "contributor"), "admin"):
         search_rules = {"teosed": {}}
     else:
         allowed = (user or {}).get("allowed_collections", [])

--- a/server/routers/admin.py
+++ b/server/routers/admin.py
@@ -5,7 +5,7 @@ import threading
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
-from ..auth import delete_user, get_all_users, update_user_role
+from ..auth import can_manage_user, delete_user, get_all_users, update_user_role
 from ..config import BASE_DIR
 from ..deps import get_json_data, require_role
 from ..git_ops import clear_git_failures, delete_work_from_git, get_git_failures, run_git_fsck
@@ -97,10 +97,7 @@ async def admin_reset_password(request: Request, user=Depends(require_role("admi
     if target not in users:
         raise HTTPException(status_code=404, detail="Kasutajat ei leitud")
 
-    role_hierarchy = {"contributor": 0, "editor": 1, "admin": 2}
-    acting_level = role_hierarchy.get(user.get("role", "contributor"), 0)
-    target_level = role_hierarchy.get(users[target].get("role", "contributor"), 0)
-    if target != user["username"] and target_level >= acting_level:
+    if target != user["username"] and not can_manage_user(user["role"], users[target].get("role", "contributor")):
         raise HTTPException(status_code=403, detail="Ei saa lähtestada võrdse või kõrgema õigusega kasutajat")
 
     token_data, error = create_reset_token(target, user["username"])

--- a/server/routers/collections.py
+++ b/server/routers/collections.py
@@ -90,7 +90,7 @@ async def delete_archive(archive_id: str, force: bool = False, user=Depends(requ
     return {"status": "success"}
 
 @router.put("/admin/collections/{collection_id}")
-async def admin_update_collection(collection_id: str, request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("admin"))):
+async def admin_update_collection(collection_id: str, request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("superadmin"))):
     """Uuendab kollektsiooni description, description_long, color ja visibility välju."""
     body = await request.json()
     description = body.get("description")      # { et, en }
@@ -194,7 +194,7 @@ async def admin_collection_users(collection_id: str, user=Depends(require_role("
     }
 
 @router.post("/admin/collections")
-async def admin_create_collection(request: Request, user=Depends(require_role("admin"))):
+async def admin_create_collection(request: Request, user=Depends(require_role("superadmin"))):
     """Loob uue kollektsiooni. Body: {id, name_et, name_en, parent?, color?, is_virtual?}"""
     body = await request.json()
     collection_id = body.get("id", "").strip()
@@ -296,7 +296,7 @@ def admin_collection_works_count(collection_id: str, user=Depends(require_role("
     return {"status": "success", "count": count}
 
 @router.delete("/admin/collections/{collection_id}")
-async def admin_delete_collection(collection_id: str, background_tasks: BackgroundTasks, user=Depends(require_role("admin"))):
+async def admin_delete_collection(collection_id: str, background_tasks: BackgroundTasks, user=Depends(require_role("superadmin"))):
     """Kustutab kollektsiooni ja eemaldab selle ID kõigi teoste metaandmetest. Keeldub kui on alamkollektsioone."""
     if not os.path.exists(COLLECTIONS_FILE):
         return {"status": "error", "message": "collections.json ei leitud"}

--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from starlette.concurrency import run_in_threadpool
 
 from ..access_ops import can_write_work
+from ..auth import is_at_least
 from ..cache import get_cached_suggestions
 from ..cache_invalidation import invalidate_all_caches as _invalidate_all_caches
 from ..config import BASE_DIR
@@ -130,9 +131,9 @@ async def metadata_suggestions(request: Request, user=Depends(require_role("edit
 
 @router.get("/recent-edits")
 async def recent_edits(request: Request, user=Depends(get_user)):
-    f_user = request.query_params.get('user') if user['role'] == 'admin' else user['username']
+    f_user = request.query_params.get('user') if is_at_least(user['role'], 'admin') else user['username']
     res = get_recent_commits(username=f_user, limit=int(request.query_params.get('limit', 30)), skip=int(request.query_params.get('offset', 0)))
-    return {"status": "success", "commits": res["commits"], "has_more": res["has_more"], "is_admin": user['role'] == 'admin'}
+    return {"status": "success", "commits": res["commits"], "has_more": res["has_more"], "is_admin": is_at_least(user['role'], 'admin')}
 
 @router.post("/git-history")
 async def git_history(request: Request, user=Depends(require_role("editor"))):

--- a/server/routers/notifications.py
+++ b/server/routers/notifications.py
@@ -26,7 +26,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Depends
 
 from ..config import BASE_DIR
 from ..deps import get_user, require_role, get_json_data
-from ..auth import get_all_users
+from ..auth import get_all_users, role_level
 from ..git_ops import save_with_git
 from ..meilisearch_ops import sync_work_to_meilisearch_async
 from ..notifications_ops import (
@@ -155,10 +155,7 @@ async def get_notification_recipients(user=Depends(require_role("editor"))):
         for account in get_all_users()
         if account.get("username")
     ]
-    users.sort(key=lambda account: (
-        0 if account.get("username") == "meelis" else 1,
-        (account.get("name") or account.get("username") or "").lower(),
-    ))
+    users.sort(key=lambda account: (account.get("name") or account.get("username") or "").lower())
     return {"status": "success", "users": users}
 
 
@@ -198,7 +195,7 @@ async def send_notification(request: Request, user=Depends(require_role("editor"
     }
 
     if recipient_mode == "all":
-        if user.get("role") != "admin":
+        if role_level(user.get("role", "contributor")) < role_level("admin"):
             raise HTTPException(status_code=403, detail="Kõigile teavitamine on lubatud ainult administraatorile")
         recipients = sorted(users_by_username.keys())
         notification_type = "system"
@@ -206,7 +203,7 @@ async def send_notification(request: Request, user=Depends(require_role("editor"
         recipients = sorted([
             account.get("username")
             for account in get_all_users()
-            if account.get("role") == "admin" and account.get("username")
+            if role_level(account.get("role", "contributor")) >= role_level("admin") and account.get("username")
         ])
         notification_type = "review_request"
     elif recipient_mode == "multiple":

--- a/src/components/CollectionPicker.tsx
+++ b/src/components/CollectionPicker.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { isAtLeast } from '../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { Library, ChevronRight, ChevronDown, X, Check, FolderOpen } from 'lucide-react';
 import { useCollection } from '../contexts/CollectionContext';
@@ -103,7 +104,7 @@ const CollectionPicker: React.FC<CollectionPickerProps> = ({
 
   // Filtreeri kollektsioonid kasutaja ligipääsu järgi
   const visibleCollections = useMemo(() => {
-    if (user?.role === 'admin') return collections;
+    if (isAtLeast(user?.role, 'admin')) return collections;
     const allowed = new Set(user?.allowed_collections ?? []);
     return Object.fromEntries(
       Object.entries(collections).filter(([id, col]) =>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { isAtLeast } from '../utils/roleUtils';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Settings, History, Shield, LogOut, ChevronDown, Bell } from 'lucide-react';
@@ -44,7 +45,7 @@ const UserMenu: React.FC = () => {
   }, [user, authToken, refreshTick]);
 
   useEffect(() => {
-    if (!user || user.role !== 'admin' || !authToken) {
+    if (!user || !isAtLeast(user.role, 'admin') || !authToken) {
       setPendingRegistrationCount(0);
       return;
     }
@@ -137,7 +138,7 @@ const UserMenu: React.FC = () => {
               {t('common:nav.settings')}
             </Link>
 
-            {user.role !== 'admin' && (
+            {!isAtLeast(user.role, 'admin') && (
               <Link
                 to="/review"
                 onClick={() => setShowMenu(false)}
@@ -148,7 +149,7 @@ const UserMenu: React.FC = () => {
               </Link>
             )}
 
-            {user.role === 'admin' && (
+            {isAtLeast(user.role, 'admin') && (
               <Link
                 to="/admin"
                 onClick={() => setShowMenu(false)}

--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useLocation } from 'react-router-dom';
 import { BookOpen, User, ExternalLink, Download, Edit3, Tag, Search, X, MessageSquare, Trash2, FolderOpen, Bookmark, Check, BookDown, IdCard, SquarePen, FileSliders, Reply, Send, StickyNote } from 'lucide-react';
@@ -75,7 +76,7 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   const [savingReplyId, setSavingReplyId] = useState<string | null>(null);
   const highlightedCommentId = new URLSearchParams(location.search).get('comment');
 
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = isAtLeast(user?.role, 'admin');
   
   // Arhiivide register (nimed kuvamiseks)
   const [archives, setArchives] = useState<Record<string, { name: string; url?: string }>>({});

--- a/src/components/editor/HistoryTab.tsx
+++ b/src/components/editor/HistoryTab.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -347,7 +348,7 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
     }
   };
 
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = isAtLeast(user?.role, 'admin');
   const canLoad = Date.now() - lastLoadTime >= RATE_LIMIT_MS;
 
   const [slugCopied, setSlugCopied] = useState(false);
@@ -573,7 +574,7 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
       )}
 
       {/* Jagamine — editor ja admin */}
-      {(user?.role === 'editor' || user?.role === 'admin') && work && hasRestrictedCollection && (
+      {(isAtLeast(user?.role, 'editor')) && work && hasRestrictedCollection && (
         <div className="mt-6 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
           <div className="flex items-center gap-2 px-5 py-3 border-b border-gray-100">
             <Link size={15} className="text-gray-400" />

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -51,7 +51,8 @@
     "resetLinkHint": "Copy the link and send it to the user. The link is valid for 24 hours.",
     "copyLink": "Copy link",
     "linkCopied": "Copied!",
-    "resetError": "Failed to create password reset link"
+    "resetError": "Failed to create password reset link",
+    "noPermissionManage": "You don't have permission to manage a user of equal or higher level"
   },
   "pending": {
     "title": "Pending Edits",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -43,7 +43,8 @@
   "roles": {
     "admin": "Administrator",
     "editor": "Editor",
-    "contributor": "Contributor"
+    "contributor": "Contributor",
+    "superadmin": "Superadministrator"
   },
   "labels": {
     "page": "Page",

--- a/src/locales/et/admin.json
+++ b/src/locales/et/admin.json
@@ -51,7 +51,8 @@
     "resetLinkHint": "Kopeeri link ja saada kasutajale. Link kehtib 24 tundi.",
     "copyLink": "Kopeeri link",
     "linkCopied": "Kopeeritud!",
-    "resetError": "Parooli-taastamise lingi loomine ebaõnnestus"
+    "resetError": "Parooli-taastamise lingi loomine ebaõnnestus",
+    "noPermissionManage": "Sul ei ole õigust hallata sama või kõrgema taseme kasutajat"
   },
   "pending": {
     "title": "Ootel muudatused",

--- a/src/locales/et/common.json
+++ b/src/locales/et/common.json
@@ -43,7 +43,8 @@
   "roles": {
     "admin": "Administraator",
     "editor": "Toimetaja",
-    "contributor": "Kaastööline"
+    "contributor": "Kaastööline",
+    "superadmin": "Superadministraator"
   },
   "labels": {
     "page": "Lk",

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { isAtLeast } from '../utils/roleUtils';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { UserPlus, Users, Upload, Library, History, Trash2, Wrench, MapPin } from 'lucide-react';
@@ -26,7 +27,7 @@ const Admin: React.FC = () => {
   const [uploadCount, setUploadCount] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!user || user.role !== 'admin') {
+    if (!user || !isAtLeast(user.role, 'admin')) {
       navigate('/');
       return;
     }
@@ -56,7 +57,7 @@ const Admin: React.FC = () => {
       .catch(() => {});
   }, [authToken]);
 
-  if (!user || user.role !== 'admin') return null;
+  if (!user || !isAtLeast(user.role, 'admin')) return null;
 
   const cards: AdminCard[] = [
     {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { isAtLeast } from '../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { searchWorks, FacetDistribution } from '../services/searchService';
 import { isQCode } from '../utils/qcodeUtils';
@@ -90,7 +91,7 @@ const Dashboard: React.FC = () => {
   const [refreshCounter, setRefreshCounter] = useState(0);  // Triggers re-fetch
   const [showLoginModal, setShowLoginModal] = useState(false);
 
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = isAtLeast(user?.role, 'admin');
 
   // Kas valitud kollektsioon on kaitstud — tühja tulemuse korral on põhjus
   // tõenäoliselt ligipääsupuudus (mitte andmete/filtrite probleem).

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { isAtLeast } from '../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { Link, Navigate, useNavigate } from 'react-router-dom';
 import { Bell, Check, ChevronLeft, Loader2, Reply, Send } from 'lucide-react';
@@ -111,8 +112,8 @@ const Notifications: React.FC = () => {
   const [replyingTo, setReplyingTo] = useState<UserNotification | null>(null);
   const [sending, setSending] = useState(false);
 
-  const canSend = user?.role === 'editor' || user?.role === 'admin';
-  const canSendAll = user?.role === 'admin';
+  const canSend = isAtLeast(user?.role, 'editor');
+  const canSendAll = isAtLeast(user?.role, 'admin');
   const unreadCount = useMemo(() => notifications.filter(item => !isSentNotification(item) && !item.read_at).length, [notifications]);
   const filteredRecipients = useMemo(() => {
     const query = recipientFilter.trim().toLowerCase();

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { isAtLeast } from '../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { parseFocusParam, buildBackToEditorPath } from '../utils/manageDeeplink';
@@ -124,7 +125,7 @@ const WorkManage: React.FC = () => {
   const MAX_COLS = 10;
   const [gridCols, setGridCols] = useState(5);
 
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = isAtLeast(user?.role, 'admin');
 
   useEffect(() => {
     if (user && !isAdmin) {

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
+import { isAtLeast } from '../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 import { MeiliSearch } from 'meilisearch';
@@ -28,7 +29,7 @@ import { buildManageLink } from '../utils/manageDeeplink';
 const Workspace: React.FC = () => {
   const { t } = useTranslation(['workspace', 'common', 'auth']);
   const { user, authToken, logout, sessionExpired, clearSessionExpired } = useUser();
-  const isAdmin = user?.role === 'admin';
+  const isAdmin = isAtLeast(user?.role, 'admin');
   const { collections, selectedCollection, setSelectedCollection } = useCollection();
   const index = useMeiliIndex();
   const [viewerToken, setViewerToken] = useState<string | null>(null);
@@ -641,7 +642,7 @@ const Workspace: React.FC = () => {
             work={work}
             onSave={handleSave}
             onUnsavedChanges={setEditorChanges}
-            onOpenMetaModal={user?.role === 'admin' ? openMetaModal : undefined}
+            onOpenMetaModal={isAtLeast(user?.role, 'admin') ? openMetaModal : undefined}
             readOnly={!user}
             statusDirty={statusDirty}
             currentStatus={currentStatus}

--- a/src/pages/admin/Collections.tsx
+++ b/src/pages/admin/Collections.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Loader2, ChevronLeft } from 'lucide-react';
@@ -12,7 +13,7 @@ const Collections: React.FC = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!userLoading && (!user || user.role !== 'admin')) {
+    if (!userLoading && (!user || !isAtLeast(user.role, 'admin'))) {
       navigate('/');
     }
   }, [user, userLoading, navigate]);
@@ -25,7 +26,7 @@ const Collections: React.FC = () => {
     );
   }
 
-  if (user.role !== 'admin') return null;
+  if (!isAtLeast(user.role, 'admin')) return null;
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/pages/admin/Maintenance.tsx
+++ b/src/pages/admin/Maintenance.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { RefreshCw, ChevronLeft, Wrench, Pencil, Trash2 } from 'lucide-react';
@@ -38,7 +39,7 @@ const Maintenance: React.FC = () => {
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
   React.useEffect(() => {
-    if (!userLoading && (!user || user.role !== 'admin')) {
+    if (!userLoading && (!user || !isAtLeast(user.role, 'admin'))) {
       navigate('/');
     }
   }, [user, userLoading, navigate]);
@@ -170,7 +171,7 @@ const Maintenance: React.FC = () => {
   };
 
   if (userLoading || !user) return null;
-  if (user.role !== 'admin') return null;
+  if (!isAtLeast(user.role, 'admin')) return null;
 
   const actions = [
     {

--- a/src/pages/admin/Places.tsx
+++ b/src/pages/admin/Places.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, Loader2, Search, Plus, Settings, X } from 'lucide-react';
@@ -45,7 +46,7 @@ const Places: React.FC = () => {
   >({});
 
   useEffect(() => {
-    if (!userLoading && (!user || user.role !== 'admin')) navigate('/');
+    if (!userLoading && (!user || !isAtLeast(user.role, 'admin'))) navigate('/');
   }, [user, userLoading, navigate]);
 
   useEffect(() => {
@@ -143,7 +144,7 @@ const Places: React.FC = () => {
     );
   }
 
-  if (user.role !== 'admin') return null;
+  if (!isAtLeast(user.role, 'admin')) return null;
 
   const selectedEntry = selectedKey ? places[selectedKey] : null;
 

--- a/src/pages/admin/Registrations.tsx
+++ b/src/pages/admin/Registrations.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -64,13 +65,13 @@ const Registrations: React.FC = () => {
   const [processingId, setProcessingId] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!userLoading && (!user || user.role !== 'admin')) {
+    if (!userLoading && (!user || !isAtLeast(user.role, 'admin'))) {
       navigate('/');
     }
   }, [user, userLoading, navigate]);
 
   useEffect(() => {
-    if (authToken && user?.role === 'admin') {
+    if (authToken && isAtLeast(user?.role, 'admin')) {
       loadRegistrations();
     }
   }, [authToken, user]);
@@ -176,7 +177,7 @@ const Registrations: React.FC = () => {
     );
   }
 
-  if (user.role !== 'admin') return null;
+  if (!isAtLeast(user.role, 'admin')) return null;
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/pages/admin/Trash.tsx
+++ b/src/pages/admin/Trash.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -37,13 +38,13 @@ const Trash: React.FC = () => {
   const [isRestoreError, setIsRestoreError] = useState(false);
 
   useEffect(() => {
-    if (!userLoading && (!user || user.role !== 'admin')) {
+    if (!userLoading && (!user || !isAtLeast(user.role, 'admin'))) {
       navigate('/');
     }
   }, [user, userLoading, navigate]);
 
   useEffect(() => {
-    if (authToken && user?.role === 'admin' && !trashLoaded) {
+    if (authToken && isAtLeast(user?.role, 'admin') && !trashLoaded) {
       loadTrash();
     }
   }, [authToken, user]);
@@ -110,7 +111,7 @@ const Trash: React.FC = () => {
     );
   }
 
-  if (user.role !== 'admin') return null;
+  if (!isAtLeast(user.role, 'admin')) return null;
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -15,12 +16,13 @@ import {
 import Header from '../../components/Header';
 import { useUser } from '../../contexts/UserContext';
 import { apiPost } from '../../services/apiClient';
+import { ROLE_LEVELS, canManageUser, assignableRoles, roleLevel } from '../../utils/roleUtils';
 
 interface User {
   username: string;
   name: string;
   email: string;
-  role: 'contributor' | 'editor' | 'admin';
+  role: 'contributor' | 'editor' | 'admin' | 'superadmin';
   created_at: string | null;
   allowed_collections?: string[];
 }
@@ -30,8 +32,6 @@ interface UsersResponse {
   users?: User[];
   message?: string;
 }
-
-const ROLE_LEVEL: Record<string, number> = { contributor: 0, editor: 1, admin: 2 };
 
 const UsersPage: React.FC = () => {
   const { t } = useTranslation(['admin', 'common']);
@@ -44,17 +44,20 @@ const UsersPage: React.FC = () => {
   const [roleUpdating, setRoleUpdating] = useState<string | null>(null);
   const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
   const [openMenu, setOpenMenu] = useState<string | null>(null);
+  // Ankru-ristkülik portaliga renderdatud menüü/kinnituse positsioneerimiseks.
+  // Vajalik, sest tabeli ümbris on overflow-x-auto, mis lõikaks absolute-menüü "nurga taha".
+  const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
   const [resetResult, setResetResult] = useState<{ username: string; name: string; reset_url: string } | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
 
   useEffect(() => {
-    if (!userLoading && (!user || user.role !== 'admin')) {
+    if (!userLoading && (!user || roleLevel(user.role) < ROLE_LEVELS.admin)) {
       navigate('/');
     }
   }, [user, userLoading, navigate]);
 
   useEffect(() => {
-    if (authToken && user?.role === 'admin') {
+    if (authToken && user && roleLevel(user.role) >= ROLE_LEVELS.admin) {
       loadUsers();
     }
   }, [authToken, user]);
@@ -159,13 +162,33 @@ const UsersPage: React.FC = () => {
     }
   };
 
-  // Sulge kebab-menüü klõpsul mujale
+  // Sulge kebab-menüü klõpsul mujale või kerimisel (fixed-positsioon triiviks muidu ankrust eemale)
   useEffect(() => {
-    if (!openMenu) return;
-    const close = () => setOpenMenu(null);
+    if (!openMenu && !deleteConfirm) return;
+    const close = () => { setOpenMenu(null); setDeleteConfirm(null); };
     document.addEventListener('click', close);
-    return () => document.removeEventListener('click', close);
-  }, [openMenu]);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('click', close);
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [openMenu, deleteConfirm]);
+
+  // Arvuta fixed-positsioon ankru järgi: joondu nupu paremasse serva, keera üles kui aken on all otsas
+  const popoverStyle = (width: number, estHeight: number): React.CSSProperties => {
+    const margin = 8;
+    const rect = anchorRect;
+    if (!rect) return { display: 'none' };
+    let left = rect.right - width;
+    if (left < margin) left = margin;
+    let top = rect.bottom + 4;
+    if (top + estHeight > window.innerHeight - margin) {
+      top = Math.max(margin, rect.top - estHeight - 4);
+    }
+    return { position: 'fixed', top, left, width };
+  };
 
   const formatDate = (isoString: string) => {
     return new Date(isoString).toLocaleDateString('et-EE', {
@@ -185,7 +208,7 @@ const UsersPage: React.FC = () => {
     );
   }
 
-  if (user.role !== 'admin') return null;
+  if (roleLevel(user.role) < ROLE_LEVELS.admin) return null;
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -252,136 +275,161 @@ const UsersPage: React.FC = () => {
               {t('users.empty')}
             </div>
           ) : (
-            <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
-              <table className="w-full min-w-[640px]">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">{t('users.name')}</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">{t('users.username')}</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">{t('users.email')}</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">{t('users.role')}</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">{t('users.created')}</th>
-                    <th className="px-4 py-3 text-left text-sm font-medium text-gray-600">Piiratud kogud</th>
-                    <th className="px-4 py-3 text-right text-sm font-medium text-gray-600">{t('users.actions')}</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {users.map((u) => {
-                    const isCurrentUser = u.username === user?.username;
-                    const isProcessing = roleUpdating === u.username;
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+              {users.map((u) => {
+                const isCurrentUser = u.username === user?.username;
+                const isProcessing = roleUpdating === u.username;
+                const canReset = isCurrentUser || canManageUser(user.role, u.role);
+                const canManage = canManageUser(user.role, u.role);
+                const canDelete = !isCurrentUser && canManage;
 
-                    return (
-                      <tr key={u.username} className={`hover:bg-gray-50 ${isCurrentUser ? 'bg-primary-50' : ''}`}>
-                        <td className="px-4 py-3 text-sm text-gray-900">
-                          <div className="flex items-center gap-2">
-                            {u.name}
-                            {isCurrentUser && (
-                              <span className="text-xs bg-primary-100 text-primary-700 px-1.5 py-0.5 rounded">
-                                {t('users.you')}
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-sm text-gray-600 font-mono">{u.username}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600">{u.email || '-'}</td>
-                        <td className="px-4 py-3 text-sm">
-                          {isCurrentUser ? (
-                            <span className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs">
-                              {t(`common:roles.${u.role}`)}
+                return (
+                  <div
+                    key={u.username}
+                    className={`relative flex flex-col rounded-lg border p-4 transition-colors ${
+                      isCurrentUser ? 'border-primary-300 bg-primary-50' : 'border-gray-200 bg-white hover:border-gray-300'
+                    }`}
+                  >
+                    {/* Identiteet: nimi + kasutajanimi + e-post; tegevuste kebab paremas ülanurgas */}
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-gray-900 truncate">{u.name}</span>
+                          {isCurrentUser && (
+                            <span className="flex-shrink-0 text-xs bg-primary-100 text-primary-700 px-1.5 py-0.5 rounded">
+                              {t('users.you')}
                             </span>
-                          ) : (
-                            <select
-                              value={u.role}
-                              onChange={(e) => handleRoleChange(u.username, e.target.value)}
-                              disabled={isProcessing}
-                              className="text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
-                            >
-                              <option value="contributor">{t('common:roles.contributor')}</option>
-                              <option value="editor">{t('common:roles.editor')}</option>
-                              <option value="admin">{t('common:roles.admin')}</option>
-                            </select>
                           )}
-                        </td>
-                        <td className="px-4 py-3 text-sm text-gray-600">
-                          {u.created_at ? formatDate(u.created_at) : '-'}
-                        </td>
-                        <td className="px-4 py-3 text-xs text-gray-400">
-                          {u.allowed_collections && u.allowed_collections.length > 0
-                            ? u.allowed_collections.join(', ')
-                            : '—'}
-                        </td>
-                        <td className="px-4 py-3 text-sm text-right relative">
-                          {(() => {
-                            const canReset = isCurrentUser || (ROLE_LEVEL[u.role] ?? 0) < (ROLE_LEVEL[user.role] ?? 0);
-                            const canDelete = !isCurrentUser;
-                            if (!canReset && !canDelete) return <span className="text-gray-400">-</span>;
-                            return (
-                              <div className="inline-block" onClick={(e) => e.stopPropagation()}>
+                        </div>
+                        <div className="mt-0.5 font-mono text-xs text-gray-500 truncate">{u.username}</div>
+                        <div className="text-sm text-gray-600 truncate">{u.email || '-'}</div>
+                      </div>
+
+                      {(canReset || canDelete) && (
+                        <div className="flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                          <button
+                            onClick={(e) => {
+                              setDeleteConfirm(null);
+                              if (openMenu === u.username) {
+                                setOpenMenu(null);
+                              } else {
+                                setAnchorRect(e.currentTarget.getBoundingClientRect());
+                                setOpenMenu(u.username);
+                              }
+                            }}
+                            disabled={isProcessing}
+                            className="p-1 text-gray-500 hover:bg-gray-100 rounded disabled:opacity-50"
+                            aria-haspopup="menu"
+                            aria-expanded={openMenu === u.username}
+                            title={t('users.actionsMenu')}
+                          >
+                            {isProcessing ? <Loader2 size={16} className="animate-spin" /> : <MoreVertical size={16} />}
+                          </button>
+                          {openMenu === u.username && createPortal(
+                            <div
+                              role="menu"
+                              style={popoverStyle(176, 96)}
+                              className="z-50 w-44 bg-white border border-gray-200 rounded-lg shadow-lg py-1 text-left"
+                              onClick={(e) => e.stopPropagation()}
+                              onKeyDown={(e) => { if (e.key === 'Escape') setOpenMenu(null); }}
+                            >
+                              {canReset && (
                                 <button
-                                  onClick={() => setOpenMenu(openMenu === u.username ? null : u.username)}
-                                  disabled={isProcessing}
-                                  className="p-1 text-gray-500 hover:bg-gray-100 rounded disabled:opacity-50"
-                                  aria-haspopup="menu"
-                                  aria-expanded={openMenu === u.username}
-                                  title={t('users.actionsMenu')}
+                                  role="menuitem"
+                                  onClick={() => handleResetPassword(u.username)}
+                                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
                                 >
-                                  {isProcessing ? <Loader2 size={16} className="animate-spin" /> : <MoreVertical size={16} />}
+                                  <KeyRound size={15} /> {t('users.resetPassword')}
                                 </button>
-                                {openMenu === u.username && (
-                                  <div
-                                    role="menu"
-                                    className="absolute right-4 z-10 mt-1 w-44 bg-white border border-gray-200 rounded-lg shadow-lg py-1 text-left"
-                                    onKeyDown={(e) => { if (e.key === 'Escape') setOpenMenu(null); }}
-                                  >
-                                    {canReset && (
-                                      <button
-                                        role="menuitem"
-                                        onClick={() => handleResetPassword(u.username)}
-                                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
-                                      >
-                                        <KeyRound size={15} /> {t('users.resetPassword')}
-                                      </button>
-                                    )}
-                                    {canDelete && (
-                                      <button
-                                        role="menuitem"
-                                        onClick={() => { setOpenMenu(null); setDeleteConfirm(u.username); }}
-                                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
-                                      >
-                                        <Trash2 size={15} /> {t('users.delete')}
-                                      </button>
-                                    )}
-                                  </div>
-                                )}
-                                {deleteConfirm === u.username && (
-                                  <div className="absolute right-4 z-10 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg p-3 text-left w-56">
-                                    <p className="text-xs text-red-600 mb-2">{t('users.confirmDelete')}</p>
-                                    <div className="flex gap-2">
-                                      <button
-                                        onClick={() => handleDeleteUser(u.username)}
-                                        disabled={isProcessing}
-                                        className="px-2 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700 disabled:opacity-50"
-                                      >
-                                        {isProcessing ? <Loader2 size={12} className="animate-spin" /> : t('users.yes')}
-                                      </button>
-                                      <button
-                                        onClick={() => setDeleteConfirm(null)}
-                                        className="px-2 py-1 bg-gray-300 text-gray-700 rounded text-xs hover:bg-gray-400"
-                                      >
-                                        {t('users.no')}
-                                      </button>
-                                    </div>
-                                  </div>
-                                )}
+                              )}
+                              {canDelete && (
+                                <button
+                                  role="menuitem"
+                                  onClick={() => { setOpenMenu(null); setDeleteConfirm(u.username); }}
+                                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+                                >
+                                  <Trash2 size={15} /> {t('users.delete')}
+                                </button>
+                              )}
+                            </div>,
+                            document.body
+                          )}
+                          {deleteConfirm === u.username && createPortal(
+                            <div
+                              style={popoverStyle(224, 96)}
+                              className="z-50 w-56 bg-white border border-gray-200 rounded-lg shadow-lg p-3 text-left"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <p className="text-xs text-red-600 mb-2">{t('users.confirmDelete')}</p>
+                              <div className="flex gap-2">
+                                <button
+                                  onClick={() => handleDeleteUser(u.username)}
+                                  disabled={isProcessing}
+                                  className="px-2 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700 disabled:opacity-50"
+                                >
+                                  {isProcessing ? <Loader2 size={12} className="animate-spin" /> : t('users.yes')}
+                                </button>
+                                <button
+                                  onClick={() => setDeleteConfirm(null)}
+                                  className="px-2 py-1 bg-gray-300 text-gray-700 rounded text-xs hover:bg-gray-400"
+                                >
+                                  {t('users.no')}
+                                </button>
                               </div>
-                            );
-                          })()}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
+                            </div>,
+                            document.body
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Tähtsad väljad: roll + piiratud kogud */}
+                    <div className="mt-3 space-y-2 border-t border-gray-100 pt-3">
+                      <div className="flex items-center gap-2">
+                        <span className="w-24 flex-shrink-0 text-xs font-medium text-gray-500">{t('users.role')}</span>
+                        {isCurrentUser || !canManage ? (
+                          <span
+                            className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 text-gray-600 rounded text-xs"
+                            title={!isCurrentUser && !canManage ? t('users.noPermissionManage') : undefined}
+                          >
+                            {t(`common:roles.${u.role}`)}
+                          </span>
+                        ) : (
+                          <select
+                            value={u.role}
+                            onChange={(e) => handleRoleChange(u.username, e.target.value)}
+                            disabled={isProcessing}
+                            className="text-sm border border-gray-300 rounded px-2 py-1 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
+                          >
+                            {assignableRoles(user.role).map((r) => (
+                              <option key={r} value={r}>{t(`common:roles.${r}`)}</option>
+                            ))}
+                          </select>
+                        )}
+                      </div>
+                      <div className="flex items-start gap-2">
+                        <span className="w-24 flex-shrink-0 text-xs font-medium text-gray-500 mt-1">Piiratud kogud</span>
+                        {u.allowed_collections && u.allowed_collections.length > 0 ? (
+                          <div className="flex flex-wrap gap-1">
+                            {u.allowed_collections.map((c) => (
+                              <span key={c} className="text-xs bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded">
+                                {c}
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-sm text-gray-400 mt-0.5">—</span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Vähemoluline: loodud-kuupäev */}
+                    <div className="mt-3 text-xs text-gray-400">
+                      {t('users.created')}: {u.created_at ? formatDate(u.created_at) : '-'}
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           )}
         </section>

--- a/src/pages/upload/UploadPage.tsx
+++ b/src/pages/upload/UploadPage.tsx
@@ -5,6 +5,7 @@
  * see fail ainult renderdab sammud ja pooleliolevate nimekirja.
  */
 import React, { useEffect } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 import {
@@ -46,7 +47,7 @@ const UploadPage: React.FC = () => {
   // ---------------------------------------------------------------------------
   useEffect(() => {
     if (authLoading) return;
-    if (!user || user.role !== 'admin') navigate('/');
+    if (!user || !isAtLeast(user.role, 'admin')) navigate('/');
   }, [user, navigate, authLoading]);
 
   // Kollektsioonide loend (sortimine nime järgi)

--- a/src/prosopography/pages/PersonDetailPage.tsx
+++ b/src/prosopography/pages/PersonDetailPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import MarkdownView from '../../components/MarkdownView';
@@ -245,8 +246,8 @@ const PersonDetailPage: React.FC = () => {
   const [tagsSaving, setTagsSaving] = useState(false);
 
   const token = authToken ?? '';
-  const canEdit = user && (user.role === 'editor' || user.role === 'admin');
-  const isAdmin = user?.role === 'admin';
+  const canEdit = isAtLeast(user?.role, 'editor');
+  const isAdmin = isAtLeast(user?.role, 'admin');
 
   const [history, setHistory] = useState<{ hash: string; full_hash: string; author: string; formatted_date: string; message: string; is_original: boolean }[]>([]);
   const [historyOpen, setHistoryOpen] = useState(false);

--- a/src/prosopography/pages/PersonEditPage.tsx
+++ b/src/prosopography/pages/PersonEditPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { useParams, useNavigate, useSearchParams, useLocation, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ArrowLeft, ArrowLeftRight, Save, X, Loader2, ImagePlus, Trash2, ExternalLink } from 'lucide-react';
@@ -75,8 +76,8 @@ const PersonEditPage: React.FC = () => {
   const [imageDragOver, setImageDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const canEdit = user && (user.role === 'editor' || user.role === 'admin');
-  const isAdmin = user?.role === 'admin';
+  const canEdit = isAtLeast(user?.role, 'editor');
+  const isAdmin = isAtLeast(user?.role, 'admin');
 
   // Kustutamine
   const [deleteOpen, setDeleteOpen] = useState(false);

--- a/src/prosopography/pages/PersonsPage.tsx
+++ b/src/prosopography/pages/PersonsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useSearchParams } from 'react-router-dom';
 import { ArrowDownAZ, Search, UserPlus, Users, CheckSquare, Square, GitMerge, X, ChevronLeft, ChevronRight, Map, List } from 'lucide-react';
@@ -114,15 +115,15 @@ const PersonsPage: React.FC = () => {
   const [showMergeModal, setShowMergeModal] = useState(false);
 
 
-  const isAdmin = user?.role === 'admin';
-  const canEdit = user && (user.role === 'editor' || user.role === 'admin');
+  const isAdmin = isAtLeast(user?.role, 'admin');
+  const canEdit = isAtLeast(user?.role, 'editor');
   const token = authToken ?? '';
   const effectiveSelectedCollection = useMemo(() => {
     if (!selectedCollection) return null;
     const collection = collections[selectedCollection];
     if (!collection) return null;
     if (collection.visibility !== 'restricted') return selectedCollection;
-    if (user?.role === 'admin') return selectedCollection;
+    if (isAtLeast(user?.role, 'admin')) return selectedCollection;
     return user?.allowed_collections?.includes(selectedCollection) ? selectedCollection : null;
   }, [collections, selectedCollection, user]);
 

--- a/src/utils/__tests__/roleUtils.test.ts
+++ b/src/utils/__tests__/roleUtils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { roleLevel, canManageUser, canAssignRole, assignableRoles, ROLE_LEVELS } from '../roleUtils';
+
+describe('roleUtils', () => {
+  it('hierarhia neli taset', () => {
+    expect(ROLE_LEVELS).toEqual({ contributor: 0, editor: 1, admin: 2, superadmin: 3 });
+  });
+  it('tundmatu roll = -1 (ei anna õigusi)', () => {
+    expect(roleLevel('user')).toBe(-1);
+    expect(roleLevel('admin')).toBe(2);
+  });
+  it('canManageUser ainult rangelt madalam', () => {
+    expect(canManageUser('admin', 'editor')).toBe(true);
+    expect(canManageUser('admin', 'admin')).toBe(false);
+    expect(canManageUser('superadmin', 'admin')).toBe(true);
+    expect(canManageUser('superadmin', 'superadmin')).toBe(false);
+  });
+  it('canAssignRole lagi', () => {
+    expect(canAssignRole('admin', 'editor')).toBe(true);
+    expect(canAssignRole('admin', 'admin')).toBe(false);
+    expect(canAssignRole('superadmin', 'admin')).toBe(true);
+    expect(canAssignRole('superadmin', 'superadmin')).toBe(false);
+  });
+  it('assignableRoles filter', () => {
+    expect(assignableRoles('admin')).toEqual(['contributor', 'editor']);
+    expect(assignableRoles('superadmin')).toEqual(['contributor', 'editor', 'admin']);
+  });
+});

--- a/src/utils/__tests__/roleUtils.test.ts
+++ b/src/utils/__tests__/roleUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { roleLevel, canManageUser, canAssignRole, assignableRoles, ROLE_LEVELS } from '../roleUtils';
+import { roleLevel, canManageUser, canAssignRole, assignableRoles, isAtLeast, ROLE_LEVELS } from '../roleUtils';
 
 describe('roleUtils', () => {
   it('hierarhia neli taset', () => {
@@ -24,5 +24,13 @@ describe('roleUtils', () => {
   it('assignableRoles filter', () => {
     expect(assignableRoles('admin')).toEqual(['contributor', 'editor']);
     expect(assignableRoles('superadmin')).toEqual(['contributor', 'editor', 'admin']);
+  });
+  it('isAtLeast: superadmin loeb adminiks', () => {
+    expect(isAtLeast('superadmin', 'admin')).toBe(true);
+    expect(isAtLeast('admin', 'admin')).toBe(true);
+    expect(isAtLeast('editor', 'admin')).toBe(false);
+    expect(isAtLeast('superadmin', 'editor')).toBe(true);
+    expect(isAtLeast(undefined, 'admin')).toBe(false);
+    expect(isAtLeast(null, 'admin')).toBe(false);
   });
 });

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -17,6 +17,16 @@ export function roleLevel(role: string): number {
   return lvl === undefined ? -1 : lvl;
 }
 
+/**
+ * Kas roll on vähemalt minRole tasemel? KASUTA seda täpse `role === 'admin'`
+ * võrdluse asemel — superadmin loeb adminiks (ja administ kõrgemaks), muidu
+ * kukub superadmin admin-funktsioonidest välja. `undefined`/tundmatu → false.
+ */
+export function isAtLeast(role: string | undefined | null, minRole: Role): boolean {
+  if (!role) return false;
+  return roleLevel(role) >= ROLE_LEVELS[minRole];
+}
+
 export function canManageUser(actorRole: string, targetRole: string): boolean {
   return roleLevel(targetRole) < roleLevel(actorRole);
 }

--- a/src/utils/roleUtils.ts
+++ b/src/utils/roleUtils.ts
@@ -1,0 +1,31 @@
+// Rolli-hierarhia frontend-pool. Peegeldab backendi ROLE_HIERARCHY-t.
+// MUGAVUS, MITTE TURVE: kõik piirangud dubleeritakse backendis (can_manage_user jne).
+export const ROLE_LEVELS: Record<string, number> = {
+  contributor: 0,
+  editor: 1,
+  admin: 2,
+  superadmin: 3,
+};
+
+export type Role = 'contributor' | 'editor' | 'admin' | 'superadmin';
+
+const ORDER: Role[] = ['contributor', 'editor', 'admin', 'superadmin'];
+
+/** Tundmatu roll = -1 (ei anna õigusi). EI vaikselt 0 — peegeldab backendi rangust. */
+export function roleLevel(role: string): number {
+  const lvl = ROLE_LEVELS[role];
+  return lvl === undefined ? -1 : lvl;
+}
+
+export function canManageUser(actorRole: string, targetRole: string): boolean {
+  return roleLevel(targetRole) < roleLevel(actorRole);
+}
+
+export function canAssignRole(actorRole: string, newRole: string): boolean {
+  return roleLevel(newRole) < roleLevel(actorRole);
+}
+
+/** Rollid, mida actor tohib määrata (rangelt madalamad), hierarhia järjekorras. */
+export function assignableRoles(actorRole: string): Role[] {
+  return ORDER.filter((r) => canAssignRole(actorRole, r));
+}

--- a/tests/test_admin_role_endpoints.py
+++ b/tests/test_admin_role_endpoints.py
@@ -1,0 +1,57 @@
+"""Endpoint-tasandi testid: superadmin-tee resetil ja kollektsioonidel."""
+
+
+def _seed_superadmin(backend_env):
+    auth = backend_env["auth"]
+    users = auth.load_users()
+    users["root"] = {
+        "password_hash": auth.hash_password("rootpass"),
+        "name": "Root",
+        "role": "superadmin",
+        "created_at": "2026-01-01T00:00:00",
+    }
+    auth.save_users(users)
+
+
+def test_superadmin_can_reset_admin(client, login, backend_env):
+    _seed_superadmin(backend_env)
+    token = login("root", "rootpass")
+    r = client.post(
+        "/admin/users/reset-password",
+        json={"username": "admin"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_admin_can_still_reset_editor(client, login):
+    # Regressioon: helper-asendus ei tohi adminilt editori-reset õigust võtta
+    token = login("admin", "adminpass")
+    r = client.post(
+        "/admin/users/reset-password",
+        json={"username": "editor"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_admin_cannot_create_collection(client, login):
+    token = login("admin", "adminpass")
+    r = client.post(
+        "/admin/collections",
+        json={"id": "x", "name_et": "X", "name_en": "X"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    # require_role("superadmin") ebaõnnestumisel tõstab deps.get_user HTTPException(401)
+    assert r.status_code == 401
+
+
+def test_superadmin_can_create_collection(client, login, backend_env):
+    _seed_superadmin(backend_env)
+    token = login("root", "rootpass")
+    r = client.post(
+        "/admin/collections",
+        json={"id": "testcoll", "name_et": "Test", "name_en": "Test"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text

--- a/tests/test_backend_smoke.py
+++ b/tests/test_backend_smoke.py
@@ -3,6 +3,18 @@ import json
 import unittest.mock
 
 
+def _seed_superadmin(backend_env):
+    auth = backend_env["auth"]
+    users = auth.load_users()
+    users["root"] = {
+        "password_hash": auth.hash_password("rootpass"),
+        "name": "Root",
+        "role": "superadmin",
+        "created_at": "2026-01-01T00:00:00",
+    }
+    auth.save_users(users)
+
+
 def test_login_and_verify_token_roundtrip(client, login):
     token = login("admin", "adminpass")
 
@@ -70,7 +82,8 @@ def test_invite_set_password_consumes_token_once(client, backend_env):
 
 
 def test_admin_collection_update_writes_json(client, login, backend_env):
-    token = login("admin", "adminpass")
+    _seed_superadmin(backend_env)
+    token = login("root", "rootpass")
     headers = {"Authorization": f"Bearer {token}"}
 
     response = client.put(
@@ -441,8 +454,9 @@ def test_public_meili_token_endpoint(client, backend_env):
 
 
 def test_collection_visibility_update(client, login, backend_env):
-    """Admin saab kollektsiooni visibility muuta."""
-    token = login("admin", "adminpass")
+    """Superadmin saab kollektsiooni visibility muuta."""
+    _seed_superadmin(backend_env)
+    token = login("root", "rootpass")
     headers = {"Authorization": f"Bearer {token}"}
 
     response = client.put(

--- a/tests/test_role_permissions.py
+++ b/tests/test_role_permissions.py
@@ -1,0 +1,99 @@
+"""Tuum-invariant: rolli-tasemed ja kes-tohib-keda hallata."""
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from server.auth import (
+    ROLE_HIERARCHY,
+    role_level,
+    is_valid_role,
+    can_manage_user,
+    can_assign_role,
+    can_change_role,
+    has_superadmin,
+)
+
+
+def test_hierarchy_has_four_tiers():
+    assert ROLE_HIERARCHY == {"contributor": 0, "editor": 1, "admin": 2, "superadmin": 3}
+
+
+def test_role_level_known():
+    assert role_level("contributor") == 0
+    assert role_level("superadmin") == 3
+
+
+def test_role_level_unknown_raises():
+    # KRIITILINE: tundmatu roll EI TOHI vaikselt muutuda tasemeks 0
+    with pytest.raises(ValueError):
+        role_level("user")
+    with pytest.raises(ValueError):
+        role_level("")
+
+
+def test_is_valid_role():
+    assert is_valid_role("admin") is True
+    assert is_valid_role("superadmin") is True
+    assert is_valid_role("user") is False
+
+
+def test_can_manage_user_strictly_lower():
+    # admin saab hallata editorit/contributorit
+    assert can_manage_user("admin", "editor") is True
+    assert can_manage_user("admin", "contributor") is True
+    # admin EI saa hallata teist admini ega superadmini (augu sulgemine)
+    assert can_manage_user("admin", "admin") is False
+    assert can_manage_user("admin", "superadmin") is False
+    # superadmin saab hallata admini, mitte teist superadmini
+    assert can_manage_user("superadmin", "admin") is True
+    assert can_manage_user("superadmin", "superadmin") is False
+
+
+def test_can_assign_role_ceiling():
+    # admin saab määrata kuni editor, mitte admin/superadmin
+    assert can_assign_role("admin", "editor") is True
+    assert can_assign_role("admin", "contributor") is True
+    assert can_assign_role("admin", "admin") is False
+    assert can_assign_role("admin", "superadmin") is False
+    # superadmin saab määrata kuni admin, mitte superadmin (võrdne tase)
+    assert can_assign_role("superadmin", "admin") is True
+    assert can_assign_role("superadmin", "superadmin") is False
+
+
+def test_can_change_role_requires_both():
+    # admin: tohib editorit puutuda JA contributoriks määrata
+    assert can_change_role("admin", "editor", "contributor") is True
+    # admin: ei tohi editorit adminiks tõsta (lagi)
+    assert can_change_role("admin", "editor", "admin") is False
+    # admin: ei tohi admini puutuda (sihtmärk)
+    assert can_change_role("admin", "admin", "contributor") is False
+    # superadmin: tohib admini editoriks alandada
+    assert can_change_role("superadmin", "admin", "editor") is True
+
+
+def test_has_superadmin():
+    assert has_superadmin({"a": {"role": "admin"}}) is False
+    assert has_superadmin({"a": {"role": "superadmin"}}) is True
+    assert has_superadmin({}) is False
+
+
+def test_warn_if_no_superadmin(monkeypatch, caplog):
+    import logging
+    import server.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "load_users", lambda: {"a": {"role": "admin"}})
+    with caplog.at_level(logging.WARNING):
+        present = auth_mod.warn_if_no_superadmin()
+    assert present is False
+    assert any("superadmin" in r.message.lower() for r in caplog.records)
+
+
+def test_warn_if_no_superadmin_present(monkeypatch, caplog):
+    import server.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "load_users", lambda: {"a": {"role": "superadmin"}})
+    present = auth_mod.warn_if_no_superadmin()
+    assert present is True

--- a/tests/test_role_permissions.py
+++ b/tests/test_role_permissions.py
@@ -12,11 +12,13 @@ from server.auth import (
     ROLE_HIERARCHY,
     role_level,
     is_valid_role,
+    is_at_least,
     can_manage_user,
     can_assign_role,
     can_change_role,
     has_superadmin,
 )
+from server.access_ops import can_read_work
 
 
 def test_hierarchy_has_four_tiers():
@@ -74,6 +76,30 @@ def test_can_change_role_requires_both():
     assert can_change_role("admin", "admin", "contributor") is False
     # superadmin: tohib admini editoriks alandada
     assert can_change_role("superadmin", "admin", "editor") is True
+
+
+def test_is_at_least_superadmin_counts_as_admin():
+    # KRIITILINE: superadmin peab läbima admin-taseme võimekuse-kontrollid
+    assert is_at_least("superadmin", "admin") is True
+    assert is_at_least("admin", "admin") is True
+    assert is_at_least("editor", "admin") is False
+    assert is_at_least("superadmin", "editor") is True
+
+
+def test_superadmin_can_read_restricted_work(monkeypatch):
+    # Regressioon: superadmin ei tohi piiratud teosest välja kukkuda (nagu admin saab).
+    # is_work_public loeb kollektsiooni-konfist — märgi "secret-coll" piiratuks.
+    import server.access_ops as access_ops
+    monkeypatch.setattr(access_ops, "get_cached_collections",
+                        lambda: {"secret-coll": {"visibility": "restricted"}})
+    work = {"collections": ["secret-coll"]}
+    admin = {"role": "admin", "allowed_collections": []}
+    superadmin = {"role": "superadmin", "allowed_collections": []}
+    editor = {"role": "editor", "allowed_collections": []}
+    assert can_read_work(work, admin) is True
+    assert can_read_work(work, superadmin) is True
+    # editorit ei päästa allowed_collections (tühi) → piiratud teost ei loe
+    assert can_read_work(work, editor) is False
 
 
 def test_has_superadmin():

--- a/tests/test_session_invalidation.py
+++ b/tests/test_session_invalidation.py
@@ -43,12 +43,32 @@ def test_delete_user_sessions_targets_only_username(auth):
 def test_update_user_role_invalidates_sessions(auth):
     _add_session(auth, "tb", "bob")
     admin = {"username": "alice", "role": "admin"}
-    ok, _ = auth.update_user_role("bob", "admin", admin)
+    # editor -> contributor on valiidne (admin tohib editorit puutuda ja contributoriks määrata)
+    ok, _ = auth.update_user_role("bob", "contributor", admin)
     assert ok is True
     # Bob peab uuesti sisse logima — sessioon kustutatud
     assert "tb" not in auth.sessions
     # Roll on uuendatud
-    assert auth._users_cache["bob"]["role"] == "admin"
+    assert auth._users_cache["bob"]["role"] == "contributor"
+
+
+def test_admin_cannot_demote_another_admin(auth):
+    # alice (admin) EI tohi teist admini (carol) puutuda
+    auth._users_cache["carol"] = {"name": "Carol", "role": "admin", "allowed_collections": []}
+    _add_session(auth, "tc", "carol")
+    admin = {"username": "alice", "role": "admin"}
+    ok, msg = auth.update_user_role("carol", "editor", admin)
+    assert ok is False
+    assert msg
+    # Carol sessioon EI tohi olla invalideeritud (operatsioon blokeeriti)
+    assert "tc" in auth.sessions
+
+
+def test_superadmin_can_demote_admin(auth):
+    auth._users_cache["carol"] = {"name": "Carol", "role": "admin", "allowed_collections": []}
+    root = {"username": "root", "role": "superadmin"}
+    ok, _ = auth.update_user_role("carol", "editor", root)
+    assert ok is True
 
 
 def test_delete_user_removes_sessions(auth):


### PR DESCRIPTION
## Kokkuvõte
- lisa range rollihierarhia koos superadmin tasemega ja kesksete can_manage/can_assign helperitega
- jõusta adminide halduses range madalama taseme invariant; eemalda meelis-kõvakoodid
- vii kollektsioonide struktuursed CRUD endpointid superadmin värava taha
- uuenda Users lehe väravad taseme-põhiseks, lisa roleUtils, i18n ja testid

## Kontrollid
- npm run typecheck
- npm run test
- .venv/bin/python -m pytest -q