### PR TITLE
Refactor TextEditor header

### DIFF
--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -5,11 +5,12 @@ import type { Collections } from '../services/collectionService';
 import type { TextAnnotation } from '../types';
 import { nextAnnId, containsAnnTag } from '../utils/annUtils';
 import { useUser } from '../contexts/UserContext';
-import { Save, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import AnnotationsTab from './editor/AnnotationsTab';
 import HistoryTab from './editor/HistoryTab';
 import EditorStatusBar from './editor/EditorStatusBar';
 import EditorToolbar from './editor/EditorToolbar';
+import EditorHeader from './editor/EditorHeader';
 import SpecialCharsPanel from './editor/SpecialCharsPanel';
 import AnnotationDialog from './editor/AnnotationDialog';
 import AnnotationPopover from './editor/AnnotationPopover';
@@ -20,8 +21,6 @@ import { cleanMarkupSpecs, marginaliaFromSelection } from '../utils/marginaliaUt
 import { vuttTheme } from './editor/VuttTheme';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 import { getLangCode } from '../utils/getLangCode';
-import { ErrorBanner } from './ErrorBanner';
-import { formatYearDisplay } from '../utils/yearDisplayUtils';
 
 // CM6 impordid
 import { EditorView, lineNumbers, keymap } from '@codemirror/view';
@@ -658,63 +657,18 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     <div className="flex flex-col h-full bg-paper font-sans">
 
       {/* 1. GLOBAL HEADER */}
-      <div className="bg-white border-b border-gray-200 shrink-0 z-20 shadow-sm">
-        {work && (
-          <div className="px-4 py-1.5 border-b border-gray-50 flex items-center gap-2 text-[11px] text-gray-500 bg-gray-50/50">
-            <span className="font-bold text-gray-700 truncate max-w-[200px]">{work.creators?.find(c => c.role === 'praeses' || c.role === 'auctor')?.name || work.creators?.[0]?.name || ''}</span>
-            <span className="text-gray-300">•</span>
-            <span className="text-gray-400">{formatYearDisplay(work.year_display, work.year, t)}</span>
-            <span className="text-gray-300">•</span>
-            <span className="italic truncate flex-1">{work.title}</span>
-          </div>
-        )}
-
-        <div className="px-4 py-2 flex items-center justify-between gap-4">
-          <div className="flex bg-gray-100 p-0.5 rounded-lg shadow-inner">
-            <button
-              onClick={() => setActiveTab('edit')}
-              className={`px-4 py-1.5 text-xs font-bold rounded-md transition-all ${activeTab === 'edit' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
-            >
-              {(readOnly ? t('tabs.view') : t('tabs.edit')).toUpperCase()}
-            </button>
-            <button
-              onClick={() => setActiveTab('annotate')}
-              className={`px-4 py-1.5 text-xs font-bold rounded-md transition-all ${activeTab === 'annotate' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
-            >
-              {t('tabs.info').toUpperCase()}
-            </button>
-            <button
-              onClick={() => setActiveTab('history')}
-              className={`px-4 py-1.5 text-xs font-bold rounded-md transition-all ${activeTab === 'history' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
-            >
-              {t('tabs.history').toUpperCase()}
-            </button>
-          </div>
-
-          {!readOnly && (
-            <div className="flex items-center gap-2">
-              <button
-                onClick={handleSave}
-                disabled={isSaving}
-                className={`flex items-center gap-2 px-5 py-1.5 text-xs font-bold uppercase tracking-wider text-white rounded shadow-sm transition-all active:scale-95 disabled:opacity-50 ${(hasUnsavedChanges || statusDirty)
-                  ? 'bg-amber-500 hover:bg-amber-600'
-                  : 'bg-primary-600 hover:bg-primary-700'
-                  }`}
-              >
-                {isSaving ? <Loader2 className="animate-spin" size={14} /> : <Save size={14} />}
-                {isSaving ? t('editor.saving') : t('editor.save').toUpperCase()}
-              </button>
-            </div>
-          )}
-        </div>
-        {saveError && (
-          <ErrorBanner
-            message={saveError}
-            onClose={() => setSaveError(null)}
-            className="mx-4 mb-2"
-          />
-        )}
-      </div>
+      <EditorHeader
+        work={work}
+        activeTab={activeTab}
+        readOnly={readOnly}
+        isSaving={isSaving}
+        hasUnsavedChanges={hasUnsavedChanges}
+        statusDirty={statusDirty}
+        saveError={saveError}
+        onTabChange={setActiveTab}
+        onSave={handleSave}
+        onClearSaveError={() => setSaveError(null)}
+      />
 
       <div className="flex-1 overflow-hidden relative flex flex-col">
 

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -34,6 +34,7 @@ import { useCopyPastePlainMarkup } from './editor/useCopyPastePlainMarkup';
 import { useReOcr } from './editor/useReOcr';
 import { useEditorState } from './editor/useEditorState';
 import { useEditorSave } from './editor/useEditorSave';
+import type { EditorTab } from './editor/types';
 
 interface TextEditorProps {
   page: Page;
@@ -50,8 +51,6 @@ interface TextEditorProps {
   collections?: Collections;
 }
 
-type TabType = 'edit' | 'annotate' | 'history';
-
 const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedChanges, onOpenMetaModal, readOnly = false, statusDirty = false, currentStatus, onStatusChange, triggerSave, onWorkUpdate, collections }) => {
   const { t, i18n } = useTranslation(['workspace', 'common']);
   const { user, authToken, userSettings } = useUser();
@@ -67,13 +66,13 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     setIsCustomChars,
   } = useSpecialChars(authToken);
   const copyPastePlainMarkup = useCopyPastePlainMarkup();
-  const [activeTab, setActiveTab] = useState<TabType>('edit');
+  const [activeTab, setActiveTab] = useState<EditorTab>('edit');
   const hasAppliedDefaultTab = useRef(false);
 
   // Sünkrooni default_tab serverist (ainult esimesel laadimsel)
   useEffect(() => {
     if (!hasAppliedDefaultTab.current && userSettings.default_tab) {
-      setActiveTab(userSettings.default_tab as TabType);
+      setActiveTab(userSettings.default_tab as EditorTab);
       hasAppliedDefaultTab.current = true;
     }
   }, [userSettings.default_tab]);

--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -3,18 +3,17 @@ import { useTranslation } from 'react-i18next';
 import type { Work } from '../../types';
 import { formatYearDisplay } from '../../utils/yearDisplayUtils';
 import { ErrorBanner } from '../ErrorBanner';
-
-type TabType = 'edit' | 'annotate' | 'history';
+import type { EditorTab } from './types';
 
 interface EditorHeaderProps {
   work?: Work;
-  activeTab: TabType;
+  activeTab: EditorTab;
   readOnly: boolean;
   isSaving: boolean;
   hasUnsavedChanges: boolean;
   statusDirty: boolean;
   saveError: string | null;
-  onTabChange: (tab: TabType) => void;
+  onTabChange: (tab: EditorTab) => void;
   onSave: () => void;
   onClearSaveError: () => void;
 }

--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -1,0 +1,96 @@
+import { Loader2, Save } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { Work } from '../../types';
+import { formatYearDisplay } from '../../utils/yearDisplayUtils';
+import { ErrorBanner } from '../ErrorBanner';
+
+type TabType = 'edit' | 'annotate' | 'history';
+
+interface EditorHeaderProps {
+  work?: Work;
+  activeTab: TabType;
+  readOnly: boolean;
+  isSaving: boolean;
+  hasUnsavedChanges: boolean;
+  statusDirty: boolean;
+  saveError: string | null;
+  onTabChange: (tab: TabType) => void;
+  onSave: () => void;
+  onClearSaveError: () => void;
+}
+
+// Tekstiredaktori ülemine päis: teose info, vahekaardid ja salvestusnupp.
+export default function EditorHeader({
+  work,
+  activeTab,
+  readOnly,
+  isSaving,
+  hasUnsavedChanges,
+  statusDirty,
+  saveError,
+  onTabChange,
+  onSave,
+  onClearSaveError,
+}: EditorHeaderProps) {
+  const { t } = useTranslation(['workspace', 'common']);
+
+  return (
+    <div className="bg-white border-b border-gray-200 shrink-0 z-20 shadow-sm">
+      {work && (
+        <div className="px-4 py-1.5 border-b border-gray-50 flex items-center gap-2 text-[11px] text-gray-500 bg-gray-50/50">
+          <span className="font-bold text-gray-700 truncate max-w-[200px]">{work.creators?.find(c => c.role === 'praeses' || c.role === 'auctor')?.name || work.creators?.[0]?.name || ''}</span>
+          <span className="text-gray-300">•</span>
+          <span className="text-gray-400">{formatYearDisplay(work.year_display, work.year, t)}</span>
+          <span className="text-gray-300">•</span>
+          <span className="italic truncate flex-1">{work.title}</span>
+        </div>
+      )}
+
+      <div className="px-4 py-2 flex items-center justify-between gap-4">
+        <div className="flex bg-gray-100 p-0.5 rounded-lg shadow-inner">
+          <button
+            onClick={() => onTabChange('edit')}
+            className={`px-4 py-1.5 text-xs font-bold rounded-md transition-all ${activeTab === 'edit' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+          >
+            {(readOnly ? t('tabs.view') : t('tabs.edit')).toUpperCase()}
+          </button>
+          <button
+            onClick={() => onTabChange('annotate')}
+            className={`px-4 py-1.5 text-xs font-bold rounded-md transition-all ${activeTab === 'annotate' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+          >
+            {t('tabs.info').toUpperCase()}
+          </button>
+          <button
+            onClick={() => onTabChange('history')}
+            className={`px-4 py-1.5 text-xs font-bold rounded-md transition-all ${activeTab === 'history' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}`}
+          >
+            {t('tabs.history').toUpperCase()}
+          </button>
+        </div>
+
+        {!readOnly && (
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onSave}
+              disabled={isSaving}
+              className={`flex items-center gap-2 px-5 py-1.5 text-xs font-bold uppercase tracking-wider text-white rounded shadow-sm transition-all active:scale-95 disabled:opacity-50 ${(hasUnsavedChanges || statusDirty)
+                ? 'bg-amber-500 hover:bg-amber-600'
+                : 'bg-primary-600 hover:bg-primary-700'
+                }`}
+            >
+              {isSaving ? <Loader2 className="animate-spin" size={14} /> : <Save size={14} />}
+              {isSaving ? t('editor.saving') : t('editor.save').toUpperCase()}
+            </button>
+          </div>
+        )}
+      </div>
+      {saveError && (
+        <ErrorBanner
+          message={saveError}
+          onClose={onClearSaveError}
+          className="mx-4 mb-2"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/types.ts
+++ b/src/components/editor/types.ts
@@ -1,0 +1,2 @@
+// Tekstiredaktori jagatud tüübid.
+export type EditorTab = 'edit' | 'annotate' | 'history';


### PR DESCRIPTION
## Kokkuvõte
- tõstab TextEditor.tsx ülemise päise eraldi `EditorHeader` komponendiks
- koondab teose inforiba, tabide nupud, salvestusnupu ja save error banneri
- vähendab TextEditor.tsx mahtu järgmise väikese refaktori sammuna

## Kontroll
- `npm run typecheck`
- `npm run build`

Refs #89