### PR TITLE
fix: kommentaari-mustandi salvestamine lahkumisel + markdown-redaktori kerimishüpe

### DIFF
--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -29,6 +29,9 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const [tab, setTab] = useState<'write' | 'preview'>('write');
   const [showHelp, setShowHelp] = useState(false);
 
+  // Tabi vahetusel salvestatud valik, et fookus+kursor säiliks 'write'-i naasmisel.
+  const tabSelRef = useRef<{ start: number; end: number } | null>(null);
+
   // Lingi-popover
   const [linkOpen, setLinkOpen] = useState(false);
   const [linkText, setLinkText] = useState('');
@@ -80,7 +83,9 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     requestAnimationFrame(() => {
       const ta = textareaRef.current;
       if (!ta) return;
-      ta.focus();
+      // preventScroll: muidu keriks ümbritsev overflow-y-auto konteiner
+      // fookuse peale tekstiala juurde ("kuva hüppab märkmete juurde").
+      ta.focus({ preventScroll: true });
       ta.setSelectionRange(res.start, res.end);
     });
   };
@@ -124,7 +129,7 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     requestAnimationFrame(() => {
       const ta = textareaRef.current;
       if (!ta) return;
-      ta.focus();
+      ta.focus({ preventScroll: true });
       ta.setSelectionRange(savedSel.current.start, savedSel.current.end);
     });
   };
@@ -136,10 +141,25 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   };
 
   // Tabi vahetus sulgeb avatud lingi-popoveri (muidu jääks see kuva üle hõljuma).
+  // 'write' → 'preview' minekul jätame valiku meelde, et tagasi tulles fookus säiliks.
   const switchTab = (next: 'write' | 'preview') => {
+    if (next === 'preview' && tab === 'write') {
+      tabSelRef.current = getSel();
+    }
     setLinkOpen(false);
     setTab(next);
   };
+
+  // 'write'-i naasmisel taasta fookus + valik (preventScroll, et kuva ei hüppaks).
+  useLayoutEffect(() => {
+    if (tab !== 'write' || !tabSelRef.current) return;
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const { start, end } = tabSelRef.current;
+    tabSelRef.current = null;
+    ta.focus({ preventScroll: true });
+    ta.setSelectionRange(start, end);
+  }, [tab]);
 
   const toolBtn = 'p-1.5 rounded hover:bg-gray-200 disabled:opacity-40';
   const editingDisabled = disabled || tab === 'preview';

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -82,6 +82,8 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   const [page_tags, setPageTags] = useState<(string | LinkedEntity)[]>(page.page_tags || []);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // Salvestamata mustand-tekst kommentaaride paanil (AnnotationsTab) — enne nupule vajutust.
+  const [annotationDraftDirty, setAnnotationDraftDirty] = useState(false);
 
   const [showTranscriptionGuide, setShowTranscriptionGuide] = useState(false);
   const [transcriptionGuideHtml, setTranscriptionGuideHtml] = useState<string>('');
@@ -111,6 +113,8 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   const editableCompartmentRef = useRef(new Compartment());
   const marginaliaCompartmentRef = useRef(new Compartment());
   const handleSaveRef = useRef<() => void>(() => {});
+  // AnnotationsTab registreerib siia kommentaari-mustandi flushi (vt handleSaveWithDrafts)
+  const commentFlushRef = useRef<(() => Annotation[] | null) | null>(null);
   const wrapWithTagRef = useRef<(tag: string) => void>(() => {});
   const isSavingRef = useRef(false);
 
@@ -135,6 +139,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   // Arvutame kas on salvestamata muudatusi (shallow compare, mitte JSON.stringify)
   const hasUnsavedChanges = useMemo(() => {
     if (isDirty) return true;
+    if (annotationDraftDirty) return true;
     if (status !== savedState.status) return true;
     // page_tags: string/LinkedEntity[] võrdlus sisulise JSON-kuju järgi
     if (JSON.stringify(page_tags) !== JSON.stringify(savedState.page_tags)) return true;
@@ -146,7 +151,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     })) return true;
     if (JSON.stringify(textAnnotations) !== JSON.stringify(savedState.text_annotations)) return true;
     return false;
-  }, [isDirty, status, savedState.status, page_tags, savedState.page_tags, comments, savedState.comments, textAnnotations, savedState.text_annotations]);
+  }, [isDirty, annotationDraftDirty, status, savedState.status, page_tags, savedState.page_tags, comments, savedState.comments, textAnnotations, savedState.text_annotations]);
 
   // --- Globaalne Ctrl+F käsitleja — avab CM6 otsingu capture-faasis enne brauserit ---
   useEffect(() => {
@@ -431,6 +436,31 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     }
   }, [page, status, comments, page_tags, textAnnotations, onSave]);
 
+  // Salvestus "Salvesta ja lahku" jaoks: enne salvestust liidab kommentaari-mustandi
+  // (uus kommentaar / pooleli muutmine) kommentaaride hulka, et see ei läheks kaduma.
+  // Tavaline Salvesta-nupp seda EI tee (mustandi postitamine on "Lisa kommentaar").
+  const handleSaveWithDrafts = useCallback(async () => {
+    if (isSavingRef.current) return;
+    const flushed = commentFlushRef.current?.() ?? null;
+    const effectiveComments = flushed ?? comments;
+    isSavingRef.current = true;
+    setIsSaving(true);
+    const text = viewRef.current?.state.doc.toString() ?? '';
+    const updatedPage: Page = { ...page, text_content: text, status, comments: effectiveComments, page_tags, text_annotations: textAnnotations };
+    try {
+      await onSave(updatedPage);
+      if (flushed) setComments(flushed);
+      setSavedState({ status, comments: effectiveComments, page_tags, text_annotations: textAnnotations });
+      setIsDirty(false);
+    } catch (e: any) {
+      console.error('Save error:', e);
+      setSaveError(t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') }));
+    } finally {
+      isSavingRef.current = false;
+      setIsSaving(false);
+    }
+  }, [page, status, comments, page_tags, textAnnotations, onSave, t]);
+
   // Annotatsioonide kohene salvestus (möödub state async viivitusest)
   const handleSaveAnnotations = useCallback(async (updatedComments: Annotation[]) => {
     if (isSavingRef.current) return;
@@ -469,8 +499,9 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
 
   useEffect(() => {
     handleSaveRef.current = handleSave;
-    if (triggerSave) triggerSave.current = handleSave;
-  }, [handleSave, triggerSave]);
+    // triggerSave'i kasutab AINULT "Salvesta ja lahku" (Workspace) → flush-variant.
+    if (triggerSave) triggerSave.current = handleSaveWithDrafts;
+  }, [handleSave, handleSaveWithDrafts, triggerSave]);
 
   // --- Toolbar toimingud ---
   const wrapWithTag = useCallback((tag: string) => {
@@ -1150,6 +1181,8 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
             setPageTags={setPageTags}
             comments={comments}
             setComments={setComments}
+            onDraftChange={setAnnotationDraftDirty}
+            flushRef={commentFlushRef}
             onSaveAnnotations={handleSaveAnnotations}
             onCommentsRestored={handleCommentsRestored}
             onReplyToComment={handleReplyToComment}

--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -31,6 +31,13 @@ interface AnnotationsTabProps {
   setPageTags: (tags: (string | LinkedEntity)[]) => void;
   comments: Annotation[];
   setComments: (comments: Annotation[]) => void;
+  // Teavitab parenti salvestamata mustand-tekstist (uus kommentaar / kommentaari muutmine),
+  // et lehelt lahkumise hoiatus käivituks ka enne "Lisa kommentaar" nuppu.
+  onDraftChange?: (hasDraft: boolean) => void;
+  // Parent saab siit kätte funktsiooni, mis liidab mustandi kommentaaride hulka ja
+  // tühjendab mustandi (kasutatakse "Salvesta ja lahku" ajal). Tagastab uue
+  // kommentaaride massiivi (mille parent salvestab) või null, kui mustandit polnud.
+  flushRef?: React.MutableRefObject<(() => Annotation[] | null) | null>;
   onSaveAnnotations?: (comments: Annotation[]) => Promise<void>;
   // Kommentaarid on serveris juba salvestatud (restore-endpoint commitis) — sünkroni
   // ainult lokaalne + salvestatud baasseis, ÄRA tee teist /save commitit.
@@ -54,6 +61,8 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   setPageTags,
   comments,
   setComments,
+  onDraftChange,
+  flushRef,
   onSaveAnnotations,
   onCommentsRestored,
   onReplyToComment,
@@ -131,6 +140,48 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
     const el = document.getElementById(`comment-${highlightedCommentId}`);
     el?.scrollIntoView({ block: 'center', behavior: 'smooth' });
   }, [highlightedCommentId, comments]);
+
+  // Salvestamata mustand-tekst (uus kommentaar VÕI kommentaari muutmine) → teavita
+  // parenti, et lahkumise hoiatus käivituks. Ainult need kaks: nad on lihtsalt
+  // kommentaaride massiivi liidetavad, seega "Salvesta ja lahku" oskab neid säilitada.
+  useEffect(() => {
+    onDraftChange?.(Boolean(newComment.trim() || editingText.trim()));
+  }, [newComment, editingText, onDraftChange]);
+
+  // Komponendi eemaldamisel (nt tabi vahetus) nulli mustand-lipp, et see ei jääks toppama.
+  useEffect(() => () => onDraftChange?.(false), [onDraftChange]);
+
+  // Registreeri flush: liidab mustandi kommentaaridesse ja tühjendab mustandi-välja.
+  // Sünkroonne ja puhas (massiivi-teisendus) → parent saab tagastatud massiivi ühe
+  // /save'iga kettale kirjutada, ilma state-async võistlusteta.
+  useEffect(() => {
+    if (!flushRef) return;
+    flushRef.current = () => {
+      let merged = comments;
+      let changed = false;
+      if (editingCommentId && editingText.trim()) {
+        merged = merged.map(c => c.id === editingCommentId ? { ...c, text: editingText } : c);
+        changed = true;
+      }
+      if (newComment.trim()) {
+        merged = [...merged, {
+          id: Date.now().toString(),
+          text: newComment,
+          author: user?.name || 'Anonüümne',
+          author_username: user?.username,
+          created_at: new Date().toISOString(),
+        }];
+        changed = true;
+      }
+      if (!changed) return null;
+      setNewComment('');
+      setEditingCommentId(null);
+      setEditingText('');
+      onDraftChange?.(false);
+      return merged;
+    };
+    return () => { if (flushRef) flushRef.current = null; };
+  }, [flushRef, comments, editingCommentId, editingText, newComment, user, onDraftChange]);
 
   // Lae kõik olemasolevad märksõnad Meilisearchist
   useEffect(() => {


### PR DESCRIPTION
## Probleem

Lehe kommentaaride paanil (Märkmed) kadus kirjutatud mustand lahkumisel:
1. Lahkumisel ei küsitud kinnitust → tekst kadus.
2. Pärast eelmist fixi tuli hoiatus, aga "Salvesta" salvestas vana `comments`-massiivi mustandist mööda (mustand elas ainult `newComment`/`editingText` väljal, sai kommentaariks alles "Lisa kommentaar" nupuga).
3. Markdown-redaktoris kerima konteiner soovimatult redaktori juurde (nt sõna valik + *kursiiv*), ja Kirjuta↔Eelvaade vahetusel kadus fookus. Sama prosopo Märkmed/Elulugu väljal (sama komponent).

## Lahendus

**Kommentaari-mustand (`AnnotationsTab` + `TextEditor`)**
- `onDraftChange` → parent teab mustandist, lahkumise hoiatus käivitub ka enne "Lisa kommentaar".
- `flushRef`: sünkroonne mustandi → `comments` liitmine; **"Salvesta ja lahku"** (`handleSaveWithDrafts`) salvestab ühe `/save`-commitiga (ei mingit state-async võistlust).
- Tavaline Salvesta-nupp / Ctrl+S jäävad muutmata — ei postita mustandit automaatselt (selleks on "Lisa kommentaar").
- Scope: uus kommentaar + kommentaari-muutmine. Vastus (`replyText`) käib eraldi serveri-endpointi kaudu → teadlikult välja jäetud, et "Salvesta" ei lubaks midagi, mida ta ei salvesta.

**Markdown-redaktor (`MarkdownEditor`)**
- `focus({ preventScroll: true })` nupuriba ja lingi-popoveri teedel → ümbritsev `overflow-y-auto` konteiner ei kerista enam redaktori juurde.
- Tabi vahetusel säilib fookus + kursori valik.

## Test
- `npm run typecheck` puhas; `markdownEditorHelpers` testid (15) läbivad.
- Käsitsi serveris kontrollitud: lahkumine mustandiga → "Salvesta ja lahku" → kommentaar alles; kursiiv/eelvaade ei hüppa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)