### PR TITLE
Refactor TextEditor save logic

### DIFF
--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -20,7 +20,6 @@ import { vuttTheme } from './editor/VuttTheme';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 import { getLangCode } from '../utils/getLangCode';
 import { ErrorBanner } from './ErrorBanner';
-import { replyToComment } from '../services/pageService';
 import { formatYearDisplay } from '../utils/yearDisplayUtils';
 
 // CM6 impordid
@@ -33,6 +32,7 @@ import { findContainer, findInnerPairs } from './editor/wrapTagUtils';
 import { useSpecialChars } from './editor/useSpecialChars';
 import { useCopyPastePlainMarkup } from './editor/useCopyPastePlainMarkup';
 import { useReOcr } from './editor/useReOcr';
+import { useEditorSave, type EditorSavedState } from './editor/useEditorSave';
 import SafeHtml from './SafeHtml';
 
 interface TextEditorProps {
@@ -104,7 +104,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   const [pendingAnnSelection, setPendingAnnSelection] = useState<{ from: number; to: number; text: string } | null>(null);
 
   // Salvestamata muudatuste jälgimine
-  const [savedState, setSavedState] = useState({
+  const [savedState, setSavedState] = useState<EditorSavedState>({
     status: page.status,
     comments: page.comments,
     page_tags: page.page_tags || [],
@@ -120,7 +120,6 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   // AnnotationsTab registreerib siia kommentaari-mustandi flushi (vt handleSaveWithDrafts)
   const commentFlushRef = useRef<(() => Annotation[] | null) | null>(null);
   const wrapWithTagRef = useRef<(tag: string) => void>(() => {});
-  const isSavingRef = useRef(false);
 
   // Kasutaja eelistus (localStorage) + kitsa paani sundrežiim
   const [marginaliaUserMode, setMarginaliaUserMode] = useState<MarginaliaMode>(
@@ -138,6 +137,32 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     authToken,
     viewRef,
     setIsDirty,
+  });
+
+  const {
+    handleSave,
+    handleSaveWithDrafts,
+    handleSaveAnnotations,
+    handleSaveTextAnnotations: saveTextAnnotations,
+    handleDeleteAndSaveTextAnnotation: deleteAndSaveTextAnnotation,
+    handleCommentsRestored,
+    handleReplyToComment,
+  } = useEditorSave({
+    page,
+    status,
+    comments,
+    setComments,
+    page_tags,
+    textAnnotations,
+    setTextAnnotations,
+    onSave,
+    setSavedState,
+    setIsDirty,
+    setIsSaving,
+    setSaveError,
+    viewRef,
+    commentFlushRef,
+    authToken,
   });
 
   // Arvutame kas on salvestamata muudatusi (shallow compare, mitte JSON.stringify)
@@ -331,88 +356,6 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   }, [lang]);
 
   // --- Salvestamine ---
-  const handleSave = useCallback(async () => {
-    if (isSavingRef.current) return;
-    isSavingRef.current = true;
-    setIsSaving(true);
-
-    const text = viewRef.current?.state.doc.toString() ?? '';
-    const updatedPage: Page = { ...page, text_content: text, status, comments, page_tags, text_annotations: textAnnotations };
-
-    try {
-      await onSave(updatedPage);
-      setSavedState({ status, comments, page_tags, text_annotations: textAnnotations });
-      setIsDirty(false);
-    } catch (e: any) {
-      console.error('Save error:', e);
-      setSaveError(t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') }));
-    } finally {
-      isSavingRef.current = false;
-      setIsSaving(false);
-    }
-  }, [page, status, comments, page_tags, textAnnotations, onSave]);
-
-  // Salvestus "Salvesta ja lahku" jaoks: enne salvestust liidab kommentaari-mustandi
-  // (uus kommentaar / pooleli muutmine) kommentaaride hulka, et see ei läheks kaduma.
-  // Tavaline Salvesta-nupp seda EI tee (mustandi postitamine on "Lisa kommentaar").
-  const handleSaveWithDrafts = useCallback(async () => {
-    if (isSavingRef.current) return;
-    const flushed = commentFlushRef.current?.() ?? null;
-    const effectiveComments = flushed ?? comments;
-    isSavingRef.current = true;
-    setIsSaving(true);
-    const text = viewRef.current?.state.doc.toString() ?? '';
-    const updatedPage: Page = { ...page, text_content: text, status, comments: effectiveComments, page_tags, text_annotations: textAnnotations };
-    try {
-      await onSave(updatedPage);
-      if (flushed) setComments(flushed);
-      setSavedState({ status, comments: effectiveComments, page_tags, text_annotations: textAnnotations });
-      setIsDirty(false);
-    } catch (e: any) {
-      console.error('Save error:', e);
-      setSaveError(t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') }));
-    } finally {
-      isSavingRef.current = false;
-      setIsSaving(false);
-    }
-  }, [page, status, comments, page_tags, textAnnotations, onSave, t]);
-
-  // Annotatsioonide kohene salvestus (möödub state async viivitusest)
-  const handleSaveAnnotations = useCallback(async (updatedComments: Annotation[]) => {
-    if (isSavingRef.current) return;
-    isSavingRef.current = true;
-    setIsSaving(true);
-    const text = viewRef.current?.state.doc.toString() ?? '';
-    const updatedPage: Page = { ...page, text_content: text, status, comments: updatedComments, page_tags, text_annotations: textAnnotations };
-    try {
-      await onSave(updatedPage);
-      setSavedState({ status, comments: updatedComments, page_tags, text_annotations: textAnnotations });
-      setIsDirty(false);
-    } catch (e: any) {
-      console.error('Save error:', e);
-      setSaveError(t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') }));
-    } finally {
-      isSavingRef.current = false;
-      setIsSaving(false);
-    }
-  }, [page, status, page_tags, textAnnotations, onSave]);
-
-  // Kommentaari taastamine: restore-endpoint on kettale juba committinud, seega
-  // sünkroni ainult lokaalne + salvestatud baasseis (mitte teist /save commitit).
-  const handleCommentsRestored = useCallback((updatedComments: Annotation[]) => {
-    setComments(updatedComments);
-    setSavedState({ status, comments: updatedComments, page_tags, text_annotations: textAnnotations });
-  }, [status, page_tags, textAnnotations]);
-
-  const handleReplyToComment = useCallback(async (commentId: string, replyText: string) => {
-    if (!authToken) {
-      throw new Error(t('saveError.tokenMissing'));
-    }
-    const updatedComments = await replyToComment(page, commentId, replyText, authToken);
-    setComments(updatedComments);
-    setSavedState({ status, comments: updatedComments, page_tags, text_annotations: textAnnotations });
-  }, [authToken, page, status, page_tags, textAnnotations, t]);
-
   useEffect(() => {
     handleSaveRef.current = handleSave;
     // triggerSave'i kasutab AINULT "Salvesta ja lahku" (Workspace) → flush-variant.
@@ -763,47 +706,12 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   }, []);
 
   const handleDeleteAndSaveTextAnnotation = useCallback(async (annId: number) => {
-    // removeAnnotationFromEditor dispatch on CM6-s sünkroonne —
-    // pärast seda on viewRef.current.state.doc juba uuendatud (tägid eemaldatud).
-    removeAnnotationFromEditor(annId);
-    const updated = textAnnotations.filter(a => a.id !== annId);
-    setTextAnnotations(updated);
-    if (isSavingRef.current) return;
-    isSavingRef.current = true;
-    setIsSaving(true);
-    // Loe tekst PÄRAST dispatch'i — CM6 on juba tägid eemaldanud
-    const text = viewRef.current?.state.doc.toString() ?? '';
-    const updatedPage: Page = { ...page, text_content: text, status, comments, page_tags, text_annotations: updated };
-    try {
-      await onSave(updatedPage);
-      setSavedState({ status, comments, page_tags, text_annotations: updated });
-      setIsDirty(false);
-    } catch (e: any) {
-      setSaveError(t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') }));
-    } finally {
-      isSavingRef.current = false;
-      setIsSaving(false);
-    }
-  }, [textAnnotations, removeAnnotationFromEditor, page, status, comments, page_tags, onSave]);
+    await deleteAndSaveTextAnnotation(annId, removeAnnotationFromEditor);
+  }, [deleteAndSaveTextAnnotation, removeAnnotationFromEditor]);
 
   const handleSaveTextAnnotations = useCallback(async (updatedTextAnnotations: TextAnnotation[]) => {
-    if (isSavingRef.current) return;
-    isSavingRef.current = true;
-    setIsSaving(true);
-    const text = viewRef.current?.state.doc.toString() ?? '';
-    const updatedPage: Page = { ...page, text_content: text, status, comments, page_tags, text_annotations: updatedTextAnnotations };
-    try {
-      await onSave(updatedPage);
-      setTextAnnotations(updatedTextAnnotations);
-      setSavedState({ status, comments, page_tags, text_annotations: updatedTextAnnotations });
-      setIsDirty(false);
-    } catch (e: any) {
-      setSaveError(t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') }));
-    } finally {
-      isSavingRef.current = false;
-      setIsSaving(false);
-    }
-  }, [page, status, comments, page_tags, onSave]);
+    await saveTextAnnotations(updatedTextAnnotations);
+  }, [saveTextAnnotations]);
 
   return (
     <>

--- a/src/components/editor/useEditorSave.ts
+++ b/src/components/editor/useEditorSave.ts
@@ -1,0 +1,153 @@
+import { useCallback, useRef, type MutableRefObject } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { EditorView } from '@codemirror/view';
+import type { Annotation, Page, PageStatus, TextAnnotation } from '../../types';
+import type { LinkedEntity } from '../../types/LinkedEntity';
+import { replyToComment } from '../../services/pageService';
+
+export interface EditorSavedState {
+  status: PageStatus;
+  comments: Annotation[];
+  page_tags: (string | LinkedEntity)[];
+  text_annotations: TextAnnotation[];
+}
+
+interface UseEditorSaveParams {
+  page: Page;
+  status: PageStatus;
+  comments: Annotation[];
+  setComments: (comments: Annotation[]) => void;
+  page_tags: (string | LinkedEntity)[];
+  textAnnotations: TextAnnotation[];
+  setTextAnnotations: (annotations: TextAnnotation[]) => void;
+  onSave: (updatedPage: Page) => Promise<void>;
+  setSavedState: (state: EditorSavedState) => void;
+  setIsDirty: (dirty: boolean) => void;
+  setIsSaving: (saving: boolean) => void;
+  setSaveError: (error: string | null) => void;
+  viewRef: MutableRefObject<EditorView | null>;
+  commentFlushRef: MutableRefObject<(() => Annotation[] | null) | null>;
+  authToken?: string | null;
+}
+
+// Tekstiredaktori salvestusloogika ja korduvate savedState uuenduste keskne koht.
+export function useEditorSave({
+  page,
+  status,
+  comments,
+  setComments,
+  page_tags,
+  textAnnotations,
+  setTextAnnotations,
+  onSave,
+  setSavedState,
+  setIsDirty,
+  setIsSaving,
+  setSaveError,
+  viewRef,
+  commentFlushRef,
+  authToken,
+}: UseEditorSaveParams) {
+  const { t } = useTranslation(['workspace', 'common']);
+  const isSavingRef = useRef(false);
+
+  const makePage = useCallback((nextComments: Annotation[], nextTextAnnotations: TextAnnotation[]): Page => {
+    const text = viewRef.current?.state.doc.toString() ?? '';
+    return { ...page, text_content: text, status, comments: nextComments, page_tags, text_annotations: nextTextAnnotations };
+  }, [page, status, page_tags, viewRef]);
+
+  const formatSaveError = useCallback((e: any) => (
+    t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') })
+  ), [t]);
+
+  const runSave = useCallback(async (
+    updatedPage: Page,
+    savedState: EditorSavedState,
+    afterSave?: () => void,
+  ) => {
+    if (isSavingRef.current) return;
+    isSavingRef.current = true;
+    setIsSaving(true);
+    try {
+      await onSave(updatedPage);
+      afterSave?.();
+      setSavedState(savedState);
+      setIsDirty(false);
+    } catch (e: any) {
+      console.error('Save error:', e);
+      setSaveError(formatSaveError(e));
+    } finally {
+      isSavingRef.current = false;
+      setIsSaving(false);
+    }
+  }, [formatSaveError, onSave, setIsDirty, setIsSaving, setSaveError, setSavedState]);
+
+  const handleSave = useCallback(async () => {
+    const updatedPage = makePage(comments, textAnnotations);
+    await runSave(updatedPage, { status, comments, page_tags, text_annotations: textAnnotations });
+  }, [comments, makePage, page_tags, runSave, status, textAnnotations]);
+
+  // Salvestus "Salvesta ja lahku" jaoks: enne salvestust liidab kommentaari-mustandi
+  // kommentaaride hulka, et see ei läheks kaduma.
+  const handleSaveWithDrafts = useCallback(async () => {
+    if (isSavingRef.current) return;
+    const flushed = commentFlushRef.current?.() ?? null;
+    const effectiveComments = flushed ?? comments;
+    const updatedPage = makePage(effectiveComments, textAnnotations);
+    await runSave(
+      updatedPage,
+      { status, comments: effectiveComments, page_tags, text_annotations: textAnnotations },
+      flushed ? () => setComments(flushed) : undefined,
+    );
+  }, [commentFlushRef, comments, makePage, page_tags, runSave, setComments, status, textAnnotations]);
+
+  // Annotatsioonide kohene salvestus (möödub state async viivitusest)
+  const handleSaveAnnotations = useCallback(async (updatedComments: Annotation[]) => {
+    const updatedPage = makePage(updatedComments, textAnnotations);
+    await runSave(updatedPage, { status, comments: updatedComments, page_tags, text_annotations: textAnnotations });
+  }, [makePage, page_tags, runSave, status, textAnnotations]);
+
+  const handleSaveTextAnnotations = useCallback(async (updatedTextAnnotations: TextAnnotation[]) => {
+    const updatedPage = makePage(comments, updatedTextAnnotations);
+    await runSave(
+      updatedPage,
+      { status, comments, page_tags, text_annotations: updatedTextAnnotations },
+      () => setTextAnnotations(updatedTextAnnotations),
+    );
+  }, [comments, makePage, page_tags, runSave, setTextAnnotations, status]);
+
+  const handleDeleteAndSaveTextAnnotation = useCallback(async (
+    annId: number,
+    removeAnnotationFromEditor: (annId: number) => void,
+  ) => {
+    // removeAnnotationFromEditor dispatch on CM6-s sünkroonne — tekst loetakse pärast dispatch'i.
+    removeAnnotationFromEditor(annId);
+    const updated = textAnnotations.filter(a => a.id !== annId);
+    setTextAnnotations(updated);
+    const updatedPage = makePage(comments, updated);
+    await runSave(updatedPage, { status, comments, page_tags, text_annotations: updated });
+  }, [comments, makePage, page_tags, runSave, setTextAnnotations, status, textAnnotations]);
+
+  const handleCommentsRestored = useCallback((updatedComments: Annotation[]) => {
+    setComments(updatedComments);
+    setSavedState({ status, comments: updatedComments, page_tags, text_annotations: textAnnotations });
+  }, [page_tags, setComments, setSavedState, status, textAnnotations]);
+
+  const handleReplyToComment = useCallback(async (commentId: string, replyText: string) => {
+    if (!authToken) throw new Error(t('saveError.tokenMissing'));
+    const updatedComments = await replyToComment(page, commentId, replyText, authToken);
+    setComments(updatedComments);
+    setSavedState({ status, comments: updatedComments, page_tags, text_annotations: textAnnotations });
+  }, [authToken, page, page_tags, setComments, setSavedState, status, textAnnotations, t]);
+
+  return {
+    isSavingRef,
+    handleSave,
+    handleSaveWithDrafts,
+    handleSaveAnnotations,
+    handleSaveTextAnnotations,
+    handleDeleteAndSaveTextAnnotation,
+    handleCommentsRestored,
+    handleReplyToComment,
+  };
+}


### PR DESCRIPTION
## Kokkuvõte
- tõstab TextEditor.tsx salvestusloogika eraldi `useEditorSave` hooki
- koondab tavalise salvestuse, draft-flush salvestuse, kommentaaride ja tekstiannotatsioonide salvestuse
- hoiab `TextEditor.tsx` sees ainult UI ja redaktori-spetsiifilise ühendusloogika

## Kontroll
- `npm run typecheck`
- `npm run build`

Refs #89