### PR TITLE
feat: markdown kommentaarid ja git-taaste

### DIFF
--- a/docs/superpowers/plans/2026-06-30-page-comments-markdown-git-restore.md
+++ b/docs/superpowers/plans/2026-06-30-page-comments-markdown-git-restore.md
@@ -1,0 +1,1225 @@
+# Lehekülje kommentaaride markdown + git-taaste — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Anda lehekülje kommentaaridele (ja vastustele) markdown-tugi (pariteet prosopoga) ning ehitada kommentaari-versioonide taastamine git-ajaloost (kustutatud + ülekirjutatud põhitekst).
+
+**Architecture:** Markdown taaskasutab olemasolevaid `MarkdownEditor`/`MarkdownView` komponente; `MarkdownView` saab valikulise `softBreaks` prop'i (single newline → `<br>`). Taaste loeb tõe git-ajaloost on-demand: uus puhas moodul `server/comment_history_ops.py` arvutab versioonid/kustutatud, kaks õhukest endpointi `server/routers/editing.py`-s pakuvad neid, UI elab `AnnotationsTab.tsx`-is (inline kella-ikoon + "Kustutatud kommentaarid" kaart).
+
+**Tech Stack:** React 19 + TypeScript + Tailwind (frontend), FastAPI + GitPython (backend), vitest (FE pure-logic), pytest (BE).
+
+## Global Constraints
+
+- **Markdown-only, XSS-kindel:** `MarkdownView` EI tohi tuua sisse `rehype-raw`-i. `softBreaks` lisab AINULT `remark-breaks` plugina.
+- **Andmemudel muutmatu:** `comment.text` / `reply.text` jäävad markdown-stringideks lehe `.json`-is; backend-skeem, Meilisearch-skeem ega migratsioon ei muutu.
+- **Õigus:** taaste-endpointid ja taaste-UI nõuavad `editor`+ (`require_role("editor")` / `isAtLeast`).
+- **Git on ainus tõeallikas:** eraldi ajaloo-indeksit EI looda.
+- **`text_annotations` jäävad puutumata** (ei markdown, ei taaste).
+- **Path/catalog tuletamine:** kasuta sama mustrit mis `/save` ja `/git-restore` (`os.path.basename(original_path)` + `BASE_DIR`). Ära dubleeri.
+- **Frontend gate:** `npm run typecheck` peab läbima (Vite ei typecheck'i build'is).
+- **Backend testid:** `.venv/bin/python -m pytest` (host venv).
+- **Commit-keel:** eesti, lõpeta `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Haru:** `feat/page-comments-markdown-git-restore` (juba loodud).
+
+---
+
+## Failistruktuur
+
+| Fail | Vastutus | Tegevus |
+|------|----------|---------|
+| `src/components/MarkdownView.tsx` | Markdown-renderdus | Modify: lisa `softBreaks?` prop |
+| `package.json` | Sõltuvused | Modify: lisa `remark-breaks` |
+| `src/components/editor/AnnotationsTab.tsx` | Kommentaaride UI | Modify: markdown sisestus/kuva + taaste-UI |
+| `src/index.css` | Stiilid | Modify: kommentaari-markdown URL-wrap klass |
+| `server/comment_history_ops.py` | Git-ajaloo arvutus (puhas) | Create |
+| `tests/test_comment_history_ops.py` | Ops-testid | Create |
+| `server/routers/editing.py` | Kaks uut endpointi | Modify |
+| `tests/test_page_comments_endpoints.py` | Endpoint-testid | Create |
+| `src/services/commentHistoryService.ts` | FE API-kõned | Create |
+| `src/locales/{et,en}/workspace.json` | i18n | Modify |
+
+---
+
+## Task 1: `MarkdownView` `softBreaks` prop + `remark-breaks` sõltuvus
+
+**Files:**
+- Modify: `package.json` (dependencies)
+- Modify: `src/components/MarkdownView.tsx`
+
+**Interfaces:**
+- Produces: `MarkdownView` prop `softBreaks?: boolean` — kui `true`, single newline renderdub `<br>`-na (`remark-breaks`). Vaikimisi `false` (prosopo käitumine muutmatu).
+
+- [ ] **Step 1: Installi `remark-breaks`**
+
+Run:
+```bash
+npm install remark-breaks
+```
+Expected: `package.json` dependencies saab `"remark-breaks": "^4.x.x"`, `package-lock.json` uueneb.
+
+- [ ] **Step 2: Lisa `softBreaks` prop `MarkdownView`-sse**
+
+Modify `src/components/MarkdownView.tsx` — lisa import ja prop, ehita `remarkPlugins` tingimuslikult:
+
+```tsx
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+
+// Piiratud, turvaline markdown-renderdus (märkmed, elulugu, kommentaarid).
+// Ainult markdown — toores HTML escape'itud (ei kasuta rehype-raw'd).
+// Renderduv DOM on allow-listitud; keelatud elementide tekst säilib (unwrapDisallowed).
+const ALLOWED_ELEMENTS = [
+  'p', 'strong', 'em', 'del', 'a',
+  'ul', 'ol', 'li',
+  'h1', 'h2', 'h3',
+  'blockquote', 'code', 'br',
+];
+
+interface MarkdownViewProps {
+  content: string;
+  className?: string;
+  // softBreaks: single newline → <br> (remark-breaks). Vajalik vanade plain-text
+  // kommentaaride reavahetuste säilitamiseks. Prosopo ei kasuta (vaikimisi false).
+  softBreaks?: boolean;
+}
+
+const MarkdownView: React.FC<MarkdownViewProps> = ({ content, className, softBreaks }) => {
+  if (!content || !content.trim()) return null;
+  const remarkPlugins = softBreaks ? [remarkGfm, remarkBreaks] : [remarkGfm];
+  return (
+    <div className={['vutt-md', className].filter(Boolean).join(' ')}>
+      <ReactMarkdown
+        remarkPlugins={remarkPlugins}
+        allowedElements={ALLOWED_ELEMENTS}
+        unwrapDisallowed
+        components={{
+          a: ({ node: _node, ...props }) => (
+            <a {...props} target="_blank" rel="noopener noreferrer" />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownView;
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run:
+```bash
+npm run typecheck
+```
+Expected: 0 viga.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json src/components/MarkdownView.tsx
+git commit -m "feat: MarkdownView softBreaks prop (remark-breaks)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Markdown sisestus + kuva kommentaarides (`AnnotationsTab`)
+
+**Files:**
+- Modify: `src/components/editor/AnnotationsTab.tsx`
+- Modify: `src/index.css`
+
+**Interfaces:**
+- Consumes: `MarkdownEditor` (`{ value, onChange, placeholder?, minRows?, disabled? }`), `MarkdownView` (`{ content, className?, softBreaks? }`).
+- Produces: kommentaari/vastuse vabatekst on markdown; kuva läbi `MarkdownView softBreaks` + URL-wrap klassi.
+
+- [ ] **Step 1: Lisa CSS URL-wrap klass**
+
+Modify `src/index.css` — lisa (nt `.vutt-md` reeglite lähedusse):
+
+```css
+/* Kommentaaride markdown: pikad URL-id ei tohi layout'i lõhkuda */
+.vutt-md-comment {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+```
+
+- [ ] **Step 2: Impordi markdown-komponendid `AnnotationsTab`-i**
+
+Modify `src/components/editor/AnnotationsTab.tsx` — lisa importide juurde (rida ~16 lähedusse):
+
+```tsx
+import MarkdownEditor from '../MarkdownEditor';
+import MarkdownView from '../MarkdownView';
+```
+
+- [ ] **Step 3: Asenda uue kommentaari `<textarea>` `MarkdownEditor`-iga**
+
+Leia uue kommentaari sisestus (`newComment` state, allpool kommentaaride loendit — `addComment` nupp). Asenda `<textarea value={newComment} onChange=... >` järgmisega:
+
+```tsx
+<MarkdownEditor
+  value={newComment}
+  onChange={setNewComment}
+  placeholder={t('info.addAnnotationPlaceholder')}
+  minRows={3}
+/>
+```
+(Säilita ümbritsev konteiner ja "Lisa" nupp muutmata; eemalda ainult `<textarea>`.)
+
+- [ ] **Step 4: Asenda kommentaari muutmise `<textarea>` `MarkdownEditor`-iga**
+
+`AnnotationsTab.tsx:849-858` (`editingCommentId === comment.id` haru) — asenda `<textarea value={editingText} ...>` järgmisega:
+
+```tsx
+<MarkdownEditor
+  value={editingText}
+  onChange={setEditingText}
+  minRows={6}
+/>
+```
+
+- [ ] **Step 5: Asenda kommentaari `text`-kuva `MarkdownView`-ga**
+
+`AnnotationsTab.tsx:879` — asenda
+`<p className="text-gray-800 text-sm mb-2 leading-relaxed pr-5 whitespace-pre-wrap">{comment.text}</p>`
+järgmisega (NB: `<div>`, mitte `<p>` — markdown tekitab ise plokk-elemente):
+
+```tsx
+<div className="text-gray-800 text-sm mb-2 leading-relaxed pr-5 vutt-md-comment">
+  <MarkdownView content={comment.text} softBreaks />
+</div>
+```
+
+- [ ] **Step 6: Asenda vastuse `text`-kuva `MarkdownView`-ga**
+
+`AnnotationsTab.tsx:888` — asenda
+`<p className="text-gray-800 text-sm mb-1 leading-relaxed whitespace-pre-wrap">{reply.text}</p>`
+järgmisega:
+
+```tsx
+<div className="text-gray-800 text-sm mb-1 leading-relaxed vutt-md-comment">
+  <MarkdownView content={reply.text} softBreaks />
+</div>
+```
+
+- [ ] **Step 7: Asenda vastuse sisestuse `<textarea>` `MarkdownEditor`-iga**
+
+`AnnotationsTab.tsx:899-913` (`replyingToCommentId === comment.id`) — asenda `<textarea value={replyText} ...>` järgmisega:
+
+```tsx
+<MarkdownEditor
+  value={replyText}
+  onChange={setReplyText}
+  placeholder={t('info.replyPlaceholder')}
+  minRows={3}
+/>
+```
+(Escape-käsitlus oli `<textarea onKeyDown>`-is; `MarkdownEditor`-il seda ei ole — Tühista-nupp jääb alles, see katab tühistamise.)
+
+- [ ] **Step 8: Typecheck**
+
+Run:
+```bash
+npm run typecheck
+```
+Expected: 0 viga.
+
+- [ ] **Step 9: Manuaalne smoke (build + visuaalne)**
+
+Run:
+```bash
+npm run build
+```
+Expected: build õnnestub. Visuaalne kontroll dev-serveris (`npm run dev`): vana plain-text kommentaar reavahetustega renderdub reavahetustega (softBreaks); `**paks**` → paks; pikk palja URL ei lõhu kasti laiust; vastus renderdub markdown'ina.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/editor/AnnotationsTab.tsx src/index.css
+git commit -m "feat: markdown kommentaarides ja vastustes (AnnotationsTab)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `comment_history_ops.py` — git-ajaloo arvutus (puhas, TDD)
+
+**Files:**
+- Create: `server/comment_history_ops.py`
+- Test: `tests/test_comment_history_ops.py`
+
+**Interfaces:**
+- Consumes: `server.git_ops.get_file_git_history(paths, max_count)` → list[dict] (`full_hash`, `hash`, `author`, `date`, ...), uusimast vanimani; `server.git_ops.get_file_at_commit(relative_path, commit_hash)` → str|None.
+- Produces:
+  - `build_comment_history(json_relpath: str, current_comments: list, max_count: int = 100) -> dict` → `{ "versions": {comment_id: [{commit_hash, timestamp, author, text}]}, "deleted": [{id, text, author, created_at, replies, last_seen_commit}], "truncated": bool }`
+  - `find_comment_in_content(file_content: str, comment_id: str) -> dict | None`
+  - `apply_comment_restore(current_comments: list, restored_comment: dict, mode: str) -> tuple[list | None, tuple[int, str] | None]` → `(new_comments, None)` õnnestumisel, `(None, (status_code, detail))` vea korral.
+
+- [ ] **Step 1: Kirjuta langevad testid (fixture + ops)**
+
+Create `tests/test_comment_history_ops.py`:
+
+```python
+"""Testid kommentaaride git-ajaloo arvutusele (päris ajutine git-repo)."""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from git import Repo
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server.git_ops as git_ops
+import server.comment_history_ops as cho
+
+
+def _page_json(comments):
+    return json.dumps({"comments": comments}, ensure_ascii=False, indent=2)
+
+
+def _c(cid, text, author="u", created="2026-01-01T00:00:00", replies=None):
+    return {"id": cid, "text": text, "author": author,
+            "created_at": created, "replies": replies or []}
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """Git-repo, kus pg1.json comments muutub mitme commiti jooksul."""
+    r = Repo.init(str(tmp_path))
+    with r.config_writer() as cw:
+        cw.set_value("user", "name", "t").set_value("user", "email", "t@t")
+    folder = tmp_path / "1690-w1"
+    folder.mkdir()
+    jp = folder / "pg1.json"
+    rel = os.path.relpath(str(jp), str(tmp_path))
+
+    def commit(comments, msg):
+        jp.write_text(_page_json(comments), encoding="utf-8")
+        r.index.add([rel])
+        r.index.commit(msg)
+
+    # c1: tekst muutub A → B → C; c2 kustutatakse; c3 lisandub hiljem
+    commit([_c("c1", "A"), _c("c2", "X", replies=[{"id": "r1", "text": "vastus"}])], "v1")
+    commit([_c("c1", "B"), _c("c2", "X2", replies=[{"id": "r1", "text": "vastus"}])], "v2")
+    commit([_c("c1", "C")], "v3 (c2 kustutatud)")          # c2 kadus, viimane seis "X2"
+    commit([_c("c1", "C"), _c("c3", "uus")], "v4")          # c3 lisandus
+
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: r)
+    return {"repo": r, "rel": rel, "folder": folder}
+
+
+def test_versions_only_historical_differing(repo):
+    current = [_c("c1", "C"), _c("c3", "uus")]
+    res = cho.build_comment_history(repo["rel"], current)
+    texts = [v["text"] for v in res["versions"].get("c1", [])]
+    # praegune "C" ei kuulu; ajaloolised erinevad: B, A (uusimast vanimani)
+    assert texts == ["B", "A"]
+    assert "c3" not in res["versions"]  # c3-l pole ajaloolisi erinevaid versioone
+
+
+def test_deleted_keeps_last_state_before_deletion(repo):
+    current = [_c("c1", "C"), _c("c3", "uus")]
+    res = cho.build_comment_history(repo["rel"], current)
+    deleted_ids = {d["id"]: d for d in res["deleted"]}
+    assert "c2" in deleted_ids
+    # viimane seis enne kustutamist oli "X2", mitte esimene "X"
+    assert deleted_ids["c2"]["text"] == "X2"
+    assert deleted_ids["c2"]["replies"] == [{"id": "r1", "text": "vastus"}]
+
+
+def test_dedup_consecutive_identical(repo, monkeypatch):
+    # current = A → versions peaks olema [C, B] (ei dubleeri)
+    current = [_c("c1", "A")]
+    res = cho.build_comment_history(repo["rel"], current)
+    texts = [v["text"] for v in res["versions"].get("c1", [])]
+    assert texts == ["C", "B"]
+
+
+def test_truncated_flag(repo):
+    res = cho.build_comment_history(repo["rel"], [_c("c1", "C")], max_count=2)
+    assert res["truncated"] is True
+    res2 = cho.build_comment_history(repo["rel"], [_c("c1", "C")], max_count=100)
+    assert res2["truncated"] is False
+
+
+def test_malformed_json_commit_does_not_crash(repo, monkeypatch):
+    # Üks commit tagastab vigast JSON-i → see commit skipitakse, ülejäänu töötab
+    real = cho.get_file_at_commit
+    calls = {"n": 0}
+    def flaky(rel, h):
+        calls["n"] += 1
+        if calls["n"] == 1:       # uusim commit → katki
+            return "{ broken json"
+        return real(rel, h)
+    monkeypatch.setattr(cho, "get_file_at_commit", flaky)
+    res = cho.build_comment_history(repo["rel"], [_c("c1", "C")])
+    # ei viska; vanematest commititest leitakse endiselt c1 ajaloolised versioonid
+    assert isinstance(res["versions"], dict)
+    assert any(v["text"] in ("B", "A") for v in res["versions"].get("c1", []))
+
+
+def test_extract_comments_meta_content_wrapper():
+    content = json.dumps({"meta_content": {"comments": [_c("c1", "Z")]}})
+    assert cho.find_comment_in_content(content, "c1")["text"] == "Z"
+
+
+def test_extract_comments_invalid_json_returns_none():
+    assert cho.find_comment_in_content("{ not json", "c1") is None
+
+
+def test_apply_restore_version_overwrites_text_keeps_replies():
+    current = [_c("c1", "uus", replies=[{"id": "r9", "text": "praegune vastus"}])]
+    new, err = cho.apply_comment_restore(current, _c("c1", "vana"), "version")
+    assert err is None
+    assert new[0]["text"] == "vana"
+    assert new[0]["replies"] == [{"id": "r9", "text": "praegune vastus"}]
+
+
+def test_apply_restore_version_missing_id_errors():
+    new, err = cho.apply_comment_restore([_c("c1", "x")], _c("cX", "y"), "version")
+    assert new is None and err[0] == 404
+
+
+def test_apply_restore_deleted_appends():
+    new, err = cho.apply_comment_restore([_c("c1", "x")], _c("c2", "tagasi"), "deleted")
+    assert err is None
+    assert [c["id"] for c in new] == ["c1", "c2"]
+
+
+def test_apply_restore_deleted_conflict():
+    new, err = cho.apply_comment_restore([_c("c1", "x")], _c("c1", "y"), "deleted")
+    assert new is None and err[0] == 409
+```
+
+- [ ] **Step 2: Käivita testid — peavad langema**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/test_comment_history_ops.py -v
+```
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.comment_history_ops'`.
+
+- [ ] **Step 3: Kirjuta `comment_history_ops.py`**
+
+Create `server/comment_history_ops.py`:
+
+```python
+"""Kommentaaride versiooniajaloo arvutus git-logist (on-demand, puhas loogika).
+
+Git on ainus tõeallikas — eraldi indeksit ei hoita. Vt
+docs/superpowers/specs/2026-06-30-page-comments-markdown-git-restore-design.md
+"""
+import json
+
+from .git_ops import get_file_at_commit, get_file_git_history
+
+
+def _extract_comments(file_content):
+    """Parsib lehe .json sisu → comments-massiiv.
+
+    Toetab nii juur-`comments` kui `meta_content.comments` struktuuri.
+    Vigane JSON / puuduv comments → [].
+    """
+    try:
+        data = json.loads(file_content)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    source = data.get("meta_content", data)
+    if not isinstance(source, dict):
+        return []
+    comments = source.get("comments", [])
+    return comments if isinstance(comments, list) else []
+
+
+def find_comment_in_content(file_content, comment_id):
+    """Leiab kommentaari-objekti faili sisust id järgi; None kui puudub."""
+    for c in _extract_comments(file_content):
+        if isinstance(c, dict) and c.get("id") == comment_id:
+            return c
+    return None
+
+
+def build_comment_history(json_relpath, current_comments, max_count=100):
+    """Arvutab kommentaaride versiooniajaloo git-logist.
+
+    versions: { id: [{commit_hash, timestamp, author, text}] } — AINULT ajaloolised
+              text-versioonid, mis erinevad praegusest; uusimast vanimani;
+              järjestikused identsed kokku tõmmatud.
+    deleted:  [{id, text, author, created_at, replies, last_seen_commit}] — id-d,
+              mis ajaloos esinevad aga current_comments-ist puuduvad; säilitatud
+              uusim esinemine (= viimane seis enne kustutamist).
+    truncated: kas ajalugu jõudis max_count-ini.
+    """
+    history = get_file_git_history(json_relpath, max_count=max_count)
+    truncated = len(history) >= max_count
+
+    current_by_id = {c.get("id"): c for c in current_comments if isinstance(c, dict)}
+    current_text = {cid: c.get("text", "") for cid, c in current_by_id.items()}
+
+    versions = {}
+    last_added = {}   # id -> viimati lisatud text (dedup)
+    deleted = {}      # id -> deleted-kirje (esimene kohatud = uusim)
+
+    for commit in history:  # uusimast vanimani
+        content = get_file_at_commit(json_relpath, commit["full_hash"])
+        if content is None:
+            continue
+        for c in _extract_comments(content):
+            if not isinstance(c, dict):
+                continue
+            cid = c.get("id")
+            if cid is None:
+                continue
+            text = c.get("text", "")
+            if cid in current_by_id:
+                if text != current_text.get(cid) and last_added.get(cid) != text:
+                    versions.setdefault(cid, []).append({
+                        "commit_hash": commit["full_hash"],
+                        "timestamp": commit["date"],
+                        "author": commit["author"],
+                        "text": text,
+                    })
+                    last_added[cid] = text
+            elif cid not in deleted:
+                deleted[cid] = {
+                    "id": cid,
+                    "text": text,
+                    "author": c.get("author", ""),
+                    "created_at": c.get("created_at", ""),
+                    "replies": c.get("replies", []),
+                    "last_seen_commit": commit["full_hash"],
+                }
+
+    return {
+        "versions": versions,
+        "deleted": list(deleted.values()),
+        "truncated": truncated,
+    }
+
+
+def apply_comment_restore(current_comments, restored_comment, mode):
+    """Rakendab taaste praegusele comments-massiivile.
+
+    mode "version": olemasoleva kommentaari text üle (replies jäävad).
+    mode "deleted": lisab terve kommentaari tagasi.
+    Returns (new_comments, None) | (None, (status_code, detail)).
+    """
+    by_id = {c.get("id"): c for c in current_comments if isinstance(c, dict)}
+    cid = restored_comment.get("id")
+    if mode == "version":
+        if cid not in by_id:
+            return None, (404, "Kommentaari ei leitud praegusest seisust")
+        new = [
+            {**c, "text": restored_comment.get("text", "")} if c.get("id") == cid else c
+            for c in current_comments
+        ]
+        return new, None
+    if mode == "deleted":
+        if cid in by_id:
+            return None, (409, "Kommentaar selle id-ga on juba olemas")
+        return list(current_comments) + [restored_comment], None
+    return None, (400, "Tundmatu mode")
+```
+
+- [ ] **Step 4: Käivita testid — peavad läbima**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/test_comment_history_ops.py -v
+```
+Expected: PASS (kõik). Kui `test_dedup_consecutive_identical` või `test_malformed_json_commit_does_not_crash` käitub ootamatult, kontrolli iteratsiooni järjekorda (`history` peab olema uusimast vanimani — `get_file_git_history` annab selle).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/comment_history_ops.py tests/test_comment_history_ops.py
+git commit -m "feat: comment_history_ops — kommentaaride git-versioonide arvutus
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `/page-comments/history` endpoint
+
+**Files:**
+- Modify: `server/routers/editing.py`
+- Test: `tests/test_page_comments_endpoints.py`
+
+**Interfaces:**
+- Consumes: `build_comment_history` (Task 3), `BASE_DIR`, `require_role`, `get_json_data`, `run_in_threadpool`.
+- Produces: `POST /page-comments/history` → `{ status, versions, deleted, truncated }`. Body: `{ original_path, file_name }`.
+
+- [ ] **Step 1: Kirjuta langev test (basename + role)**
+
+Create `tests/test_page_comments_endpoints.py`:
+
+```python
+"""Endpoint-testid: /page-comments/history ja /page-comments/restore."""
+
+
+def test_history_rejects_non_basename_filename(client, login, backend_env):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/history",
+        json={"original_path": "1690-w1", "file_name": "../escape.txt"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_history_requires_editor(client, login, backend_env):
+    # Anonüümne (ilma tokenita) → 401
+    r = client.post(
+        "/page-comments/history",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt"},
+    )
+    assert r.status_code == 401
+```
+
+- [ ] **Step 2: Käivita — peab langema**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/test_page_comments_endpoints.py -v
+```
+Expected: FAIL — 404 (endpoint puudub) `test_history_rejects...`-is.
+
+- [ ] **Step 3: Lisa import + endpoint `editing.py`-sse**
+
+Modify `server/routers/editing.py` — lisa importide juurde (olemasoleva `git_ops` impordi lähedusse):
+
+```python
+from ..comment_history_ops import (
+    apply_comment_restore,
+    build_comment_history,
+    find_comment_in_content,
+)
+```
+
+Lisa "GIT AJALUGU JA BULK" sektsiooni (nt pärast `/git-restore`):
+
+```python
+def _validate_page_paths(data):
+    """Tuletab + valideerib catalog/filename/json-teed (ühine history+restore).
+
+    Returns (catalog, filename, json_relpath, json_path, txt_path) või tõstab 400.
+    """
+    raw_file = data.get('file_name', '')
+    if not raw_file or os.path.basename(raw_file) != raw_file:
+        raise HTTPException(status_code=400, detail="Vigane failinimi")
+    catalog = os.path.basename(data.get('original_path', ''))
+    if not catalog:
+        raise HTTPException(status_code=400, detail="Vigane tee")
+    json_filename = os.path.splitext(raw_file)[0] + ".json"
+    json_relpath = os.path.join(catalog, json_filename)
+    json_path = os.path.join(BASE_DIR, catalog, json_filename)
+    txt_path = os.path.join(BASE_DIR, catalog, raw_file)
+    # Path traversal kaitse: tulemus peab jääma BASE_DIR-i
+    base_real = os.path.realpath(BASE_DIR)
+    if not os.path.realpath(json_path).startswith(base_real + os.sep):
+        raise HTTPException(status_code=400, detail="Tee väljaspool lubatud kataloogi")
+    return catalog, raw_file, json_relpath, json_path, txt_path
+
+
+def _read_current_comments(json_path):
+    """Loeb praeguse comments-massiivi kettalt (toetab meta_content wrapperit)."""
+    if not os.path.exists(json_path):
+        return []
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    source = data.get('meta_content', data) if isinstance(data, dict) else {}
+    comments = source.get('comments', []) if isinstance(source, dict) else []
+    return comments or []
+
+
+@router.post("/page-comments/history")
+async def page_comments_history(request: Request, user=Depends(require_role("editor"))):
+    data = await get_json_data(request)
+    _catalog, _filename, json_relpath, json_path, _txt = _validate_page_paths(data)
+    current = _read_current_comments(json_path)
+    result = await run_in_threadpool(build_comment_history, json_relpath, current)
+    return {"status": "success", **result}
+```
+
+- [ ] **Step 4: Käivita testid — peavad läbima**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/test_page_comments_endpoints.py -v
+```
+Expected: PASS (mõlemad). NB: `test_history_requires_editor` eeldab, et `require_role("editor")` ilma tokenita → 401 (vt olemasolevat mustrit `deps.get_user`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/routers/editing.py tests/test_page_comments_endpoints.py
+git commit -m "feat: /page-comments/history endpoint + valideerimishelperid
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `/page-comments/restore` endpoint
+
+**Files:**
+- Modify: `server/routers/editing.py`
+- Test: `tests/test_page_comments_endpoints.py` (laienda)
+
+**Interfaces:**
+- Consumes: `_validate_page_paths`, `_read_current_comments` (Task 4), `apply_comment_restore`, `find_comment_in_content`, `get_file_git_history`, `get_file_at_commit`, `save_with_git`, `sync_work_to_meilisearch_async`.
+- Produces: `POST /page-comments/restore` → `{ status, comments }`. Body: `{ original_path, file_name, mode, comment_id, commit_hash }`.
+
+- [ ] **Step 1: Kirjuta langevad testid (git-repo fixture + happy path + servajuhud)**
+
+Laienda `tests/test_page_comments_endpoints.py` — lisa fixture, mis seab BASE_DIR + git-repo nii `git_ops` kui `editing`-routeri jaoks, ja kommentaariga lehe:
+
+```python
+import json
+import os
+
+import pytest
+from git import Repo
+
+
+@pytest.fixture
+def page_repo(backend_env, tmp_path, monkeypatch):
+    """Git-repo lehe pg1.json-iga: c1 muudeti, c2 kustutati."""
+    import server.git_ops as git_ops
+    import server.routers.editing as editing
+
+    data_dir = tmp_path / "data"
+    folder = data_dir / "1690-w1"
+    folder.mkdir(parents=True)
+    r = Repo.init(str(data_dir))
+    with r.config_writer() as cw:
+        cw.set_value("user", "name", "t").set_value("user", "email", "t@t")
+
+    txt = folder / "pg1.txt"
+    jp = folder / "pg1.json"
+    txt.write_text("lehe tekst", encoding="utf-8")
+
+    def commit(comments, msg):
+        jp.write_text(json.dumps({"comments": comments}, ensure_ascii=False, indent=2),
+                      encoding="utf-8")
+        r.index.add([os.path.relpath(str(txt), str(data_dir)),
+                     os.path.relpath(str(jp), str(data_dir))])
+        r.index.commit(msg)
+
+    c1 = {"id": "c1", "text": "vana", "author": "u", "created_at": "2026-01-01T00:00:00", "replies": []}
+    c2 = {"id": "c2", "text": "kustutatav", "author": "u", "created_at": "2026-01-01T00:00:00", "replies": []}
+    commit([c1, c2], "v1")
+    commit([{**c1, "text": "uus"}], "v2 (c2 kustutatud, c1 muudetud)")
+
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: r)
+    monkeypatch.setattr(editing, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(editing, "sync_work_to_meilisearch_async", lambda *a, **k: None)
+
+    # full hash v1 (vanim) — c2 ja c1 "vana" seis
+    v1_hash = list(r.iter_commits())[-1].hexsha
+    return {"repo": r, "folder": folder, "v1_hash": v1_hash, "jp": jp}
+
+
+def test_restore_version_overwrites_text(client, login, page_repo):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "version", "comment_id": "c1", "commit_hash": page_repo["v1_hash"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    comments = r.json()["comments"]
+    assert next(c for c in comments if c["id"] == "c1")["text"] == "vana"
+    # kettal ka uuendatud
+    on_disk = json.loads(page_repo["jp"].read_text(encoding="utf-8"))["comments"]
+    assert next(c for c in on_disk if c["id"] == "c1")["text"] == "vana"
+
+
+def test_restore_deleted_appends(client, login, page_repo):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "deleted", "comment_id": "c2", "commit_hash": page_repo["v1_hash"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    assert any(c["id"] == "c2" for c in r.json()["comments"])
+
+
+def test_restore_rejects_commit_outside_history(client, login, page_repo):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "version", "comment_id": "c1", "commit_hash": "0" * 40},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_restore_version_missing_comment_in_commit(client, login, page_repo):
+    token = login("editor", "editorpass")
+    # c2 puudub v2-st; aga küsime version c2 v2-hash'iga → leia v2 hash
+    v2_hash = list(page_repo["repo"].iter_commits())[0].hexsha
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "version", "comment_id": "c2", "commit_hash": v2_hash},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_restore_deleted_conflict_when_id_exists(client, login, page_repo):
+    token = login("editor", "editorpass")
+    # c1 on praegu olemas → deleted c1 → 409
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "deleted", "comment_id": "c1", "commit_hash": page_repo["v1_hash"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 409, r.text
+```
+
+- [ ] **Step 2: Käivita — peavad langema**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/test_page_comments_endpoints.py -v
+```
+Expected: FAIL — restore-endpoint puudub (404).
+
+- [ ] **Step 3: Lisa `/page-comments/restore` endpoint**
+
+Modify `server/routers/editing.py` — lisa pärast `/page-comments/history`:
+
+```python
+@router.post("/page-comments/restore")
+async def page_comments_restore(
+    request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("editor"))
+):
+    data = await get_json_data(request)
+    mode = data.get('mode')
+    comment_id = data.get('comment_id')
+    commit_hash = data.get('commit_hash')
+    if mode not in ("version", "deleted") or not comment_id or not commit_hash:
+        raise HTTPException(status_code=400, detail="Vigased parameetrid")
+
+    catalog, filename, json_relpath, json_path, txt_path = _validate_page_paths(data)
+
+    # commit_hash peab kuuluma SELLE faili ajalukku (mitte suvaline git-objekt)
+    history = get_file_git_history(json_relpath, max_count=500)
+    valid = {h['full_hash'] for h in history} | {h['hash'] for h in history}
+    if commit_hash not in valid:
+        raise HTTPException(status_code=400, detail="Commit ei kuulu selle faili ajalukku")
+
+    content = get_file_at_commit(json_relpath, commit_hash)
+    if content is None:
+        raise HTTPException(status_code=400, detail="Commitist ei leitud faili")
+    restored = find_comment_in_content(content, comment_id)
+    if restored is None:
+        raise HTTPException(status_code=404, detail="Kommentaari ei leitud sellest commitist")
+
+    if not os.path.exists(json_path):
+        raise HTTPException(status_code=404, detail="Lehe metaandmeid ei leitud")
+    with open(json_path, 'r', encoding='utf-8') as f:
+        cur_data = json.load(f)
+    source = cur_data['meta_content'] if (
+        isinstance(cur_data, dict) and isinstance(cur_data.get('meta_content'), dict)
+    ) else cur_data
+    current = source.get('comments', []) or []
+
+    new_comments, error = apply_comment_restore(current, restored, mode)
+    if error is not None:
+        raise HTTPException(status_code=error[0], detail=error[1])
+    source['comments'] = new_comments
+
+    # .txt jääb muutmata (taastame ainult kommentaari)
+    with open(txt_path, 'r', encoding='utf-8') as f:
+        txt = f.read()
+
+    save_with_git(
+        txt_path, txt, user['username'],
+        message=f"Restore comment {comment_id}: {commit_hash[:8]}",
+        additional_files=[(json_path, json.dumps(cur_data, indent=2, ensure_ascii=False))],
+    )
+    background_tasks.add_task(sync_work_to_meilisearch_async, catalog)
+    return {"status": "success", "comments": new_comments}
+```
+
+- [ ] **Step 4: Käivita kõik backend-testid — peavad läbima**
+
+Run:
+```bash
+.venv/bin/python -m pytest tests/test_page_comments_endpoints.py tests/test_comment_history_ops.py -v
+```
+Expected: PASS (kõik).
+
+- [ ] **Step 5: Regressiooni-kontroll (kogu backend-svit)**
+
+Run:
+```bash
+.venv/bin/python -m pytest -q
+```
+Expected: olemasolevad testid ei katke.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/routers/editing.py tests/test_page_comments_endpoints.py
+git commit -m "feat: /page-comments/restore endpoint (version + deleted)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Frontend — service + taaste-UI (`AnnotationsTab`)
+
+**Files:**
+- Create: `src/services/commentHistoryService.ts`
+- Modify: `src/components/editor/AnnotationsTab.tsx`
+- Modify: `src/locales/et/workspace.json`, `src/locales/en/workspace.json`
+
+**Interfaces:**
+- Consumes: `FILE_API_URL`, `getAuthHeaders`, `fetchWithTimeout` (kõik juba `AnnotationsTab`-is imporditud), `Annotation` tüüp, `MarkdownView`.
+- Produces:
+  - `fetchCommentHistory(page, authToken) -> Promise<CommentHistory>` kus `CommentHistory = { versions: Record<string, CommentVersion[]>; deleted: DeletedComment[]; truncated: boolean }`
+  - `restoreComment(page, params, authToken) -> Promise<Annotation[]>` kus `params = { mode: 'version'|'deleted'; comment_id: string; commit_hash: string }`
+
+- [ ] **Step 1: Loo service**
+
+Create `src/services/commentHistoryService.ts`:
+
+```typescript
+import { Page, Annotation } from '../types';
+import { FILE_API_URL } from '../config';
+import { fetchWithTimeout, getAuthHeaders } from '../utils/fetchWithTimeout';
+
+export interface CommentVersion {
+  commit_hash: string;
+  timestamp: string;
+  author: string;
+  text: string;
+}
+
+export interface DeletedComment {
+  id: string;
+  text: string;
+  author: string;
+  created_at: string;
+  replies: Annotation['replies'];
+  last_seen_commit: string;
+}
+
+export interface CommentHistory {
+  versions: Record<string, CommentVersion[]>;
+  deleted: DeletedComment[];
+  truncated: boolean;
+}
+
+function pageFileNames(page: Page): { original_path: string; file_name: string } {
+  const imageFilename = page.image_url.split('/').pop() || '';
+  const file_name = imageFilename.replace(/\.[^/.]+$/, '') + '.txt';
+  return {
+    original_path: page.original_path || page.originaal_kataloog || '',
+    file_name,
+  };
+}
+
+export async function fetchCommentHistory(
+  page: Page,
+  authToken?: string,
+): Promise<CommentHistory> {
+  const response = await fetchWithTimeout(`${FILE_API_URL}/page-comments/history`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
+    body: JSON.stringify(pageFileNames(page)),
+    timeout: 30000,
+  });
+  if (!response.ok) {
+    const e = await response.json().catch(() => ({}));
+    throw new Error(e.detail || `History failed: ${response.status}`);
+  }
+  const data = await response.json();
+  return {
+    versions: data.versions || {},
+    deleted: data.deleted || [],
+    truncated: !!data.truncated,
+  };
+}
+
+export async function restoreComment(
+  page: Page,
+  params: { mode: 'version' | 'deleted'; comment_id: string; commit_hash: string },
+  authToken?: string,
+): Promise<Annotation[]> {
+  const response = await fetchWithTimeout(`${FILE_API_URL}/page-comments/restore`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
+    body: JSON.stringify({ ...pageFileNames(page), ...params }),
+    timeout: 30000,
+  });
+  if (!response.ok) {
+    const e = await response.json().catch(() => ({}));
+    throw new Error(e.detail || `Restore failed: ${response.status}`);
+  }
+  const data = await response.json();
+  return data.comments || [];
+}
+```
+
+- [ ] **Step 2: Lisa i18n võtmed (et)**
+
+Modify `src/locales/et/workspace.json` — lisa `info` objekti sisse:
+
+```json
+"commentHistory": "Ajalugu",
+"restoreText": "Taasta see tekst",
+"restoreComment": "Taasta kommentaar",
+"deletedComments": "Kustutatud kommentaarid",
+"noDeletedComments": "Kustutatud kommentaare ei leitud",
+"noOlderVersions": "Varasemaid versioone ei ole",
+"historyTruncated": "Näidatakse viimase 100 commiti ajalugu.",
+"restoreError": "Taastamine ebaõnnestus"
+```
+
+- [ ] **Step 3: Lisa i18n võtmed (en)**
+
+Modify `src/locales/en/workspace.json` — lisa `info` objekti sisse:
+
+```json
+"commentHistory": "History",
+"restoreText": "Restore this text",
+"restoreComment": "Restore comment",
+"deletedComments": "Deleted comments",
+"noDeletedComments": "No deleted comments found",
+"noOlderVersions": "No earlier versions",
+"historyTruncated": "Showing history of the last 100 commits.",
+"restoreError": "Restore failed"
+```
+
+- [ ] **Step 4: Lisa state + laadija `AnnotationsTab`-i**
+
+Modify `src/components/editor/AnnotationsTab.tsx`. Lisa import (Task 2 lisas juba MarkdownView):
+
+```tsx
+import { History as HistoryIcon } from 'lucide-react';
+import { fetchCommentHistory, restoreComment, CommentHistory } from '../../services/commentHistoryService';
+```
+
+Lisa state (teiste `useState`-de juurde, ~rida 75):
+
+```tsx
+const [commentHistory, setCommentHistory] = useState<CommentHistory | null>(null);
+const [historyLoading, setHistoryLoading] = useState(false);
+const [historyError, setHistoryError] = useState<string | null>(null);
+const [openHistoryId, setOpenHistoryId] = useState<string | null>(null);
+const [deletedCardOpen, setDeletedCardOpen] = useState(false);
+const canRestore = isAtLeast(user?.role, 'editor');
+```
+
+Lisa laadija + taaste-funktsioonid (komponendi sees, teiste handlerite juurde). `_page` on prop (vt rida 45 alias):
+
+```tsx
+const ensureHistory = async () => {
+  if (commentHistory || historyLoading) return;
+  setHistoryLoading(true);
+  setHistoryError(null);
+  try {
+    setCommentHistory(await fetchCommentHistory(_page, authToken || undefined));
+  } catch (e) {
+    setHistoryError(e instanceof Error ? e.message : String(e));
+  } finally {
+    setHistoryLoading(false);
+  }
+};
+
+const doRestore = async (
+  mode: 'version' | 'deleted', commentId: string, commitHash: string,
+) => {
+  try {
+    const updated = await restoreComment(
+      _page, { mode, comment_id: commentId, commit_hash: commitHash }, authToken || undefined,
+    );
+    setComments(updated);
+    if (onSaveAnnotations) await onSaveAnnotations(updated);
+    setCommentHistory(null);        // sunni värske laadimine järgmisel avamisel
+    setOpenHistoryId(null);
+  } catch (e) {
+    setHistoryError(e instanceof Error ? e.message : t('info.restoreError'));
+  }
+};
+```
+
+- [ ] **Step 5: Lisa inline "Ajalugu" nupp + versioonide panel**
+
+Modify `AnnotationsTab.tsx` — kommentaari toimingute reas (`!readOnly && <div className="absolute top-2 right-2 ...">`, ~rida 934) lisa Reply/Edit/Delete nuppude kõrvale (ainult `canRestore`):
+
+```tsx
+{canRestore && (
+  <button
+    onClick={async () => {
+      await ensureHistory();
+      setOpenHistoryId(openHistoryId === comment.id ? null : comment.id);
+    }}
+    className="text-gray-400 hover:text-primary-600 transition-colors"
+    title={t('info.commentHistory')}
+  >
+    <HistoryIcon size={14} />
+  </button>
+)}
+```
+
+Lisa kommentaari kasti lõppu (pärast replies/reply-plokki, enne kommentaari `</div>` sulgemist) versioonide panel:
+
+```tsx
+{openHistoryId === comment.id && (
+  <div className="mt-3 border-t border-gray-200 pt-2 space-y-2">
+    {historyLoading && <p className="text-xs text-gray-400">…</p>}
+    {historyError && <p className="text-xs text-red-600">{historyError}</p>}
+    {!historyLoading && (commentHistory?.versions[comment.id]?.length ? (
+      commentHistory.versions[comment.id].map(v => (
+        <div key={v.commit_hash} className="bg-white border border-gray-100 rounded px-2 py-1.5">
+          <div className="vutt-md-comment text-sm text-gray-700">
+            <MarkdownView content={v.text} softBreaks />
+          </div>
+          <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
+            <span>{v.author} · {new Date(v.timestamp).toLocaleString('et-EE')}</span>
+            <button
+              onClick={() => doRestore('version', comment.id, v.commit_hash)}
+              className="text-primary-600 hover:text-primary-800 font-medium"
+            >
+              {t('info.restoreText')}
+            </button>
+          </div>
+        </div>
+      ))
+    ) : (
+      <p className="text-xs text-gray-400 italic">{t('info.noOlderVersions')}</p>
+    ))}
+  </div>
+)}
+```
+
+- [ ] **Step 6: Lisa "Kustutatud kommentaarid" kaart**
+
+Modify `AnnotationsTab.tsx` — kommentaaride kasti (`{/* Comments */}` plokk) lõppu, pärast kommentaaride loendi konteinerit, lisa (ainult `canRestore`):
+
+```tsx
+{canRestore && (
+  <div className="mt-3 border-t border-gray-100 pt-3">
+    <button
+      onClick={async () => {
+        await ensureHistory();
+        setDeletedCardOpen(o => !o);
+      }}
+      className="flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700"
+    >
+      <Trash2 size={13} />
+      {t('info.deletedComments')}
+      {commentHistory && ` (${commentHistory.deleted.length})`}
+    </button>
+    {deletedCardOpen && (
+      <div className="mt-2 space-y-2">
+        {historyLoading && <p className="text-xs text-gray-400">…</p>}
+        {historyError && <p className="text-xs text-red-600">{historyError}</p>}
+        {!historyLoading && commentHistory && (
+          commentHistory.deleted.length === 0 ? (
+            <p className="text-xs text-gray-400 italic">{t('info.noDeletedComments')}</p>
+          ) : (
+            <>
+              {commentHistory.deleted.map(d => (
+                <div key={d.id} className="bg-gray-50 border border-gray-100 rounded px-2 py-1.5">
+                  <div className="vutt-md-comment text-sm text-gray-700">
+                    <MarkdownView content={d.text} softBreaks />
+                  </div>
+                  <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
+                    <span>{d.author} · {new Date(d.created_at).toLocaleString('et-EE')}</span>
+                    <button
+                      onClick={() => doRestore('deleted', d.id, d.last_seen_commit)}
+                      className="text-primary-600 hover:text-primary-800 font-medium"
+                    >
+                      {t('info.restoreComment')}
+                    </button>
+                  </div>
+                </div>
+              ))}
+              {commentHistory.truncated && (
+                <p className="text-xs text-gray-400 italic">{t('info.historyTruncated')}</p>
+              )}
+            </>
+          )
+        )}
+      </div>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 7: Typecheck**
+
+Run:
+```bash
+npm run typecheck
+```
+Expected: 0 viga. (Kui `_page.original_path`/`originaal_kataloog` tüübiviga — kontrolli `Page` tüüpi `src/types.ts`-is; service kasutab `page.original_path || page.originaal_kataloog`.)
+
+- [ ] **Step 8: Build + manuaalne smoke**
+
+Run:
+```bash
+npm run build
+```
+Expected: õnnestub. Dev-serveris (`npm run dev`) editorina: kella-ikoon avab muudetud kommentaari varasemad versioonid + "Taasta see tekst" toob teksti tagasi; "Kustutatud kommentaarid" kaart laeb esimesel avamisel, näitab kustutatud kommentaari + "Taasta kommentaar"; tühja korral "Kustutatud kommentaare ei leitud".
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/services/commentHistoryService.ts src/components/editor/AnnotationsTab.tsx \
+  src/locales/et/workspace.json src/locales/en/workspace.json
+git commit -m "feat: kommentaaride versiooniajaloo taaste-UI (AnnotationsTab)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Markdown comment + reply → Task 1 (softBreaks) + Task 2 (sisestus/kuva). ✅
+- `text_annotations` puutumata → Task 2 ei muuda neid. ✅
+- Reavahetuste säilitus (risk 1) → Task 1 `softBreaks` + Task 2 kasutus. ✅
+- Pikad URL-id (risk 2) → Task 2 `.vutt-md-comment` CSS. ✅
+- `/page-comments/history` (versions ainult ajaloolised+erinevad, deleted viimane seis, truncated) → Task 3 (loogika) + Task 4 (endpoint). ✅
+- `/page-comments/restore` (version/deleted, replies säilib, 404/409) → Task 3 + Task 5. ✅
+- Turvalisus (basename, traversal, commit ajaloos) → Task 4 `_validate_page_paths` + Task 5 commit-kontroll. ✅
+- Catalog jagatud helperist → Task 4/5 `_validate_page_paths`. ✅
+- UI: inline kella + "Kustutatud kommentaarid" kaart, laisk laadimine, nuppude sõnastus, truncated-tekst → Task 6. ✅
+- Õigus editor+ → endpointid `require_role("editor")`, UI `canRestore`. ✅
+- Testid (dedup, mitu muudatust+kustutus, vahepealne puudumine, vigane JSON, 404/409, commit väljaspool ajalugu, basename) → Task 3 + Task 5 testid. ✅
+
+**Placeholder scan:** kõik sammud sisaldavad tegelikku koodi/käske. ✅
+
+**Type consistency:** `CommentHistory`/`CommentVersion`/`DeletedComment` (service) ühtivad endpointi väljundiga (`versions`, `deleted`, `truncated`); `restoreComment` params (`mode`, `comment_id`, `commit_hash`) ühtivad endpointi sisendiga; `_validate_page_paths` tagastus (5 väärtust) ühtib mõlema endpoint-kutsega. ✅
+
+**Märkus reaalsuse kohta:** real-numbrid (`AnnotationsTab.tsx:849`, `:879`, `:888`, `:934`) on snapshot — kontrolli konteksti enne asendamist (otsi tsiteeritud `className`-stringe).

--- a/docs/superpowers/specs/2026-06-30-page-comments-markdown-git-restore-design.md
+++ b/docs/superpowers/specs/2026-06-30-page-comments-markdown-git-restore-design.md
@@ -1,0 +1,299 @@
+# Lehekülje kommentaaride markdown-tugi + git-versiooniajaloo taaste
+
+**Kuupäev:** 2026-06-30
+**Staatus:** Disain (heaks kiidetud, ootab plaani)
+
+## Probleem ja motivatsioon
+
+Lehekülje kommentaarid (`comments` väli lehe `.json`-is) sisaldavad sageli
+väärtuslikku sisu — kasutajate kirjutatud tõlkeid jms. Praegu:
+
+- **Andmed on juba git'is:** iga lehe-`/save` commitib lehe `.json` faili, mis
+  sisaldab `comments`-massiivi (koos vastustega). Vana seis on git-ajaloos alati
+  olemas ja `get_file_at_commit`-iga loetav.
+- **Aga taastamise teed kommentaaridele ei ole.** `/git-restore`
+  (`server/routers/editing.py`) taastab teadlikult ainult `.txt` teksti +
+  `text_annotations`; `comments` jäetakse puutumata. Kui keegi kustutab või
+  kirjutab tõlke üle, ei too ükski UI-nupp seda tagasi (peale käsitsi git-arheoloogia).
+
+Kustutamise üle pole keegi kaevanud — see on **ennetav** töö, kuna kommentaaridesse
+on tihti palju tööd sisse pandud.
+
+Lisaks: prosopograafia eluloo/märkmete väljadel on juba markdown-tugi
+(`MarkdownEditor` + `MarkdownView`, vt
+[2026-06-29-markdown-notes-editor-design.md](2026-06-29-markdown-notes-editor-design.md)).
+**Pariteedi pärast** peaks sama tugi olema ka lehekülje kommentaaridel.
+
+## Ulatuse otsused
+
+| Teema | Otsus |
+|-------|-------|
+| Taaste katvus | Kustutatud kommentaarid **ja** muudetud (ülekirjutatud) kommentaari **põhiteksti** versiooniajalugu |
+| Markdown ulatus | Kommentaari põhitekst (`Annotation.text`) **+** vastused (`AnnotationReply.text`). EI puuduta `text_annotations` (lühikesed inline-märkused). |
+| Taaste-UI asukoht | Inline "Ajalugu" nupp/kella-ikoon kommentaari juures + eraldi klapitav kaart "Kustutatud kommentaarid" all |
+| Backend-mehhanism | On-demand git-walk (ainus tõeallikas git; 0 uut salvestust ega indeksit) |
+| Õigus | Taaste ja markdown-muutmine: `editor`+ (sama kui kommentaaride praegune muutmine) |
+
+### Kasutaja-nähtavad regressiooniriskid (eksplitsiitsed eesmärgid)
+
+Need EI ole "nice to have", vaid disaini eesmärgid — algne motivatsioon (väärtuslik
+sisu, pikad URL-id) tähendab, et need peavad olema lahendatud:
+
+1. **Vanade plain-text kommentaaride reavahetused.** `MarkdownView` ei kasuta
+   praegu `remark-breaks`-i (kontrollitud) → standardne markdown tõmbab üksikud
+   reavahetused kokku. Vanad plain-text kommentaarid, kus kasutaja vajutas Enter,
+   muutuksid visuaalselt. **Lahendus:** `MarkdownView` saab valikulise prop'i
+   `softBreaks?: boolean` (lisab `remark-breaks` plugina **ainult kui `true`**);
+   kommentaaride vaade kasutab `softBreaks`, prosopo jääb muutmata. Single newline
+   → `<br>` (`br` on juba allow-listis). **Uus sõltuvus:** `npm install remark-breaks`
+   (pole veel installitud; `rehype-raw` on package.json-is, aga `MarkdownView` ei
+   kasuta seda — turvalisus, ära too sisse).
+2. **Pikad URL-id.** Markdown lubab ilusamaid linke, aga palja pika lingi kleepimine
+   võib endiselt layout'i lõhkuda. **Lahendus:** kommentaaride markdown-vaate
+   konteinerile CSS `overflow-wrap: anywhere; word-break: break-word` (Tailwind
+   `break-words` + vajadusel `[overflow-wrap:anywhere]`, või `.vutt-md` kõrval eraldi
+   kommentaari-klass).
+
+## Olemasolev kontekst (koodi-leiud)
+
+- **Andmemudel** (`src/types.ts`):
+  - `Annotation { id, text, author, author_username?, created_at, replies?: AnnotationReply[] }`
+  - `AnnotationReply { id, text, author, author_username, created_at }`
+  - `text_annotations: TextAnnotation[]` — eraldi inline-highlightide kommentaarid (ei kuulu skoopi).
+- **Kommentaaride operatsioonid** (`src/components/editor/AnnotationsTab.tsx`):
+  lisa (`addComment`), muuda `text` (`saveEditComment` — kirjutab üle), kustuta
+  (`removeComment`), vasta (`saveReply` → `/page-comments/reply` endpoint).
+- **Püsivus:** kommentaarid salvestuvad läbi tavalise lehe-`/save`
+  (`handleSaveAnnotations` → `onSave` → meta_content sisaldab `comments`).
+  Seega kommentaaride iga seis on lehe `.json` git-commitis.
+- **Git-helperid** (`server/git_ops.py`): `get_file_git_history(paths, max_count)`
+  → commitide nimekiri; `get_file_at_commit(path, hash)` → faili sisu commitis;
+  `save_with_git(...)` → salvestus + commit.
+- **Meilisearch** (`server/meili_doc.py`): `comments` läheb indeksisse objektidena
+  (`has_annotations` + otsing). Markdown-süntaks jääb objektidesse (vt allpool).
+- **Markdown-komponendid** (`src/components/`): `MarkdownEditor`
+  (`{ value, onChange, placeholder?, minRows?, id?, disabled? }`) ja `MarkdownView`
+  (`{ content, className? }`, allow-list, XSS-kindel, ei kasuta `rehype-raw`-i;
+  **ega `remark-breaks`-i** → lisame valikulise `softBreaks` prop'i, vt risk 1).
+
+## Lahendus
+
+### 1. Markdown-pool
+
+**`AnnotationsTab.tsx`:**
+
+- **Sisestus:** kommentaari lisamise/muutmise `<textarea>` ja vastuse `<textarea>`
+  asenduvad `MarkdownEditor`-iga.
+- **Renderdus:** kommentaari `text`-kuva (`<p>{comment.text}</p>`) ja vastuse
+  tekstikuva → `MarkdownView` `softBreaks`-iga + kommentaari-klassiga (URL-wrap).
+  - **DOM-detail:** `MarkdownView` renderdab ise `<div>` + plokk-elemente
+    (`<p>`, `<ul>`, `<h3>` jms). **EI tohi** asendada `<p>{comment.text}</p>` nii,
+    et `MarkdownView` jääks olemasoleva `<p>` sisse (invalid HTML / CSS-anomaalia).
+    Wrapper peab olema `<div>` (või eemalda ümbritsev `<p>`).
+- **Tekst-annotatsioonid jäävad muutmata** (plain `<textarea>` + plain kuva).
+- **Kontrollpunkt (manuaalne + smoke-test):** veendu, et vanade plain-text
+  kommentaaride reavahetused renderduvad ootuspäraselt (`softBreaks`); pikk palja
+  URL ei lõhu layout'i; loend/link/paks renderduvad korrektselt.
+
+**Muutumatu:**
+
+- `text` jääb markdown-stringiks lehe `.json`-is. Backend, andmemudel,
+  Meilisearch-skeem ega migratsioon ei muutu (vanad plain-text kommentaarid
+  renderduvad markdown'ina korrektselt — tavaline tekst on kehtiv markdown).
+- **Otsingu-mõju:** Meilisearchi `comments`-objektidesse jääb markdown-süntaks
+  (`**`, `[..](..)`) — sama olukord nagu prosopo `notes`/`biography` puhul,
+  aktsepteeritav. Reindeksit ei vaja; uued salvestused sünkivad niikuinii.
+
+**i18n:** olemasolevad kommentaaride võtmed; vajadusel `common` namespace
+markdown-redaktori jagatud nuppudele (juba olemas prosopost).
+
+### 2. Backend — kaks uut endpointi
+
+Lisatakse `server/routers/editing.py`-sse, kõrvuti `/git-history`, `/git-restore`.
+
+#### `POST /page-comments/history` (require_role `editor`)
+
+**Sisend:** `{ original_path, file_name }`
+
+**Terminoloogia:** `file_name` on API-väli (request body); backendis `filename`
+muutuja. Lehe `.json` tee: `os.path.splitext(filename)[0] + ".json"`.
+
+**Loogika:**
+
+1. **Turvavalideerimine** (vt allpool "Turvalisus"): `file_name` peab olema
+   basename; JSON-tee peab jääma teose kataloogi piiresse.
+2. `get_file_git_history(json_path, max_count=100)` → commitide nimekiri
+   **uusimast vanimani**. Kui ajalugu jõuab `max_count`-ni → `truncated = true`.
+3. Loe **praegune** `comments` (kettalt) → praeguste id-de ja `text`-ide hulk.
+4. Käi commitid läbi **uusimast vanimani**; iga commiti kohta
+   `get_file_at_commit(json_path, hash)` → parsi `comments`.
+   - Toeta nii uut (`comments` juurtasandil) kui `meta_content.comments`
+     struktuuri (`source = d.get("meta_content", d)` muster).
+   - Vigane JSON / puuduv `comments` selles commitis → **skip see commit**, ära
+     katkesta kogu päringut.
+5. Ehita kaks struktuuri:
+   - **`versions`**: `{ commentId: [{ commit_hash, timestamp, author, text }] }`.
+     Semantika (UI jaoks puhas): **sisaldab AINULT ajaloolisi versioone, mis
+     erinevad praegusest `text`-ist.** Dedup: käies uusimast vanimani, lisa
+     versioon ainult kui selle `text` erineb eelmisest **lisatud** versioonist;
+     praegust (kettal olevat) `text`-i versiooni hulka EI lisata. Nii ei teki
+     segadust, kas `versions[id]` sisaldab praegust teksti — ei sisalda.
+   - **`deleted`**: `[{ id, text, author, created_at, replies, last_seen_commit }]` —
+     id-d, mis esinevad ajaloos, aga **puuduvad praegusest seisust** (praegune seis
+     on tõe-alus: kui praegu puudub, aga ajaloos esineb → `deleted`). Käies uusimast
+     vanimani, esimene commit kus id taas ilmub = **viimane seis enne kustutamist**;
+     säilita see (sisu + `replies`).
+
+**Väljund:** `{ status: "success", versions, deleted, truncated }`
+
+**Jõudlus:** lehe-ajalood on tavaliselt lühikesed; `max_count=100` katab äärmusjuhud.
+Laetakse laisalt (alles UI avamisel), mitte lehe laadimisel. `truncated` annab
+kasutajale ausa signaali, et vanemat ajalugu pole skännitud (vt UI).
+
+#### `POST /page-comments/restore` (require_role `editor`)
+
+**Sisend:** `{ original_path, file_name, mode, comment_id, commit_hash }`
+kus `mode ∈ {"version", "deleted"}`.
+
+**Loogika:**
+
+1. **Turvavalideerimine** (vt allpool): basename-kontroll, tee teose piires,
+   `commit_hash` peab kuuluma **selle faili** git-ajalukku.
+2. Tuleta `catalog`/path **sama helperiga, mida olemasolev `/save` ja kommentaaride
+   salvestus kasutavad** (`os.path.basename(original_path)` + `BASE_DIR`, nagu
+   `editing.py` `/save`). Ära dubleeri path-parsimist — vähendab riski, et restore
+   salvestab faili, aga reindekseerib vale töö.
+3. Loe praegune lehe `.json`.
+4. Loe `comment_id`-le vastav kommentaar `commit_hash`-i seisust
+   (`get_file_at_commit` + parse).
+   - Kui `comment_id` selles commitis puudub → **400/404** (`version` mode'is
+     tähendab see, et valitud commit ei sisalda seda kommentaari).
+5. - **`version`**: leia praeguses `comments`-massiivis `comment_id`, kirjuta
+     selle `text` üle commitist loetuga. **Replies jäävad praeguseks** (ei kao).
+     Kui `comment_id` praegu puudub (vahepeal kustutatud) → suuna `deleted`-loogikale
+     või tagasta viga (täpsusta plaanis; default: viga, kasuta `deleted` mode'i).
+   - **`deleted`**: lisa terve kommentaari-objekt (koos `replies`-iga) praegusesse
+     `comments`-massiivi tagasi. **Id-kollisioon** (id on vahepeal uuesti tekkinud) →
+     **409 konflikt** (ära kirjuta olemasolevat üle).
+6. Salvesta `save_with_git`-iga: lehe `.txt` (muutmata, praegune tekst) +
+   uuendatud `.json` `additional_files`-ina, commit-sõnum
+   `Restore comment {comment_id}: {commit_hash[:8]}`.
+7. `background_tasks.add_task(sync_work_to_meilisearch_async, catalog)`.
+
+**Väljund:** `{ status: "success", comments }` (uuendatud massiiv, et frontend
+saaks oleku värskendada).
+
+#### Turvalisus (mõlemad endpointid)
+
+Git-lugemise endpointid tehakse konservatiivseks isegi `editor`+ nõude juures:
+
+- **`file_name` peab olema basename** — ei tohi sisaldada `/`, `..` vms
+  (`os.path.basename` + valideeri, et tulemus võrdub sisendiga; muidu 400).
+- **JSON-tee peab jääma teose/`BASE_DIR` kataloogi piiresse** (path traversal kaitse,
+  nt `os.path.realpath` kontroll).
+- **`commit_hash` peab kuuluma selle faili git-ajaloo commitide hulka**, mitte suvaline
+  git-objekt — kontrolli `get_file_git_history` tulemuse vastu (muidu 400/403).
+- **Vigane / puuduv JSON või `comments` commitis** → skip (history) või 400 (restore),
+  vastavalt olukorrale.
+- **`comment_id` otsitakse ainult selle faili kommentaaridest** (mitte globaalselt).
+
+### 3. UI
+
+**Laadimise semantika (oluline):** `/page-comments/history` laetakse **laisalt** —
+alles siis kui kasutaja avab kella-ikooni VÕI klapitava kaardi esimest korda.
+Üks päring katab nii `versions` kui `deleted` (need tulevad samast vastusest).
+**Mitte** lehe avamisel automaatselt. Kuni laadimiseni ei tea frontend, kas
+kustutatuid on — seega kaart on alati nähtav (kokkuklapitud nupuna), mitte tingitud
+`deleted.length`-ist.
+
+**`AnnotationsTab.tsx`:**
+
+- **Inline "Ajalugu" nupp / kella-ikoon** iga olemasoleva kommentaari juures
+  (nähtav `editor`+): klikk → laeb (esmakordsel) `/page-comments/history`, näitab
+  selle kommentaari `versions[commentId]` laienduses/popoveris. Iga versioon:
+  autor + kuupäev + `MarkdownView` eelvaade + nupp **"Taasta see tekst"** → `restore`
+  `mode: "version"`. Kui `versions[commentId]` on tühi (pole ajaloolisi erinevaid
+  versioone), näita "Varasemaid versioone ei ole" / inaktiivne ikoon.
+- **Eraldi klapitav kaart all** (`editor`+), pealkiri **"Kustutatud kommentaarid"**:
+  esimene avamine laeb (kui veel laadimata) `/page-comments/history`. Sisu:
+  - kui `deleted.length > 0`: loend (autor, kuupäev, `MarkdownView` sisu) + nupp
+    **"Taasta kommentaar"** → `restore` `mode: "deleted"`;
+  - kui `deleted` tühi: **"Kustutatud kommentaare ei leitud"**;
+  - kui `truncated`: väike abitekst **"Näidatakse viimase 100 commiti ajalugu."**
+- Pärast taastet: värskenda kohalik `comments`-olek serveri-vastusest
+  (tõeallikas server, nagu user-collections-inline-edit mustris).
+
+**Nuppude sõnastus (teadlik):** `version` mode taastab **ainult põhiteksti**, mitte
+vastuseid → "Taasta see tekst" / "Taasta kommentaari tekst". `deleted` mode toob
+terve kommentaari tagasi → "Taasta kommentaar". See teeb vahe kasutajale selgeks.
+
+**i18n:** `workspace`/`common` namespace, et/en võtmed
+(nt `annotations.commentHistory`, `annotations.deletedComments`,
+`annotations.restoreText`, `annotations.restoreComment`, `annotations.noDeleted`,
+`annotations.historyTruncated`).
+
+**Õigus:** "Ajalugu"-nupp + taaste-kaart ainult `editor`+ (sama kui kommentaaride
+muutmine). `MarkdownView` renderdus on kõigile (avalik vaade renderdab
+kommentaare niikuinii).
+
+## Komponentide piirid
+
+| Üksus | Mida teeb | Sõltuvused |
+|-------|-----------|------------|
+| `MarkdownEditor` | Olemasolev, taaskasutatakse muutmata | — |
+| `MarkdownView` | Olemasolev; lisandub valikuline `softBreaks` prop (opt-in `remark-breaks`) | `remark-breaks` |
+| `/page-comments/history` | Arvutab git-ajaloost kommentaari-versioonid + kustutatud | `git_ops` helperid |
+| `/page-comments/restore` | Taastab valitud versiooni/kustutatud kommentaari | `git_ops.save_with_git`, meili sync |
+| `AnnotationsTab.tsx` | Markdown-sisestus/-kuva + taaste-UI | uued endpointid, markdown-komponendid |
+
+Backend-endpointid on puhtad funktsioonid git-ajaloo üle — testitavad ilma UI-ta
+(anna tee + commitid, kontrolli `versions`/`deleted` struktuuri).
+
+## Mida EI tehta (YAGNI)
+
+- **Eraldi tuletatud ajaloo-indeksit ei looda** — git on ainus tõeallikas.
+- **`text_annotations` markdown-tuge ega taastet** ei lisata (lühikesed märkused).
+- **Vastuste (`replies`) eraldi taaste/versioonimine.** Markdown-tugi laieneb küll
+  `AnnotationReply.text` peale (renderdus + sisestus), AGA: kui olemasoleva vastuse
+  tekst kirjutatakse üle või vastus kustutatakse, **v1 ei paku selle eraldi
+  taastamist**. Vastused tulevad tagasi **ainult koos tervenisti kustutatud
+  põhikommentaariga** (`deleted` mode). "Kommentaaride ajalugu" ≠ reply-ajalugu.
+- **Meilisearch reindeks** pole vajalik (skeem ei muutu).
+
+## Testid
+
+- **Backend (pytest):**
+  - `/page-comments/history`:
+    - dedup: järjestikused identsed `text`-id ei tekita topeltkirjeid;
+    - `versions[id]` sisaldab AINULT praegusest erinevaid ajaloolisi versioone
+      (mitte praegust `text`-i);
+    - **mitu muudatust + siis kustutamine**: `deleted` võtab **viimase seisu enne
+      kustutamist**, mitte esimest ajaloolist versiooni;
+    - **kommentaar puudub vahepealses commitis, aga esineb veel vanemas**: praeguse
+      seisu suhtes — kui praegu puudub, aga ajaloos esineb → `deleted` (praegune seis
+      on tõe-alus);
+    - `meta_content`-mähitud ja juur-`comments` struktuurid mõlemad parsitakse;
+    - **vigane JSON vanas commitis ei tapa kogu päringut** (skip, ülejäänu töötab);
+    - `max_count` cap + `truncated` lipp.
+  - `/page-comments/restore`:
+    - `version` kirjutab `text` üle, **säilitab replies**;
+    - `deleted` lisab terve objekti (koos replies) tagasi;
+    - **`version` commitist, kus `comment_id` puudub → 400/404**;
+    - **`deleted`, kui id on vahepeal uuesti tekkinud → 409 konflikt**;
+    - `commit_hash` ei kuulu selle faili ajalukku → 400/403;
+    - `file_name` ei ole basename / path traversal → 400;
+    - git-commit tekib; õiguse kontroll (`editor`+).
+- **Frontend (typecheck + smoke):** `npm run typecheck` peab läbima.
+  - markdown-renderdus kommentaarides + vastustes; `softBreaks` säilitab vanade
+    plain-text kommentaaride üksikud reavahetused;
+  - pikk palja URL ei lõhu layout'i (URL-wrap klass);
+  - vähemalt üks list / link / paks smoke-test renderdub korrektselt;
+  - taaste-UI värskendab oleku serveri-vastusest; laisk laadimine (ei laadita lehe
+    avamisel).
+
+## Riskid
+
+- **Pika ajalooga leht:** `/page-comments/history` parsib N JSON-faili. Leevendus:
+  `max_count` cap + laisk laadimine. Kui osutub aeglaseks, saab hiljem cache'ida.
+- **Markdown otsingus:** süntaks jääb Meilisearchi `comments`-objektidesse —
+  teadlik aktsepteeritud kompromiss (sama kui prosopo).

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-zoom-pan-pinch": "^3.7.0",
         "recharts": "^3.5.0",
         "rehype-raw": "^7.0.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -4562,6 +4563,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -6025,6 +6040,21 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-zoom-pan-pinch": "^3.7.0",
     "recharts": "^3.5.0",
     "rehype-raw": "^7.0.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/server/comment_history_ops.py
+++ b/server/comment_history_ops.py
@@ -1,0 +1,117 @@
+"""Kommentaaride versiooniajaloo arvutus git-logist (on-demand, puhas loogika).
+
+Git on ainus tõeallikas — eraldi indeksit ei hoita. Vt
+`docs/superpowers/specs/2026-06-30-page-comments-markdown-git-restore-design.md`.
+"""
+import json
+
+from .git_ops import get_file_at_commit, get_file_git_history
+
+
+def _extract_comments(file_content):
+    """Parsib lehe .json sisu → comments-massiiv.
+
+    Toetab nii juur-`comments` kui `meta_content.comments` struktuuri.
+    Vigane JSON / puuduv comments → [].
+    """
+    try:
+        data = json.loads(file_content)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    source = data.get("meta_content", data)
+    if not isinstance(source, dict):
+        return []
+    comments = source.get("comments", [])
+    return comments if isinstance(comments, list) else []
+
+
+def find_comment_in_content(file_content, comment_id):
+    """Leiab kommentaari-objekti faili sisust id järgi; None kui puudub."""
+    for c in _extract_comments(file_content):
+        if isinstance(c, dict) and c.get("id") == comment_id:
+            return c
+    return None
+
+
+def build_comment_history(json_relpath, current_comments, max_count=100):
+    """Arvutab kommentaaride versiooniajaloo git-logist.
+
+    versions: { id: [{commit_hash, timestamp, author, text}] } — AINULT ajaloolised
+              text-versioonid, mis erinevad praegusest; uusimast vanimani;
+              järjestikused identsed kokku tõmmatud.
+    deleted:  [{id, text, author, created_at, replies, last_seen_commit}] — id-d,
+              mis ajaloos esinevad aga current_comments-ist puuduvad; säilitatud
+              uusim esinemine (= viimane seis enne kustutamist).
+    truncated: kas ajalugu jõudis max_count-ini.
+    """
+    history = get_file_git_history(json_relpath, max_count=max_count)
+    truncated = len(history) >= max_count
+
+    current_by_id = {c.get("id"): c for c in current_comments if isinstance(c, dict)}
+    current_text = {cid: c.get("text", "") for cid, c in current_by_id.items()}
+
+    versions = {}
+    last_added = {}   # id -> viimati lisatud text (dedup)
+    deleted = {}      # id -> deleted-kirje (esimene kohatud = uusim)
+
+    for commit in history:  # uusimast vanimani
+        content = get_file_at_commit(json_relpath, commit["full_hash"])
+        if content is None:
+            continue
+        for c in _extract_comments(content):
+            if not isinstance(c, dict):
+                continue
+            cid = c.get("id")
+            if cid is None:
+                continue
+            text = c.get("text", "")
+            if cid in current_by_id:
+                if text != current_text.get(cid) and last_added.get(cid) != text:
+                    versions.setdefault(cid, []).append({
+                        "commit_hash": commit["full_hash"],
+                        "timestamp": commit["date"],
+                        "author": commit["author"],
+                        "text": text,
+                    })
+                    last_added[cid] = text
+            elif cid not in deleted:
+                deleted[cid] = {
+                    "id": cid,
+                    "text": text,
+                    "author": c.get("author", ""),
+                    "created_at": c.get("created_at", ""),
+                    "replies": c.get("replies", []),
+                    "last_seen_commit": commit["full_hash"],
+                }
+
+    return {
+        "versions": versions,
+        "deleted": list(deleted.values()),
+        "truncated": truncated,
+    }
+
+
+def apply_comment_restore(current_comments, restored_comment, mode):
+    """Rakendab taaste praegusele comments-massiivile.
+
+    mode "version": olemasoleva kommentaari text üle (replies jäävad).
+    mode "deleted": lisab terve kommentaari tagasi.
+    Returns (new_comments, None) | (None, (status_code, detail)).
+    """
+    by_id = {c.get("id"): c for c in current_comments if isinstance(c, dict)}
+    cid = restored_comment.get("id")
+    if mode == "version":
+        if cid not in by_id:
+            return None, (404, "Kommentaari ei leitud praegusest seisust")
+        new = [
+            {**c, "text": restored_comment.get("text", "")} if c.get("id") == cid else c
+            for c in current_comments
+        ]
+        return new, None
+    if mode == "deleted":
+        if cid in by_id:
+            return None, (409, "Kommentaar selle id-ga on juba olemas")
+        return list(current_comments) + [restored_comment], None
+    return None, (400, "Tundmatu mode")

--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -11,6 +11,11 @@ from ..access_ops import can_write_work
 from ..auth import is_at_least
 from ..cache import get_cached_suggestions
 from ..cache_invalidation import invalidate_all_caches as _invalidate_all_caches
+from ..comment_history_ops import (
+    apply_comment_restore,
+    build_comment_history,
+    find_comment_in_content,
+)
 from ..config import BASE_DIR
 from ..deps import get_json_data, get_user, require_role
 from ..entity_labels_ops import enrich_entity_labels_async, enrich_entity_labels_async_qcodes
@@ -149,6 +154,101 @@ async def commit_diff(request: Request, user=Depends(require_role("editor"))):
     diff_res = get_commit_diff(commit_hash, filepaths=clean_path)
     if not diff_res or not diff_res.get('diff'): diff_res = get_commit_diff(commit_hash)
     return {"status": "success", **diff_res} if diff_res else {"status": "error"}
+
+def _validate_page_paths(data):
+    """Tuletab + valideerib catalog/filename/json-teed (ühine history+restore).
+
+    Returns (catalog, filename, json_relpath, json_path, txt_path) või tõstab 400.
+    """
+    raw_file = data.get('file_name', '')
+    if not raw_file or os.path.basename(raw_file) != raw_file:
+        raise HTTPException(status_code=400, detail="Vigane failinimi")
+    catalog = os.path.basename(data.get('original_path', ''))
+    if not catalog:
+        raise HTTPException(status_code=400, detail="Vigane tee")
+    json_filename = os.path.splitext(raw_file)[0] + ".json"
+    json_relpath = os.path.join(catalog, json_filename)
+    json_path = os.path.join(BASE_DIR, catalog, json_filename)
+    txt_path = os.path.join(BASE_DIR, catalog, raw_file)
+    # Path traversal kaitse: tulemus peab jääma BASE_DIR-i
+    base_real = os.path.realpath(BASE_DIR)
+    if not os.path.realpath(json_path).startswith(base_real + os.sep):
+        raise HTTPException(status_code=400, detail="Tee väljaspool lubatud kataloogi")
+    return catalog, raw_file, json_relpath, json_path, txt_path
+
+
+def _read_current_comments(json_path):
+    """Loeb praeguse comments-massiivi kettalt (toetab meta_content wrapperit)."""
+    if not os.path.exists(json_path):
+        return []
+    with open(json_path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    source = data.get('meta_content', data) if isinstance(data, dict) else {}
+    comments = source.get('comments', []) if isinstance(source, dict) else []
+    return comments or []
+
+
+@router.post("/page-comments/history")
+async def page_comments_history(request: Request, user=Depends(require_role("editor"))):
+    data = await get_json_data(request)
+    _catalog, _filename, json_relpath, json_path, _txt = _validate_page_paths(data)
+    current = _read_current_comments(json_path)
+    result = await run_in_threadpool(build_comment_history, json_relpath, current)
+    return {"status": "success", **result}
+
+
+@router.post("/page-comments/restore")
+async def page_comments_restore(
+    request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("editor"))
+):
+    data = await get_json_data(request)
+    mode = data.get('mode')
+    comment_id = data.get('comment_id')
+    commit_hash = data.get('commit_hash')
+    if mode not in ("version", "deleted") or not comment_id or not commit_hash:
+        raise HTTPException(status_code=400, detail="Vigased parameetrid")
+
+    catalog, _filename, json_relpath, json_path, txt_path = _validate_page_paths(data)
+
+    # commit_hash peab kuuluma SELLE faili ajalukku (mitte suvaline git-objekt)
+    history = get_file_git_history(json_relpath, max_count=500)
+    valid = {h['full_hash'] for h in history} | {h['hash'] for h in history}
+    if commit_hash not in valid:
+        raise HTTPException(status_code=400, detail="Commit ei kuulu selle faili ajalukku")
+
+    content = get_file_at_commit(json_relpath, commit_hash)
+    if content is None:
+        raise HTTPException(status_code=400, detail="Commitist ei leitud faili")
+    restored = find_comment_in_content(content, comment_id)
+    if restored is None:
+        raise HTTPException(status_code=404, detail="Kommentaari ei leitud sellest commitist")
+
+    if not os.path.exists(json_path):
+        raise HTTPException(status_code=404, detail="Lehe metaandmeid ei leitud")
+    with open(json_path, 'r', encoding='utf-8') as f:
+        cur_data = json.load(f)
+    source = cur_data['meta_content'] if (
+        isinstance(cur_data, dict) and isinstance(cur_data.get('meta_content'), dict)
+    ) else cur_data
+    current = source.get('comments', []) or []
+
+    new_comments, error = apply_comment_restore(current, restored, mode)
+    if error is not None:
+        raise HTTPException(status_code=error[0], detail=error[1])
+    source['comments'] = new_comments
+
+    # .txt jääb muutmata (taastame ainult kommentaari)
+    with open(txt_path, 'r', encoding='utf-8') as f:
+        txt = f.read()
+
+    save_with_git(
+        txt_path, txt, user['username'],
+        message=f"Restore comment {comment_id}: {commit_hash[:8]}",
+        additional_files=[(json_path, json.dumps(cur_data, indent=2, ensure_ascii=False))],
+    )
+    background_tasks.add_task(sync_work_to_meilisearch_async, catalog)
+    return {"status": "success", "comments": new_comments}
+
 
 @router.post("/git-restore")
 async def git_restore(request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("editor"))):

--- a/src/components/MarkdownView.tsx
+++ b/src/components/MarkdownView.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 
-// Piiratud, turvaline markdown-renderdus (märkmed, elulugu jms).
+// Piiratud, turvaline markdown-renderdus (märkmed, elulugu, kommentaarid).
 // Ainult markdown — toores HTML escape'itud (ei kasuta rehype-raw'd).
 // Renderduv DOM on allow-listitud; keelatud elementide tekst säilib (unwrapDisallowed).
 const ALLOWED_ELEMENTS = [
@@ -15,14 +16,18 @@ const ALLOWED_ELEMENTS = [
 interface MarkdownViewProps {
   content: string;
   className?: string;
+  // softBreaks: single newline → <br> (remark-breaks). Vajalik vanade plain-text
+  // kommentaaride reavahetuste säilitamiseks. Prosopo ei kasuta (vaikimisi false).
+  softBreaks?: boolean;
 }
 
-const MarkdownView: React.FC<MarkdownViewProps> = ({ content, className }) => {
+const MarkdownView: React.FC<MarkdownViewProps> = ({ content, className, softBreaks }) => {
   if (!content || !content.trim()) return null;
+  const remarkPlugins = softBreaks ? [remarkGfm, remarkBreaks] : [remarkGfm];
   return (
     <div className={['vutt-md', className].filter(Boolean).join(' ')}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={remarkPlugins}
         allowedElements={ALLOWED_ELEMENTS}
         unwrapDisallowed
         components={{

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -451,6 +451,13 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     }
   }, [page, status, page_tags, textAnnotations, onSave]);
 
+  // Kommentaari taastamine: restore-endpoint on kettale juba committinud, seega
+  // sünkroni ainult lokaalne + salvestatud baasseis (mitte teist /save commitit).
+  const handleCommentsRestored = useCallback((updatedComments: Annotation[]) => {
+    setComments(updatedComments);
+    setSavedState({ status, comments: updatedComments, page_tags, text_annotations: textAnnotations });
+  }, [status, page_tags, textAnnotations]);
+
   const handleReplyToComment = useCallback(async (commentId: string, replyText: string) => {
     if (!authToken) {
       throw new Error(t('saveError.tokenMissing'));
@@ -1144,6 +1151,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
             comments={comments}
             setComments={setComments}
             onSaveAnnotations={handleSaveAnnotations}
+            onCommentsRestored={handleCommentsRestored}
             onReplyToComment={handleReplyToComment}
             readOnly={readOnly || false}
             user={user}

--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useLocation } from 'react-router-dom';
-import { BookOpen, User, ExternalLink, Download, Edit3, Tag, Search, X, MessageSquare, Trash2, FolderOpen, Bookmark, Check, BookDown, IdCard, SquarePen, FileSliders, Reply, Send, StickyNote } from 'lucide-react';
+import { BookOpen, User, ExternalLink, Download, Edit3, Tag, Search, X, MessageSquare, Trash2, FolderOpen, Bookmark, Check, BookDown, IdCard, SquarePen, FileSliders, Reply, Send, StickyNote, History as HistoryIcon } from 'lucide-react';
 import DownloadModal from '../DownloadModal';
 import { Work, Page, Annotation, ArchiveRef } from '../../types';
 import type { TextAnnotation } from '../../types';
@@ -19,6 +19,7 @@ import { useCollection } from '../../contexts/CollectionContext';
 import { useMeiliIndex } from '../../contexts/MeilisearchContext';
 import { getCollectionColorClasses, getCollectionHierarchy } from '../../services/collectionService';
 import { formatYearDisplay } from '../../utils/yearDisplayUtils';
+import { fetchCommentHistory, restoreComment, CommentHistory } from '../../services/commentHistoryService';
 import MarkdownEditor from '../MarkdownEditor';
 import MarkdownView from '../MarkdownView';
 
@@ -76,9 +77,15 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   const [replyText, setReplyText] = useState('');
   const [replyError, setReplyError] = useState<string | null>(null);
   const [savingReplyId, setSavingReplyId] = useState<string | null>(null);
+  const [commentHistory, setCommentHistory] = useState<CommentHistory | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [openHistoryId, setOpenHistoryId] = useState<string | null>(null);
+  const [deletedCardOpen, setDeletedCardOpen] = useState(false);
   const highlightedCommentId = new URLSearchParams(location.search).get('comment');
 
   const isAdmin = isAtLeast(user?.role, 'admin');
+  const canRestore = isAtLeast(user?.role, 'editor');
   
   // Arhiivide register (nimed kuvamiseks)
   const [archives, setArchives] = useState<Record<string, { name: string; url?: string }>>({});
@@ -214,6 +221,35 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
       setReplyError(e.message || t('common:errors.unknownError'));
     } finally {
       setSavingReplyId(null);
+    }
+  };
+
+  const ensureHistory = async () => {
+    if (commentHistory || historyLoading) return;
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      setCommentHistory(await fetchCommentHistory(_page, authToken || undefined));
+    } catch (e) {
+      setHistoryError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const doRestore = async (
+    mode: 'version' | 'deleted', commentId: string, commitHash: string,
+  ) => {
+    try {
+      const updated = await restoreComment(
+        _page, { mode, comment_id: commentId, commit_hash: commitHash }, authToken || undefined,
+      );
+      setComments(updated);
+      if (onSaveAnnotations) await onSaveAnnotations(updated);
+      setCommentHistory(null);
+      setOpenHistoryId(null);
+    } catch (e) {
+      setHistoryError(e instanceof Error ? e.message : t('info.restoreError'));
     }
   };
 
@@ -923,6 +959,32 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
                       </div>
                     </div>
                   )}
+                  {openHistoryId === comment.id && (
+                    <div className="mt-3 border-t border-gray-200 pt-2 space-y-2">
+                      {historyLoading && <p className="text-xs text-gray-400">…</p>}
+                      {historyError && <p className="text-xs text-red-600">{historyError}</p>}
+                      {!historyLoading && (commentHistory?.versions[comment.id]?.length ? (
+                        commentHistory.versions[comment.id].map(v => (
+                          <div key={v.commit_hash} className="bg-white border border-gray-100 rounded px-2 py-1.5">
+                            <div className="vutt-md-comment text-sm text-gray-700">
+                              <MarkdownView content={v.text} softBreaks />
+                            </div>
+                            <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
+                              <span>{v.author} · {new Date(v.timestamp).toLocaleString('et-EE')}</span>
+                              <button
+                                onClick={() => doRestore('version', comment.id, v.commit_hash)}
+                                className="text-primary-600 hover:text-primary-800 font-medium"
+                              >
+                                {t('info.restoreText')}
+                              </button>
+                            </div>
+                          </div>
+                        ))
+                      ) : (
+                        <p className="text-xs text-gray-400 italic">{t('info.noOlderVersions')}</p>
+                      ))}
+                    </div>
+                  )}
                   {!readOnly && (
                     <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                       {onReplyToComment && (
@@ -947,6 +1009,18 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
                           <Edit3 size={14} />
                         </button>
                       )}
+                      {canRestore && (
+                        <button
+                          onClick={async () => {
+                            await ensureHistory();
+                            setOpenHistoryId(openHistoryId === comment.id ? null : comment.id);
+                          }}
+                          className="text-gray-400 hover:text-primary-600 p-1 rounded hover:bg-white transition-colors"
+                          title={t('info.commentHistory')}
+                        >
+                          <HistoryIcon size={14} />
+                        </button>
+                      )}
                       <button
                         onClick={() => removeComment(comment.id)}
                         className="text-gray-400 hover:text-red-600 p-1 rounded hover:bg-white transition-colors"
@@ -961,6 +1035,55 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
             </div>
           ))}
         </div>
+
+        {canRestore && (
+          <div className="mt-3 border-t border-gray-100 pt-3">
+            <button
+              onClick={async () => {
+                await ensureHistory();
+                setDeletedCardOpen(o => !o);
+              }}
+              className="flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700"
+            >
+              <Trash2 size={13} />
+              {t('info.deletedComments')}
+              {commentHistory && ` (${commentHistory.deleted.length})`}
+            </button>
+            {deletedCardOpen && (
+              <div className="mt-2 space-y-2">
+                {historyLoading && <p className="text-xs text-gray-400">…</p>}
+                {historyError && <p className="text-xs text-red-600">{historyError}</p>}
+                {!historyLoading && commentHistory && (
+                  commentHistory.deleted.length === 0 ? (
+                    <p className="text-xs text-gray-400 italic">{t('info.noDeletedComments')}</p>
+                  ) : (
+                    <>
+                      {commentHistory.deleted.map(d => (
+                        <div key={d.id} className="bg-gray-50 border border-gray-100 rounded px-2 py-1.5">
+                          <div className="vutt-md-comment text-sm text-gray-700">
+                            <MarkdownView content={d.text} softBreaks />
+                          </div>
+                          <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
+                            <span>{d.author} · {new Date(d.created_at).toLocaleString('et-EE')}</span>
+                            <button
+                              onClick={() => doRestore('deleted', d.id, d.last_seen_commit)}
+                              className="text-primary-600 hover:text-primary-800 font-medium"
+                            >
+                              {t('info.restoreComment')}
+                            </button>
+                          </div>
+                        </div>
+                      ))}
+                      {commentHistory.truncated && (
+                        <p className="text-xs text-gray-400 italic">{t('info.historyTruncated')}</p>
+                      )}
+                    </>
+                  )
+                )}
+              </div>
+            )}
+          </div>
+        )}
 
         {!readOnly ? (
           <div className="mt-auto">

--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -31,6 +31,9 @@ interface AnnotationsTabProps {
   comments: Annotation[];
   setComments: (comments: Annotation[]) => void;
   onSaveAnnotations?: (comments: Annotation[]) => Promise<void>;
+  // Kommentaarid on serveris juba salvestatud (restore-endpoint commitis) — sünkroni
+  // ainult lokaalne + salvestatud baasseis, ÄRA tee teist /save commitit.
+  onCommentsRestored?: (comments: Annotation[]) => void;
   onReplyToComment?: (commentId: string, replyText: string) => Promise<void>;
   readOnly: boolean;
   user: any;
@@ -51,6 +54,7 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   comments,
   setComments,
   onSaveAnnotations,
+  onCommentsRestored,
   onReplyToComment,
   readOnly,
   user,
@@ -244,8 +248,9 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
       const updated = await restoreComment(
         _page, { mode, comment_id: commentId, commit_hash: commitHash }, authToken || undefined,
       );
-      setComments(updated);
-      if (onSaveAnnotations) await onSaveAnnotations(updated);
+      // Restore-endpoint juba committis kettale — sünkroni ainult seis, ilma teise salvestuseta.
+      if (onCommentsRestored) onCommentsRestored(updated);
+      else setComments(updated);
       setCommentHistory(null);
       setOpenHistoryId(null);
     } catch (e) {

--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -19,6 +19,8 @@ import { useCollection } from '../../contexts/CollectionContext';
 import { useMeiliIndex } from '../../contexts/MeilisearchContext';
 import { getCollectionColorClasses, getCollectionHierarchy } from '../../services/collectionService';
 import { formatYearDisplay } from '../../utils/yearDisplayUtils';
+import MarkdownEditor from '../MarkdownEditor';
+import MarkdownView from '../MarkdownView';
 
 interface AnnotationsTabProps {
   work?: Work;
@@ -846,15 +848,10 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
             >
               {editingCommentId === comment.id ? (
                 <div className="space-y-2">
-                  <textarea
+                  <MarkdownEditor
                     value={editingText}
-                    onChange={(e) => setEditingText(e.target.value)}
-                    className="w-full px-2 py-1.5 text-sm border border-primary-300 rounded focus:border-primary-500 focus:ring-1 focus:ring-primary-200 outline-none resize-y"
-                    rows={6}
-                    autoFocus
-                    onKeyDown={(e) => {
-                      if (e.key === 'Escape') { setEditingCommentId(null); setEditingText(''); }
-                    }}
+                    onChange={setEditingText}
+                    minRows={6}
                   />
                   <div className="flex gap-2 justify-end">
                     <button
@@ -876,7 +873,9 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
                 </div>
               ) : (
                 <>
-                  <p className="text-gray-800 text-sm mb-2 leading-relaxed pr-5 whitespace-pre-wrap">{comment.text}</p>
+                  <div className="text-gray-800 text-sm mb-2 leading-relaxed pr-5 vutt-md-comment">
+                    <MarkdownView content={comment.text} softBreaks />
+                  </div>
                   <div className="flex justify-between items-center text-xs text-gray-500">
                     <span className="font-semibold text-primary-700">{comment.author}</span>
                     <span>{new Date(comment.created_at).toLocaleString('et-EE')}</span>
@@ -885,7 +884,9 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
                     <div className="mt-3 space-y-2 border-l-2 border-primary-100 pl-3">
                       {(comment.replies || []).map(reply => (
                         <div key={reply.id} className="bg-white border border-gray-100 rounded-md px-3 py-2">
-                          <p className="text-gray-800 text-sm mb-1 leading-relaxed whitespace-pre-wrap">{reply.text}</p>
+                          <div className="text-gray-800 text-sm mb-1 leading-relaxed vutt-md-comment">
+                            <MarkdownView content={reply.text} softBreaks />
+                          </div>
                           <div className="flex justify-between items-center text-xs text-gray-500">
                             <span className="font-semibold text-primary-700">{reply.author}</span>
                             <span>{new Date(reply.created_at).toLocaleString('et-EE')}</span>
@@ -896,20 +897,11 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
                   )}
                   {replyingToCommentId === comment.id && (
                     <div className="mt-3 space-y-2">
-                      <textarea
+                      <MarkdownEditor
                         value={replyText}
-                        onChange={(e) => setReplyText(e.target.value)}
+                        onChange={setReplyText}
                         placeholder={t('info.replyPlaceholder')}
-                        className="w-full px-2 py-1.5 text-sm border border-primary-300 rounded focus:border-primary-500 focus:ring-1 focus:ring-primary-200 outline-none resize-y"
-                        rows={3}
-                        autoFocus
-                        onKeyDown={(e) => {
-                          if (e.key === 'Escape') {
-                            setReplyingToCommentId(null);
-                            setReplyText('');
-                            setReplyError(null);
-                          }
-                        }}
+                        minRows={3}
                       />
                       {replyError && <p className="text-xs text-red-600">{replyError}</p>}
                       <div className="flex gap-2 justify-end">
@@ -972,11 +964,11 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
 
         {!readOnly ? (
           <div className="mt-auto">
-            <textarea
+            <MarkdownEditor
               value={newComment}
-              onChange={(e) => setNewComment(e.target.value)}
+              onChange={setNewComment}
               placeholder={t('info.commentPlaceholder')}
-              className="w-full px-3 py-2 text-sm border border-gray-300 rounded mb-2 focus:border-primary-500 focus:ring-1 focus:ring-primary-200 outline-none resize-none h-24"
+              minRows={3}
             />
             <button
               onClick={addComment}

--- a/src/index.css
+++ b/src/index.css
@@ -390,6 +390,12 @@ hr.page-break::before {
 .vutt-md {
   overflow-wrap: break-word;
 }
+
+/* Kommentaaride markdown: pikad URL-id ei tohi layout'i lõhkuda */
+.vutt-md-comment {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
 .vutt-md h1 { font-size: 1.5rem; font-weight: 700; margin: 0.5rem 0; }
 .vutt-md h2 { font-size: 1.25rem; font-weight: 700; margin: 0.5rem 0; }
 .vutt-md h3 { font-size: 1.1rem; font-weight: 600; margin: 0.5rem 0; }

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -154,7 +154,11 @@
       "section": "Transcription",
       "selectNoText": "Select untranscribed",
       "button": "Transcribe ({{count}})",
-      "model": { "label": "Model", "print": "Print", "hand": "Handwriting" },
+      "model": {
+        "label": "Model",
+        "print": "Print",
+        "hand": "Handwriting"
+      },
       "progress": "OCR: {{ready}}/{{total}} done, {{errors}} failed",
       "confirm": {
         "line1": "{{count}} pages will be re-sent to OCR.",
@@ -164,7 +168,12 @@
         "cancel": "Cancel"
       },
       "error": "Failed to start re-OCR.",
-      "badge": { "noText": "no text", "processing": "OCR running", "ready": "OCR ready for review", "error": "OCR failed" }
+      "badge": {
+        "noText": "no text",
+        "processing": "OCR running",
+        "ready": "OCR ready for review",
+        "error": "OCR failed"
+      }
     },
     "tabs": {
       "replace": "Replace pages"
@@ -305,7 +314,15 @@
     "replyPlaceholder": "Write a reply...",
     "sendReply": "Send reply",
     "saveEdit": "Save",
-    "cancelEdit": "Cancel"
+    "cancelEdit": "Cancel",
+    "commentHistory": "History",
+    "restoreText": "Restore this text",
+    "restoreComment": "Restore comment",
+    "deletedComments": "Deleted comments",
+    "noDeletedComments": "No deleted comments found",
+    "noOlderVersions": "No earlier versions",
+    "historyTruncated": "Showing history of the last 100 commits.",
+    "restoreError": "Restore failed"
   },
   "zotero": {
     "hint": "Zotero: use the browser extension's \"Save to Zotero\" button"

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -154,7 +154,11 @@
       "section": "Transkriptsioon",
       "selectNoText": "Vali tekstita",
       "button": "Transkribeeri ({{count}})",
-      "model": { "label": "Mudel", "print": "Trükitekst", "hand": "Käsikiri" },
+      "model": {
+        "label": "Mudel",
+        "print": "Trükitekst",
+        "hand": "Käsikiri"
+      },
       "progress": "OCR: {{ready}}/{{total}} valmis, {{errors}} veaga",
       "confirm": {
         "line1": "{{count}} lehte saadetakse uuesti OCR-i.",
@@ -164,7 +168,12 @@
         "cancel": "Tühista"
       },
       "error": "Re-OCR alustamine ebaõnnestus.",
-      "badge": { "noText": "tekstita", "processing": "OCR töötab", "ready": "OCR valmis ülevaatamiseks", "error": "OCR ebaõnnestus" }
+      "badge": {
+        "noText": "tekstita",
+        "processing": "OCR töötab",
+        "ready": "OCR valmis ülevaatamiseks",
+        "error": "OCR ebaõnnestus"
+      }
     },
     "tabs": {
       "replace": "Asenda leheküljed"
@@ -305,7 +314,15 @@
     "replyPlaceholder": "Kirjuta vastus...",
     "sendReply": "Saada vastus",
     "saveEdit": "Salvesta",
-    "cancelEdit": "Tühista"
+    "cancelEdit": "Tühista",
+    "commentHistory": "Ajalugu",
+    "restoreText": "Taasta see tekst",
+    "restoreComment": "Taasta kommentaar",
+    "deletedComments": "Kustutatud kommentaarid",
+    "noDeletedComments": "Kustutatud kommentaare ei leitud",
+    "noOlderVersions": "Varasemaid versioone ei ole",
+    "historyTruncated": "Näidatakse viimase 100 commiti ajalugu.",
+    "restoreError": "Taastamine ebaõnnestus"
   },
   "zotero": {
     "hint": "Zotero: kasuta brauserilaiendi \"Save to Zotero\" nuppu"

--- a/src/services/commentHistoryService.ts
+++ b/src/services/commentHistoryService.ts
@@ -1,0 +1,75 @@
+import { Page, Annotation } from '../types';
+import { FILE_API_URL } from '../config';
+import { fetchWithTimeout, getAuthHeaders } from '../utils/fetchWithTimeout';
+
+export interface CommentVersion {
+  commit_hash: string;
+  timestamp: string;
+  author: string;
+  text: string;
+}
+
+export interface DeletedComment {
+  id: string;
+  text: string;
+  author: string;
+  created_at: string;
+  replies: Annotation['replies'];
+  last_seen_commit: string;
+}
+
+export interface CommentHistory {
+  versions: Record<string, CommentVersion[]>;
+  deleted: DeletedComment[];
+  truncated: boolean;
+}
+
+function pageFileNames(page: Page): { original_path: string; file_name: string } {
+  const imageFilename = page.image_url.split('/').pop() || '';
+  const file_name = imageFilename.replace(/\.[^/.]+$/, '') + '.txt';
+  return {
+    original_path: page.original_path || page.originaal_kataloog || '',
+    file_name,
+  };
+}
+
+export async function fetchCommentHistory(
+  page: Page,
+  authToken?: string,
+): Promise<CommentHistory> {
+  const response = await fetchWithTimeout(`${FILE_API_URL}/page-comments/history`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
+    body: JSON.stringify(pageFileNames(page)),
+    timeout: 30000,
+  });
+  if (!response.ok) {
+    const e = await response.json().catch(() => ({}));
+    throw new Error(e.detail || `History failed: ${response.status}`);
+  }
+  const data = await response.json();
+  return {
+    versions: data.versions || {},
+    deleted: data.deleted || [],
+    truncated: !!data.truncated,
+  };
+}
+
+export async function restoreComment(
+  page: Page,
+  params: { mode: 'version' | 'deleted'; comment_id: string; commit_hash: string },
+  authToken?: string,
+): Promise<Annotation[]> {
+  const response = await fetchWithTimeout(`${FILE_API_URL}/page-comments/restore`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
+    body: JSON.stringify({ ...pageFileNames(page), ...params }),
+    timeout: 30000,
+  });
+  if (!response.ok) {
+    const e = await response.json().catch(() => ({}));
+    throw new Error(e.detail || `Restore failed: ${response.status}`);
+  }
+  const data = await response.json();
+  return data.comments || [];
+}

--- a/tests/test_comment_history_ops.py
+++ b/tests/test_comment_history_ops.py
@@ -1,0 +1,129 @@
+"""Testid kommentaaride git-ajaloo arvutusele (päris ajutine git-repo)."""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from git import Repo
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import server.git_ops as git_ops
+import server.comment_history_ops as cho
+
+
+def _page_json(comments):
+    return json.dumps({"comments": comments}, ensure_ascii=False, indent=2)
+
+
+def _c(cid, text, author="u", created="2026-01-01T00:00:00", replies=None):
+    return {"id": cid, "text": text, "author": author,
+            "created_at": created, "replies": replies or []}
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """Git-repo, kus pg1.json comments muutub mitme commiti jooksul."""
+    r = Repo.init(str(tmp_path))
+    with r.config_writer() as cw:
+        cw.set_value("user", "name", "t").set_value("user", "email", "t@t")
+    folder = tmp_path / "1690-w1"
+    folder.mkdir()
+    jp = folder / "pg1.json"
+    rel = os.path.relpath(str(jp), str(tmp_path))
+
+    def commit(comments, msg):
+        jp.write_text(_page_json(comments), encoding="utf-8")
+        r.index.add([rel])
+        r.index.commit(msg)
+
+    # c1: tekst muutub A → B → C; c2 kustutatakse; c3 lisandub hiljem
+    commit([_c("c1", "A"), _c("c2", "X", replies=[{"id": "r1", "text": "vastus"}])], "v1")
+    commit([_c("c1", "B"), _c("c2", "X2", replies=[{"id": "r1", "text": "vastus"}])], "v2")
+    commit([_c("c1", "C")], "v3 (c2 kustutatud)")
+    commit([_c("c1", "C"), _c("c3", "uus")], "v4")
+
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: r)
+    return {"repo": r, "rel": rel, "folder": folder}
+
+
+def test_versions_only_historical_differing(repo):
+    current = [_c("c1", "C"), _c("c3", "uus")]
+    res = cho.build_comment_history(repo["rel"], current)
+    texts = [v["text"] for v in res["versions"].get("c1", [])]
+    assert texts == ["B", "A"]
+    assert "c3" not in res["versions"]
+
+
+def test_deleted_keeps_last_state_before_deletion(repo):
+    current = [_c("c1", "C"), _c("c3", "uus")]
+    res = cho.build_comment_history(repo["rel"], current)
+    deleted_ids = {d["id"]: d for d in res["deleted"]}
+    assert "c2" in deleted_ids
+    assert deleted_ids["c2"]["text"] == "X2"
+    assert deleted_ids["c2"]["replies"] == [{"id": "r1", "text": "vastus"}]
+
+
+def test_dedup_consecutive_identical(repo, monkeypatch):
+    current = [_c("c1", "A")]
+    res = cho.build_comment_history(repo["rel"], current)
+    texts = [v["text"] for v in res["versions"].get("c1", [])]
+    assert texts == ["C", "B"]
+
+
+def test_truncated_flag(repo):
+    res = cho.build_comment_history(repo["rel"], [_c("c1", "C")], max_count=2)
+    assert res["truncated"] is True
+    res2 = cho.build_comment_history(repo["rel"], [_c("c1", "C")], max_count=100)
+    assert res2["truncated"] is False
+
+
+def test_malformed_json_commit_does_not_crash(repo, monkeypatch):
+    real = cho.get_file_at_commit
+    calls = {"n": 0}
+
+    def flaky(rel, h):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "{ broken json"
+        return real(rel, h)
+
+    monkeypatch.setattr(cho, "get_file_at_commit", flaky)
+    res = cho.build_comment_history(repo["rel"], [_c("c1", "C")])
+    assert isinstance(res["versions"], dict)
+    assert any(v["text"] in ("B", "A") for v in res["versions"].get("c1", []))
+
+
+def test_extract_comments_meta_content_wrapper():
+    content = json.dumps({"meta_content": {"comments": [_c("c1", "Z")]}})
+    assert cho.find_comment_in_content(content, "c1")["text"] == "Z"
+
+
+def test_extract_comments_invalid_json_returns_none():
+    assert cho.find_comment_in_content("{ not json", "c1") is None
+
+
+def test_apply_restore_version_overwrites_text_keeps_replies():
+    current = [_c("c1", "uus", replies=[{"id": "r9", "text": "praegune vastus"}])]
+    new, err = cho.apply_comment_restore(current, _c("c1", "vana"), "version")
+    assert err is None
+    assert new[0]["text"] == "vana"
+    assert new[0]["replies"] == [{"id": "r9", "text": "praegune vastus"}]
+
+
+def test_apply_restore_version_missing_id_errors():
+    new, err = cho.apply_comment_restore([_c("c1", "x")], _c("cX", "y"), "version")
+    assert new is None and err[0] == 404
+
+
+def test_apply_restore_deleted_appends():
+    new, err = cho.apply_comment_restore([_c("c1", "x")], _c("c2", "tagasi"), "deleted")
+    assert err is None
+    assert [c["id"] for c in new] == ["c1", "c2"]
+
+
+def test_apply_restore_deleted_conflict():
+    new, err = cho.apply_comment_restore([_c("c1", "x")], _c("c1", "y"), "deleted")
+    assert new is None and err[0] == 409

--- a/tests/test_page_comments_endpoints.py
+++ b/tests/test_page_comments_endpoints.py
@@ -1,0 +1,123 @@
+"""Endpoint-testid: /page-comments/history ja /page-comments/restore."""
+import json
+import os
+
+import pytest
+from git import Repo
+
+
+def test_history_rejects_non_basename_filename(client, login, backend_env):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/history",
+        json={"original_path": "1690-w1", "file_name": "../escape.txt"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_history_requires_editor(client, login, backend_env):
+    r = client.post(
+        "/page-comments/history",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt"},
+    )
+    assert r.status_code == 401
+
+
+@pytest.fixture
+def page_repo(backend_env, tmp_path, monkeypatch):
+    """Git-repo lehe pg1.json-iga: c1 muudeti, c2 kustutati."""
+    import server.git_ops as git_ops
+    import server.routers.editing as editing
+
+    data_dir = tmp_path / "data"
+    folder = data_dir / "1690-w1"
+    folder.mkdir(parents=True)
+    r = Repo.init(str(data_dir))
+    with r.config_writer() as cw:
+        cw.set_value("user", "name", "t").set_value("user", "email", "t@t")
+
+    txt = folder / "pg1.txt"
+    jp = folder / "pg1.json"
+    txt.write_text("lehe tekst", encoding="utf-8")
+
+    def commit(comments, msg):
+        jp.write_text(json.dumps({"comments": comments}, ensure_ascii=False, indent=2),
+                      encoding="utf-8")
+        r.index.add([os.path.relpath(str(txt), str(data_dir)),
+                     os.path.relpath(str(jp), str(data_dir))])
+        r.index.commit(msg)
+
+    c1 = {"id": "c1", "text": "vana", "author": "u", "created_at": "2026-01-01T00:00:00", "replies": []}
+    c2 = {"id": "c2", "text": "kustutatav", "author": "u", "created_at": "2026-01-01T00:00:00", "replies": []}
+    commit([c1, c2], "v1")
+    commit([{**c1, "text": "uus"}], "v2 (c2 kustutatud, c1 muudetud)")
+
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: r)
+    monkeypatch.setattr(editing, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(editing, "sync_work_to_meilisearch_async", lambda *a, **k: None)
+
+    v1_hash = list(r.iter_commits())[-1].hexsha
+    return {"repo": r, "folder": folder, "v1_hash": v1_hash, "jp": jp}
+
+
+def test_restore_version_overwrites_text(client, login, page_repo):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "version", "comment_id": "c1", "commit_hash": page_repo["v1_hash"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    comments = r.json()["comments"]
+    assert next(c for c in comments if c["id"] == "c1")["text"] == "vana"
+    on_disk = json.loads(page_repo["jp"].read_text(encoding="utf-8"))["comments"]
+    assert next(c for c in on_disk if c["id"] == "c1")["text"] == "vana"
+
+
+def test_restore_deleted_appends(client, login, page_repo):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "deleted", "comment_id": "c2", "commit_hash": page_repo["v1_hash"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200, r.text
+    assert any(c["id"] == "c2" for c in r.json()["comments"])
+
+
+def test_restore_rejects_commit_outside_history(client, login, page_repo):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "version", "comment_id": "c1", "commit_hash": "0" * 40},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 400, r.text
+
+
+def test_restore_version_missing_comment_in_commit(client, login, page_repo):
+    token = login("editor", "editorpass")
+    v2_hash = list(page_repo["repo"].iter_commits())[0].hexsha
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "version", "comment_id": "c2", "commit_hash": v2_hash},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_restore_deleted_conflict_when_id_exists(client, login, page_repo):
+    token = login("editor", "editorpass")
+    r = client.post(
+        "/page-comments/restore",
+        json={"original_path": "1690-w1", "file_name": "pg1.txt",
+              "mode": "deleted", "comment_id": "c1", "commit_hash": page_repo["v1_hash"]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 409, r.text


### PR DESCRIPTION
## Kokkuvõte
- lisab lehekülje kommentaaridele ja vastustele MarkdownEditor/MarkdownView toe koos soft line breakidega
- lisab git-ajaloost arvutatavad kommentaariversioonid ja kustutatud kommentaaride taastamise endpointid
- lisab editor+ UI varasemate tekstiversioonide ja kustutatud kommentaaride taastamiseks

## Kontroll
- npm run typecheck
- npm run build
- .venv/bin/python -m pytest tests/test_comment_history_ops.py -v
- .venv/bin/python -m pytest tests/test_page_comments_endpoints.py -v
- .venv/bin/python -m pytest -q