### PR TITLE
Refactor work API helpers

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -21,8 +21,8 @@ import BulkGenrePicker from '../components/BulkGenrePicker';
 import { LinkedEntity } from '../types/LinkedEntity';
 import { getEntityLabelsCache } from '../services/entityLabelsService';
 import { Link, useSearchParams } from 'react-router-dom';
-import { FILE_API_URL } from '../config';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+import { bulkAssignCollection, bulkAssignGenre, bulkAssignTags } from '../services/workApi';
 import { getLangCode } from '../utils/getLangCode';
 import { buildLinkedEntityMaps, collectLinkedEntities } from '../utils/buildLinkedEntityMaps';
 import { useCollectionUrlSync } from '../hooks/useCollectionUrlSync';
@@ -436,20 +436,7 @@ const Dashboard: React.FC = () => {
     setBulkAssignLoading(true);
     try {
       const token = localStorage.getItem('vutt_token');
-      const response = await fetchWithTimeout(`${FILE_API_URL}/works/bulk-collection`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({
-          auth_token: token,
-          work_ids: Array.from(selectedWorkIds),
-          // null = "Määramata" → set puhastab kõik; päris kollektsioon → add lisab olemasolevate kõrvale
-          mode: collectionId === null ? 'set' : 'add',
-          collection_id: collectionId
-        }),
-        timeout: 30000
-      });
-
-      const result = await response.json();
+      const result = await bulkAssignCollection(token, Array.from(selectedWorkIds), collectionId);
       if (result.status === 'success') {
         // Tühjenda valik ja uuenda otsing
         setSelectedWorkIds(new Set());
@@ -475,19 +462,7 @@ const Dashboard: React.FC = () => {
     setBulkAssignLoading(true);
     try {
       const token = localStorage.getItem('vutt_token');
-      const response = await fetchWithTimeout(`${FILE_API_URL}/works/bulk-tags`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({
-          auth_token: token,
-          work_ids: Array.from(selectedWorkIds),
-          tags,
-          mode
-        }),
-        timeout: 30000
-      });
-
-      const result = await response.json();
+      const result = await bulkAssignTags(token, Array.from(selectedWorkIds), tags, mode);
       if (result.status === 'success') {
         setSelectedWorkIds(new Set());
         setSelectMode(false);
@@ -511,19 +486,7 @@ const Dashboard: React.FC = () => {
     setBulkAssignLoading(true);
     try {
       const token = localStorage.getItem('vutt_token');
-      const response = await fetchWithTimeout(`${FILE_API_URL}/works/bulk-genre`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-        body: JSON.stringify({
-          auth_token: token,
-          work_ids: Array.from(selectedWorkIds),
-          genre,
-          mode: genre ? 'add' : 'set'
-        }),
-        timeout: 30000
-      });
-
-      const result = await response.json();
+      const result = await bulkAssignGenre(token, Array.from(selectedWorkIds), genre);
       if (result.status === 'success') {
         setSelectedWorkIds(new Set());
         setSelectMode(false);

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -226,8 +226,10 @@ const WorkManage: React.FC = () => {
         if (!cancelled && data.progress && data.progress.active) {
           timer = setTimeout(tick, 4000);
         }
-      } catch {
-        if (!cancelled) timer = setTimeout(tick, 6000);
+      } catch (e) {
+        // HTTP vead (nt 401/403 aegunud token, 404 puuduv teos) on lõplikud:
+        // ära tee taustal lõputut ebaõnnestunud pollimist. Võrgu/timeout'i viga proovi uuesti.
+        if (!cancelled && !(e instanceof ApiError)) timer = setTimeout(tick, 6000);
       }
     };
     tick();

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -16,9 +16,24 @@ import {
 } from 'lucide-react';
 import Header from '../components/Header';
 import PageImageEditorModal from '../components/PageImageEditorModal';
-import { FILE_API_URL } from '../config';
 import { useUser } from '../contexts/UserContext';
-import { fetchWithTimeout, getAuthHeaders } from '../utils/fetchWithTimeout';
+import { ApiError } from '../services/apiClient';
+import {
+  addWorkPages,
+  deleteWork,
+  deleteWorkPages,
+  DeletedWorkPage,
+  getDeletedWorkPages,
+  getReocrStatus,
+  getViewerToken,
+  getWorkMetadata,
+  getWorkPages,
+  reorderWorkPages,
+  replaceWorkPageImage,
+  restoreDeletedWorkPage,
+  startReocrBatch,
+  WorkPageInfo,
+} from '../services/workApi';
 import { naturalCompare } from '../utils/naturalSort';
 import { planChunks } from '../utils/bulkAddChunks';
 import { computeBlockMoveOrder, VisiblePage } from '../utils/blockReorder';
@@ -29,23 +44,8 @@ import { mapReocrState, selectableNoTextFiles, ReocrStatusResponse } from '../ut
 const CHUNK_MAX_FILES = 20;
 const CHUNK_MAX_BYTES = 200 * 1024 * 1024;
 
-interface PageInfo {
-  page_num: number;
-  sequence: number;
-  base_name: string;
-  filename: string;
-  lehekylje_pilt: string;
-  status: string;
-  has_text: boolean;
-}
-
-interface DeletedPage {
-  filename: string;
-  base_name: string;
-  deleted_at: string | null;
-  deleted_by: string | null;
-  commit_hash: string | null;
-}
+type PageInfo = WorkPageInfo;
+type DeletedPage = DeletedWorkPage;
 
 type ActiveTab = 'pages' | 'trash' | 'replace';
 
@@ -138,12 +138,7 @@ const WorkManage: React.FC = () => {
     setLoading(true);
     setLoadError(null);
     try {
-      const res = await fetchWithTimeout(
-        `${FILE_API_URL}/admin/work/${workId}/pages`,
-        { method: 'GET', headers: getAuthHeaders(authToken) }
-      );
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await getWorkPages(workId, authToken);
       if (data.status === 'success') {
         const loaded: PageInfo[] = data.pages || [];
         setPages(loaded);
@@ -164,12 +159,7 @@ const WorkManage: React.FC = () => {
     setTrashLoading(true);
     setTrashError(null);
     try {
-      const res = await fetchWithTimeout(
-        `${FILE_API_URL}/admin/work/${workId}/trash-pages`,
-        { method: 'GET', headers: getAuthHeaders(authToken) }
-      );
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json();
+      const data = await getDeletedWorkPages(workId, authToken);
       if (data.status === 'success') {
         setTrashPages(data.pages || []);
         setTrashLoaded(true);
@@ -186,12 +176,7 @@ const WorkManage: React.FC = () => {
 
   useEffect(() => {
     if (!workId || !authToken) return;
-    fetchWithTimeout(`${FILE_API_URL}/get-work-metadata`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
-      body: JSON.stringify({ work_id: workId })
-    })
-      .then(r => r.json())
+    getWorkMetadata(workId, authToken)
       .then(d => {
         if (d.status === 'success') {
           setWorkTitle(d.metadata?.title || workId || '');
@@ -215,11 +200,7 @@ const WorkManage: React.FC = () => {
     if (!workId || !authToken || !isAdmin) return;
     let cancelled = false;
     const fetchToken = () => {
-      fetchWithTimeout(`${FILE_API_URL}/work/${workId}/viewer-token`, {
-        headers: getAuthHeaders(authToken),
-        timeout: 10000,
-      })
-        .then(r => r.ok ? r.json() : null)
+      getViewerToken(workId, authToken)
         .then(d => {
           if (!cancelled && d?.image_exp && d?.image_sig) {
             setImageToken({ exp: d.image_exp, sig: d.image_sig });
@@ -240,16 +221,10 @@ const WorkManage: React.FC = () => {
 
     const tick = async () => {
       try {
-        const res = await fetchWithTimeout(
-          `${FILE_API_URL}/admin/work/${workId}/reocr-status`,
-          { headers: getAuthHeaders(authToken), timeout: 8000 },
-        );
-        if (res.ok) {
-          const data = await res.json();
-          if (!cancelled) setReocrStatus(data);
-          if (!cancelled && data.progress && data.progress.active) {
-            timer = setTimeout(tick, 4000);
-          }
+        const data = await getReocrStatus<ReocrStatusResponse>(workId, authToken);
+        if (!cancelled) setReocrStatus(data);
+        if (!cancelled && data.progress && data.progress.active) {
+          timer = setTimeout(tick, 4000);
         }
       } catch {
         if (!cancelled) timer = setTimeout(tick, 6000);
@@ -364,16 +339,10 @@ const WorkManage: React.FC = () => {
     if (!workId || !authToken || selectedFiles.size === 0) return;
     setBatchError(null);
     try {
-      const res = await fetchWithTimeout(`${FILE_API_URL}/admin/work/${workId}/reocr-batch`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
-        body: JSON.stringify({ page_filenames: Array.from(selectedFiles), material_type: ocrModel }),
-        timeout: 30000,
+      await startReocrBatch(workId, authToken, {
+        page_filenames: Array.from(selectedFiles),
+        material_type: ocrModel,
       });
-      if (!res.ok) {
-        const d = await res.json().catch(() => ({}));
-        throw new Error(d.detail || t('manage.reocr.error'));
-      }
       setBatchConfirm(false);
       handleClearSelection();
       // Nonce bump taaskäivitab poll-effecti (alustab pollimist), mis teeb ise status-fetchi
@@ -417,19 +386,7 @@ const WorkManage: React.FC = () => {
     setReorderSaving(true);
     setReorderError(null);
     try {
-      const res = await fetchWithTimeout(
-        `${FILE_API_URL}/admin/work/${workId}/reorder-pages`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
-          body: JSON.stringify({ order }),
-          timeout: 30000,
-        }
-      );
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || `HTTP ${res.status}`);
-      }
+      await reorderWorkPages(workId, authToken, order);
       await loadPages();
       // Salvestus = commit → tühjenda valik (uue protsessi eeldus). NB: Liiguta
       // (mustand) EI tühjenda, et saaks sama plokki uuesti liigutada.
@@ -451,25 +408,19 @@ const WorkManage: React.FC = () => {
     setBulkDeleting(true);
     setBulkDeleteError(null);
     try {
-      const res = await fetchWithTimeout(`${FILE_API_URL}/admin/work/${workId}/delete-pages`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...getAuthHeaders(authToken) },
-        body: JSON.stringify({ base_names: baseNames }),
-        timeout: 30000,
-      });
-      if (res.status === 409) {
-        setBulkDeleteError(t('manage.bulkDelete.conflict'));
-        await loadPages();
-        setSelectedFiles(new Set());
-        return;
-      }
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await deleteWorkPages(workId, authToken, baseNames);
       await loadPages();
       if (trashLoaded) loadTrashPages();
       setSelectedFiles(new Set());
       setBulkDeleteConfirm(false);
     } catch (e: any) {
-      setBulkDeleteError(e.message || t('manage.deletePageError'));
+      if (e instanceof ApiError && e.status === 409) {
+        setBulkDeleteError(t('manage.bulkDelete.conflict'));
+        await loadPages();
+        setSelectedFiles(new Set());
+      } else {
+        setBulkDeleteError(e.message || t('manage.deletePageError'));
+      }
     } finally {
       setBulkDeleting(false);
     }
@@ -481,15 +432,7 @@ const WorkManage: React.FC = () => {
     if (!workId || !authToken) throw new Error('Not authorized');
     setReplaceError(null);
 
-    const formData = new FormData();
-    formData.append('file', file);
-
-    const res = await fetchWithTimeout(
-      `${FILE_API_URL}/admin/work/${workId}/page/${pageNum}/replace-image`,
-      { method: 'POST', headers: getAuthHeaders(authToken), body: formData, timeout: 30000 }
-    );
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
+    const data = await replaceWorkPageImage(workId, authToken, pageNum, file);
     if (data.status !== 'success') throw new Error(t('manage.replaceError'));
 
     // Õnnestus: cache-bust + sessionStorage (Workspace tühistab cache'i) + lehtede uuesti laadimine
@@ -526,19 +469,7 @@ const WorkManage: React.FC = () => {
         // Tühistus on tüki-granulaarne: parajasti pooleliolev tükk jõuab veel
         // serverisse committida; katkestus rakendub alles järgmise tüki ees.
         if (cancelRef.current) break;
-        const formData = new FormData();
-        chunk.files.forEach((f) => formData.append('file', f));
-        formData.append('after_page_num', String(chunk.afterPageNum));
-
-        const res = await fetchWithTimeout(
-          `${FILE_API_URL}/admin/work/${workId}/add-pages`,
-          { method: 'POST', headers: getAuthHeaders(authToken), body: formData, timeout: 120000 }
-        );
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({}));
-          throw new Error(err.detail || `HTTP ${res.status}`);
-        }
-        const data = await res.json();
+        const data = await addWorkPages(workId, authToken, chunk.files, chunk.afterPageNum);
         if (data.meili_warning) meiliWarned = true;
         done += chunk.files.length;
         setUploadProgress({ done, total });
@@ -566,11 +497,7 @@ const WorkManage: React.FC = () => {
     setRestoringPage(filename);
     setRestoreMessage(null);
     try {
-      const res = await fetchWithTimeout(
-        `${FILE_API_URL}/admin/work/${workId}/trash-pages/${encodeURIComponent(filename)}/restore`,
-        { method: 'POST', headers: getAuthHeaders(authToken), timeout: 30000 }
-      );
-      const data = await res.json();
+      const data = await restoreDeletedWorkPage(workId, authToken, filename);
       if (data.status === 'success') {
         setRestoreMessage({ text: t('manage.trash.restoreSuccess', { name: filename }), ok: true });
         setTrashPages(prev => prev.filter(p => p.filename !== filename));
@@ -591,15 +518,8 @@ const WorkManage: React.FC = () => {
     setDeletingWork(true);
     setDeleteWorkError(null);
     try {
-      const res = await fetchWithTimeout(
-        `${FILE_API_URL}/admin/work/${workId}`,
-        { method: 'DELETE', headers: getAuthHeaders(authToken), timeout: 15000 }
-      );
-      if (res.ok) {
-        navigate('/');
-      } else {
-        setDeleteWorkError(t('management.deleteWorkError'));
-      }
+      await deleteWork(workId, authToken);
+      navigate('/');
     } catch {
       setDeleteWorkError(t('management.deleteWorkError'));
     } finally {

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -69,10 +69,19 @@ async function apiRequest<T>(
 
   let requestBody: BodyInit | undefined;
   if (body !== undefined) {
-    headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
-    requestBody = headers['Content-Type'] === 'application/json'
-      ? JSON.stringify(body)
-      : body as BodyInit;
+    const isBodyInit = body instanceof FormData
+      || body instanceof URLSearchParams
+      || body instanceof Blob
+      || typeof body === 'string';
+
+    if (isBodyInit) {
+      requestBody = body as BodyInit;
+    } else {
+      headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
+      requestBody = headers['Content-Type'] === 'application/json'
+        ? JSON.stringify(body)
+        : body as BodyInit;
+    }
   }
 
   const response = await fetchWithTimeout(buildUrl(path, options.baseUrl), {

--- a/src/services/workApi.ts
+++ b/src/services/workApi.ts
@@ -1,0 +1,189 @@
+import { LinkedEntity } from '../types/LinkedEntity';
+import { ApiRequestOptions, apiDelete, apiGet, apiPost } from './apiClient';
+
+// Teoste ja haldusvaate backend API abifunktsioonid. Komponendid peaksid siin
+// kasutama domeenimeetodeid, mitte otse URL-e kokku panema.
+
+export interface ApiStatusResponse {
+  status?: string;
+  message?: string;
+  detail?: string;
+}
+
+export interface WorkPageInfo {
+  page_num: number;
+  sequence: number;
+  base_name: string;
+  filename: string;
+  lehekylje_pilt: string;
+  status: string;
+  has_text: boolean;
+}
+
+export interface DeletedWorkPage {
+  filename: string;
+  base_name: string;
+  deleted_at: string | null;
+  deleted_by: string | null;
+  commit_hash: string | null;
+}
+
+export interface WorkPagesResponse extends ApiStatusResponse {
+  pages?: WorkPageInfo[];
+}
+
+export interface DeletedWorkPagesResponse extends ApiStatusResponse {
+  pages?: DeletedWorkPage[];
+}
+
+export interface WorkMetadataResponse extends ApiStatusResponse {
+  metadata?: {
+    title?: string;
+    type?: { id?: string } | null;
+    [key: string]: unknown;
+  };
+}
+
+export interface ViewerTokenResponse {
+  image_exp?: number;
+  image_sig?: string;
+}
+
+export interface ReocrBatchRequest {
+  page_filenames: string[];
+  material_type: 'print' | 'hand';
+}
+
+export interface AddPagesResponse extends ApiStatusResponse {
+  meili_warning?: boolean;
+}
+
+const auth = (token: string | null, options: ApiRequestOptions = {}): ApiRequestOptions => ({
+  ...options,
+  token,
+});
+
+const authJson = (token: string | null, options: ApiRequestOptions = {}): ApiRequestOptions => ({
+  ...auth(token, options),
+  headers: { 'Content-Type': 'application/json', ...options.headers },
+});
+
+export function bulkAssignCollection(
+  token: string | null,
+  workIds: string[],
+  collectionId: string | null,
+): Promise<ApiStatusResponse> {
+  return apiPost<ApiStatusResponse>('/works/bulk-collection', {
+    auth_token: token,
+    work_ids: workIds,
+    // null = "Määramata" → set puhastab kõik; päris kollektsioon → add lisab olemasolevate kõrvale
+    mode: collectionId === null ? 'set' : 'add',
+    collection_id: collectionId,
+  }, authJson(token, { timeout: 30000 }));
+}
+
+export function bulkAssignTags(
+  token: string | null,
+  workIds: string[],
+  tags: LinkedEntity[],
+  mode: 'add' | 'replace' | 'remove',
+): Promise<ApiStatusResponse> {
+  return apiPost<ApiStatusResponse>('/works/bulk-tags', {
+    auth_token: token,
+    work_ids: workIds,
+    tags,
+    mode,
+  }, authJson(token, { timeout: 30000 }));
+}
+
+export function bulkAssignGenre(
+  token: string | null,
+  workIds: string[],
+  genre: LinkedEntity | null,
+): Promise<ApiStatusResponse> {
+  return apiPost<ApiStatusResponse>('/works/bulk-genre', {
+    auth_token: token,
+    work_ids: workIds,
+    genre,
+    mode: genre ? 'add' : 'set',
+  }, authJson(token, { timeout: 30000 }));
+}
+
+export function getWorkPages(workId: string, token: string): Promise<WorkPagesResponse> {
+  return apiGet<WorkPagesResponse>(`/admin/work/${workId}/pages`, auth(token));
+}
+
+export function getDeletedWorkPages(workId: string, token: string): Promise<DeletedWorkPagesResponse> {
+  return apiGet<DeletedWorkPagesResponse>(`/admin/work/${workId}/trash-pages`, auth(token));
+}
+
+export function getWorkMetadata(workId: string, token: string): Promise<WorkMetadataResponse> {
+  return apiPost<WorkMetadataResponse>('/get-work-metadata', { work_id: workId }, authJson(token));
+}
+
+export function getViewerToken(workId: string, token: string): Promise<ViewerTokenResponse> {
+  return apiGet<ViewerTokenResponse>(`/work/${workId}/viewer-token`, auth(token, { timeout: 10000 }));
+}
+
+export function getReocrStatus<T>(workId: string, token: string): Promise<T> {
+  return apiGet<T>(`/admin/work/${workId}/reocr-status`, auth(token, { timeout: 8000 }));
+}
+
+export function startReocrBatch(
+  workId: string,
+  token: string,
+  body: ReocrBatchRequest,
+): Promise<ApiStatusResponse> {
+  return apiPost<ApiStatusResponse>(`/admin/work/${workId}/reocr-batch`, body, authJson(token, { timeout: 30000 }));
+}
+
+export function reorderWorkPages(workId: string, token: string, order: string[]): Promise<ApiStatusResponse> {
+  return apiPost<ApiStatusResponse>(`/admin/work/${workId}/reorder-pages`, { order }, authJson(token, { timeout: 30000 }));
+}
+
+export function deleteWorkPages(workId: string, token: string, baseNames: string[]): Promise<ApiStatusResponse> {
+  return apiPost<ApiStatusResponse>(`/admin/work/${workId}/delete-pages`, { base_names: baseNames }, authJson(token, { timeout: 30000 }));
+}
+
+export function replaceWorkPageImage(
+  workId: string,
+  token: string,
+  pageNum: number,
+  file: File,
+): Promise<ApiStatusResponse> {
+  const formData = new FormData();
+  formData.append('file', file);
+  return apiPost<ApiStatusResponse>(
+    `/admin/work/${workId}/page/${pageNum}/replace-image`,
+    formData,
+    auth(token, { timeout: 30000 }),
+  );
+}
+
+export function addWorkPages(
+  workId: string,
+  token: string,
+  files: File[],
+  afterPageNum: number,
+): Promise<AddPagesResponse> {
+  const formData = new FormData();
+  files.forEach((file) => formData.append('file', file));
+  formData.append('after_page_num', String(afterPageNum));
+  return apiPost<AddPagesResponse>(`/admin/work/${workId}/add-pages`, formData, auth(token, { timeout: 120000 }));
+}
+
+export function restoreDeletedWorkPage(
+  workId: string,
+  token: string,
+  filename: string,
+): Promise<ApiStatusResponse> {
+  return apiPost<ApiStatusResponse>(
+    `/admin/work/${workId}/trash-pages/${encodeURIComponent(filename)}/restore`,
+    undefined,
+    auth(token, { timeout: 30000 }),
+  );
+}
+
+export function deleteWork(workId: string, token: string): Promise<ApiStatusResponse | null> {
+  return apiDelete<ApiStatusResponse | null>(`/admin/work/${workId}`, auth(token, { timeout: 15000 }));
+}


### PR DESCRIPTION
## Kokkuvõte
- lisab `src/services/workApi.ts` teoste ja haldusvaate API meetoditega
- viib Dashboardi bulk-toimingud ja WorkManage'i admin API kõned uude service'isse
- laiendab `apiClient` tuge `FormData`/`Blob`/`URLSearchParams` body'dele

## Kontroll
- `npm run typecheck`
- `npm run build`

Refs #89