### PR TITLE
fix: markdown-redaktori kõrgus püsib eelvaate-vahetusel

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -168,21 +168,21 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         </div>
       )}
 
-      {/* Sisu */}
+      {/* Sisu. Tekstiala jääb DOM-i ka eelvaate ajal (peidetud CSS-iga), et
+          kasutaja venitatud kõrgus ei kaoks tabi vahetusel. */}
       <div className="relative">
-        {tab === 'write' ? (
-          <textarea
-            ref={textareaRef}
-            id={id}
-            value={value}
-            disabled={disabled}
-            placeholder={placeholder}
-            rows={minRows}
-            onChange={e => onChange(e.target.value)}
-            onMouseUp={handleTextareaMouseUp}
-            className="w-full px-3 py-2 text-sm border border-gray-300 rounded-b focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y font-mono leading-relaxed block"
-          />
-        ) : (
+        <textarea
+          ref={textareaRef}
+          id={id}
+          value={value}
+          disabled={disabled}
+          placeholder={placeholder}
+          rows={minRows}
+          onChange={e => onChange(e.target.value)}
+          onMouseUp={handleTextareaMouseUp}
+          className={`w-full px-3 py-2 text-sm border border-gray-300 rounded-b focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none resize-y font-mono leading-relaxed block${tab === 'write' ? '' : ' hidden'}`}
+        />
+        {tab === 'preview' && (
           <div className="w-full min-h-[80px] px-3 py-2 text-sm border border-gray-300 rounded-b bg-white">
             {value.trim()
               ? <MarkdownView content={value} />

--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -1096,7 +1096,7 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
               value={newComment}
               onChange={setNewComment}
               placeholder={t('info.commentPlaceholder')}
-              minRows={3}
+              minRows={5}
             />
             <button
               onClick={addComment}


### PR DESCRIPTION
## Kokkuvõte
- Tekstiala jääb DOM-i ka eelvaate ajal (peidetud CSS-iga) → kasutaja venitatud kõrgus ei lähtestu `Kirjuta`/`Eelvaade` vahetusel
- Uue kommentaari kast algab kõrgemana (`minRows` 3 → 5)

## Kontroll
- npm run typecheck
- npm run build
- npx vitest run markdownEditorHelpers (15 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)