### PR TITLE
feat: kommentaaride versiooniajalugu eraldi kaardina + diff-vaade

### DIFF
--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useLocation } from 'react-router-dom';
-import { BookOpen, User, ExternalLink, Download, Edit3, Tag, Search, X, MessageSquare, Trash2, FolderOpen, Bookmark, Check, BookDown, IdCard, SquarePen, FileSliders, Reply, Send, StickyNote, History as HistoryIcon } from 'lucide-react';
+import { BookOpen, User, ExternalLink, Download, Edit3, Tag, Search, X, MessageSquare, Trash2, FolderOpen, Bookmark, Check, BookDown, IdCard, SquarePen, FileSliders, Reply, Send, StickyNote, History as HistoryIcon, ChevronDown, ChevronUp } from 'lucide-react';
 import DownloadModal from '../DownloadModal';
 import { Work, Page, Annotation, ArchiveRef } from '../../types';
 import type { TextAnnotation } from '../../types';
@@ -20,6 +20,7 @@ import { useMeiliIndex } from '../../contexts/MeilisearchContext';
 import { getCollectionColorClasses, getCollectionHierarchy } from '../../services/collectionService';
 import { formatYearDisplay } from '../../utils/yearDisplayUtils';
 import { fetchCommentHistory, restoreComment, CommentHistory } from '../../services/commentHistoryService';
+import { lineDiff } from '../../utils/lineDiff';
 import MarkdownEditor from '../MarkdownEditor';
 import MarkdownView from '../MarkdownView';
 
@@ -84,8 +85,7 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   const [commentHistory, setCommentHistory] = useState<CommentHistory | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
-  const [openHistoryId, setOpenHistoryId] = useState<string | null>(null);
-  const [deletedCardOpen, setDeletedCardOpen] = useState(false);
+  const [restoreOpen, setRestoreOpen] = useState(false);
   const highlightedCommentId = new URLSearchParams(location.search).get('comment');
 
   const isAdmin = isAtLeast(user?.role, 'admin');
@@ -228,8 +228,8 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
     }
   };
 
-  const ensureHistory = async () => {
-    if (commentHistory || historyLoading) return;
+  const loadHistory = async (force = false) => {
+    if (!force && (commentHistory || historyLoading)) return;
     setHistoryLoading(true);
     setHistoryError(null);
     try {
@@ -251,8 +251,7 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
       // Restore-endpoint juba committis kettale — sünkroni ainult seis, ilma teise salvestuseta.
       if (onCommentsRestored) onCommentsRestored(updated);
       else setComments(updated);
-      setCommentHistory(null);
-      setOpenHistoryId(null);
+      await loadHistory(true);   // värskenda ajaloo-kaart uue seisuga
     } catch (e) {
       setHistoryError(e instanceof Error ? e.message : t('info.restoreError'));
     }
@@ -964,34 +963,8 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
                       </div>
                     </div>
                   )}
-                  {openHistoryId === comment.id && (
-                    <div className="mt-3 border-t border-gray-200 pt-2 space-y-2">
-                      {historyLoading && <p className="text-xs text-gray-400">…</p>}
-                      {historyError && <p className="text-xs text-red-600">{historyError}</p>}
-                      {!historyLoading && (commentHistory?.versions[comment.id]?.length ? (
-                        commentHistory.versions[comment.id].map(v => (
-                          <div key={v.commit_hash} className="bg-white border border-gray-100 rounded px-2 py-1.5">
-                            <div className="vutt-md-comment text-sm text-gray-700">
-                              <MarkdownView content={v.text} softBreaks />
-                            </div>
-                            <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
-                              <span>{v.author} · {new Date(v.timestamp).toLocaleString('et-EE')}</span>
-                              <button
-                                onClick={() => doRestore('version', comment.id, v.commit_hash)}
-                                className="text-primary-600 hover:text-primary-800 font-medium"
-                              >
-                                {t('info.restoreText')}
-                              </button>
-                            </div>
-                          </div>
-                        ))
-                      ) : (
-                        <p className="text-xs text-gray-400 italic">{t('info.noOlderVersions')}</p>
-                      ))}
-                    </div>
-                  )}
                   {!readOnly && (
-                    <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity bg-white/95 rounded-md shadow-sm border border-gray-100 px-1 py-0.5">
                       {onReplyToComment && (
                         <button
                           onClick={() => {
@@ -1014,18 +987,6 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
                           <Edit3 size={14} />
                         </button>
                       )}
-                      {canRestore && (
-                        <button
-                          onClick={async () => {
-                            await ensureHistory();
-                            setOpenHistoryId(openHistoryId === comment.id ? null : comment.id);
-                          }}
-                          className="text-gray-400 hover:text-primary-600 p-1 rounded hover:bg-white transition-colors"
-                          title={t('info.commentHistory')}
-                        >
-                          <HistoryIcon size={14} />
-                        </button>
-                      )}
                       <button
                         onClick={() => removeComment(comment.id)}
                         className="text-gray-400 hover:text-red-600 p-1 rounded hover:bg-white transition-colors"
@@ -1040,55 +1001,6 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
             </div>
           ))}
         </div>
-
-        {canRestore && (
-          <div className="mt-3 border-t border-gray-100 pt-3">
-            <button
-              onClick={async () => {
-                await ensureHistory();
-                setDeletedCardOpen(o => !o);
-              }}
-              className="flex items-center gap-1.5 text-xs font-medium text-gray-500 hover:text-gray-700"
-            >
-              <Trash2 size={13} />
-              {t('info.deletedComments')}
-              {commentHistory && ` (${commentHistory.deleted.length})`}
-            </button>
-            {deletedCardOpen && (
-              <div className="mt-2 space-y-2">
-                {historyLoading && <p className="text-xs text-gray-400">…</p>}
-                {historyError && <p className="text-xs text-red-600">{historyError}</p>}
-                {!historyLoading && commentHistory && (
-                  commentHistory.deleted.length === 0 ? (
-                    <p className="text-xs text-gray-400 italic">{t('info.noDeletedComments')}</p>
-                  ) : (
-                    <>
-                      {commentHistory.deleted.map(d => (
-                        <div key={d.id} className="bg-gray-50 border border-gray-100 rounded px-2 py-1.5">
-                          <div className="vutt-md-comment text-sm text-gray-700">
-                            <MarkdownView content={d.text} softBreaks />
-                          </div>
-                          <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
-                            <span>{d.author} · {new Date(d.created_at).toLocaleString('et-EE')}</span>
-                            <button
-                              onClick={() => doRestore('deleted', d.id, d.last_seen_commit)}
-                              className="text-primary-600 hover:text-primary-800 font-medium"
-                            >
-                              {t('info.restoreComment')}
-                            </button>
-                          </div>
-                        </div>
-                      ))}
-                      {commentHistory.truncated && (
-                        <p className="text-xs text-gray-400 italic">{t('info.historyTruncated')}</p>
-                      )}
-                    </>
-                  )
-                )}
-              </div>
-            )}
-          </div>
-        )}
 
         {!readOnly ? (
           <div className="mt-auto">
@@ -1112,6 +1024,132 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
           </div>
         )}
       </div>
+
+      {/* Versiooniajalugu / taastamine — eraldi kaart kõige all (kontseptuaalselt
+          erinev igapäevasest kommenteerimisest: muudetud kommentaaride varasemad
+          versioonid diffina + kustutatud kommentaaride taaste). Ainult editor+. */}
+      {canRestore && (
+        <div className="mt-4 bg-white rounded-lg border border-gray-200 shadow-sm">
+          <button
+            onClick={async () => { await loadHistory(); setRestoreOpen(o => !o); }}
+            className="flex items-center gap-2 w-full px-5 py-3 text-left text-gray-700 hover:bg-gray-50 rounded-lg"
+          >
+            <HistoryIcon size={18} className="text-primary-600" />
+            <h4 className="font-bold">{t('info.versionHistory')}</h4>
+            {commentHistory && (
+              <span className="ml-1 text-xs text-gray-400">
+                ({Object.keys(commentHistory.versions).length + commentHistory.deleted.length})
+              </span>
+            )}
+            {restoreOpen
+              ? <ChevronUp size={16} className="ml-auto text-gray-400" />
+              : <ChevronDown size={16} className="ml-auto text-gray-400" />}
+          </button>
+
+          {restoreOpen && (
+            <div className="px-5 pb-5 space-y-5">
+              {historyLoading && <p className="text-xs text-gray-400">…</p>}
+              {historyError && <p className="text-xs text-red-600">{historyError}</p>}
+              {!historyLoading && commentHistory && (
+                <>
+                  {/* Muudetud kommentaaride varasemad versioonid (diff vana → praegune) */}
+                  <div>
+                    <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
+                      {t('info.editedComments')}
+                    </h5>
+                    {Object.keys(commentHistory.versions).length === 0 ? (
+                      <p className="text-xs text-gray-400 italic">{t('info.noOlderVersions')}</p>
+                    ) : (
+                      <div className="space-y-3">
+                        {Object.entries(commentHistory.versions).map(([cid, versions]) => {
+                          const cur = comments.find(c => c.id === cid);
+                          return (
+                            <div key={cid} className="border-l-2 border-gray-200 pl-3">
+                              {cur && (
+                                <p className="text-xs text-gray-500 mb-1.5 truncate">
+                                  <span className="font-semibold text-primary-700">{cur.author}</span>
+                                  {cur.text ? ` — ${cur.text.replace(/\s+/g, ' ').slice(0, 80)}` : ''}
+                                </p>
+                              )}
+                              <div className="space-y-2">
+                                {versions.map(v => (
+                                  <div key={v.commit_hash} className="bg-gray-50 border border-gray-100 rounded overflow-hidden">
+                                    <div>
+                                      {lineDiff(v.text, cur?.text ?? '').map((d, idx) => (
+                                        <div
+                                          key={idx}
+                                          className={`font-mono text-xs whitespace-pre-wrap break-words px-2 py-0.5 border-l-2 ${
+                                            d.type === 'add'
+                                              ? 'bg-green-50 text-green-900 border-green-400'
+                                              : d.type === 'del'
+                                                ? 'bg-red-50 text-red-900 border-red-300'
+                                                : 'text-gray-500 border-transparent'
+                                          }`}
+                                        >
+                                          <span className="select-none opacity-60 mr-1">
+                                            {d.type === 'add' ? '+' : d.type === 'del' ? '−' : ' '}
+                                          </span>
+                                          {d.text || ' '}
+                                        </div>
+                                      ))}
+                                    </div>
+                                    <div className="flex justify-between items-center text-xs text-gray-400 px-2 py-1 bg-white border-t border-gray-100">
+                                      <span>{v.author} · {new Date(v.timestamp).toLocaleString('et-EE')}</span>
+                                      <button
+                                        onClick={() => doRestore('version', cid, v.commit_hash)}
+                                        className="text-primary-600 hover:text-primary-800 font-medium"
+                                      >
+                                        {t('info.restoreText')}
+                                      </button>
+                                    </div>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Kustutatud kommentaarid */}
+                  <div>
+                    <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
+                      {t('info.deletedComments')} ({commentHistory.deleted.length})
+                    </h5>
+                    {commentHistory.deleted.length === 0 ? (
+                      <p className="text-xs text-gray-400 italic">{t('info.noDeletedComments')}</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {commentHistory.deleted.map(d => (
+                          <div key={d.id} className="bg-gray-50 border border-gray-100 rounded px-2 py-1.5">
+                            <div className="vutt-md-comment text-sm text-gray-700">
+                              <MarkdownView content={d.text} softBreaks />
+                            </div>
+                            <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
+                              <span>{d.author} · {new Date(d.created_at).toLocaleString('et-EE')}</span>
+                              <button
+                                onClick={() => doRestore('deleted', d.id, d.last_seen_commit)}
+                                className="text-primary-600 hover:text-primary-800 font-medium"
+                              >
+                                {t('info.restoreComment')}
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {commentHistory.truncated && (
+                    <p className="text-xs text-gray-400 italic">{t('info.historyTruncated')}</p>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -316,6 +316,8 @@
     "saveEdit": "Save",
     "cancelEdit": "Cancel",
     "commentHistory": "History",
+    "versionHistory": "Version history",
+    "editedComments": "Edited comments",
     "restoreText": "Restore this text",
     "restoreComment": "Restore comment",
     "deletedComments": "Deleted comments",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -316,6 +316,8 @@
     "saveEdit": "Salvesta",
     "cancelEdit": "Tühista",
     "commentHistory": "Ajalugu",
+    "versionHistory": "Versiooniajalugu",
+    "editedComments": "Muudetud kommentaarid",
     "restoreText": "Taasta see tekst",
     "restoreComment": "Taasta kommentaar",
     "deletedComments": "Kustutatud kommentaarid",

--- a/src/utils/__tests__/lineDiff.test.ts
+++ b/src/utils/__tests__/lineDiff.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { lineDiff } from '../lineDiff';
+
+describe('lineDiff', () => {
+  it('märgib täiesti erineva üherealise teksti del + add', () => {
+    expect(lineDiff('A', 'C')).toEqual([
+      { type: 'del', text: 'A' },
+      { type: 'add', text: 'C' },
+    ]);
+  });
+
+  it('identne tekst on ainult context', () => {
+    expect(lineDiff('sama\ntekst', 'sama\ntekst')).toEqual([
+      { type: 'context', text: 'sama' },
+      { type: 'context', text: 'tekst' },
+    ]);
+  });
+
+  it('säilitab muutmata read ja märgib ainult muudetud rea', () => {
+    const res = lineDiff('rida1\nvana\nrida3', 'rida1\nuus\nrida3');
+    expect(res).toEqual([
+      { type: 'context', text: 'rida1' },
+      { type: 'del', text: 'vana' },
+      { type: 'add', text: 'uus' },
+      { type: 'context', text: 'rida3' },
+    ]);
+  });
+
+  it('lisatud rida = add', () => {
+    expect(lineDiff('rida1', 'rida1\nrida2')).toEqual([
+      { type: 'context', text: 'rida1' },
+      { type: 'add', text: 'rida2' },
+    ]);
+  });
+
+  it('eemaldatud rida = del', () => {
+    expect(lineDiff('rida1\nrida2', 'rida1')).toEqual([
+      { type: 'context', text: 'rida1' },
+      { type: 'del', text: 'rida2' },
+    ]);
+  });
+
+  it('tühi vana → kõik add', () => {
+    expect(lineDiff('', 'uus')).toEqual([{ type: 'add', text: 'uus' }]);
+  });
+});

--- a/src/utils/lineDiff.ts
+++ b/src/utils/lineDiff.ts
@@ -1,0 +1,52 @@
+// Lihtne reapõhine diff (LCS) kahe teksti vahel. Kasutatakse kommentaaride
+// varasema versiooni ja praeguse seisu võrdluseks (sama punane/roheline stiil
+// nagu HistoryTab/Review git-diffidel). Komentaarid on lühikesed → O(m·n) sobib.
+
+export type DiffLineType = 'add' | 'del' | 'context';
+
+export interface DiffLine {
+  type: DiffLineType;
+  text: string;
+}
+
+/**
+ * Reapõhine diff vanast (`oldText`) uue (`newText`) suunas.
+ * `del` = ainult vanas (eemaldatud), `add` = ainult uues (lisatud),
+ * `context` = mõlemas (muutmata).
+ */
+export function lineDiff(oldText: string, newText: string): DiffLine[] {
+  // Tühi string = null read (mitte üks tühi rida), et diff ei näitaks tühja müra.
+  const a = oldText ? oldText.split('\n') : [];
+  const b = newText ? newText.split('\n') : [];
+  const m = a.length;
+  const n = b.length;
+
+  // LCS pikkuste tabel (tagant ettepoole).
+  const lcs: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j]
+        ? lcs[i + 1][j + 1] + 1
+        : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      out.push({ type: 'context', text: a[i] });
+      i++; j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ type: 'del', text: a[i] });
+      i++;
+    } else {
+      out.push({ type: 'add', text: b[j] });
+      j++;
+    }
+  }
+  while (i < m) { out.push({ type: 'del', text: a[i] }); i++; }
+  while (j < n) { out.push({ type: 'add', text: b[j] }); j++; }
+  return out;
+}


### PR DESCRIPTION
## Kokkuvõte
Kommentaaride versioonide/taastamise UI ümberkujundus kasutaja tagasiside põhjal:
- **Eraldi "Versiooniajalugu" kaart kõige all** (alla uue kommentaari kasti) — kontseptuaalselt erinev igapäevasest kommenteerimisest. Varem oli "Kustutatud kommentaarid" segadusseajavalt uue kommentaari kasti kohal.
- **Versiooni-nupp eemaldatud** kommentaari hõljuvast nupureast; koondatud alla.
- **Varasemad versioonid diffina** (vana → praegune), sama punane/roheline stiil nagu HistoryTab/Review git-diffidel. Uus puhas reapõhine LCS-diff `src/utils/lineDiff.ts`.
- **Hõljuv nupurida** (vasta/toimeta/kustuta) sai tausta → loetav teksti kohal.

## Kontroll
- npm run typecheck
- npm run build
- npx vitest run (540 passed, sh 6 uut lineDiff testi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)