### PR TITLE
Refactor TextEditor Re-OCR panel

### DIFF
--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -5,12 +5,12 @@ import type { Collections } from '../services/collectionService';
 import type { TextAnnotation } from '../types';
 import { nextAnnId, containsAnnTag } from '../utils/annUtils';
 import { useUser } from '../contexts/UserContext';
-import { Loader2 } from 'lucide-react';
 import AnnotationsTab from './editor/AnnotationsTab';
 import HistoryTab from './editor/HistoryTab';
 import EditorStatusBar from './editor/EditorStatusBar';
 import EditorToolbar from './editor/EditorToolbar';
 import EditorHeader from './editor/EditorHeader';
+import ReocrPanel from './editor/ReocrPanel';
 import SpecialCharsPanel from './editor/SpecialCharsPanel';
 import AnnotationDialog from './editor/AnnotationDialog';
 import AnnotationPopover from './editor/AnnotationPopover';
@@ -699,58 +699,25 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
               />
             </div>
 
-            {(reocrStatus === 'uploading' || reocrStatus === 'processing') && (
-              <div className="shrink-0 bg-emerald-50 border-b border-emerald-200 px-4 py-2 flex items-center gap-2 text-xs text-emerald-800">
-                <Loader2 className="animate-spin shrink-0" size={12} />
-                {t('editor.reocr.inProgress')}
-              </div>
-            )}
+            <ReocrPanel
+              variant="banner"
+              status={reocrStatus}
+              text={reocrText}
+              error={reocrError}
+              onApply={applyReOcr}
+              onDelete={deleteOcrFile}
+            />
 
             {/* 3. EDITOR AREA */}
             <div className="flex-1 relative flex overflow-hidden bg-white">
-              {(reocrStatus === 'done' || reocrStatus === 'error') && (
-                <div className="absolute inset-0 z-20 bg-white/95 flex flex-col">
-                  <div className="px-4 py-3 border-b border-gray-200 shrink-0">
-                    <span className="text-sm font-semibold text-gray-800">
-                      {reocrStatus === 'error' ? t('editor.reocr.error') : t('editor.reocr.modalTitle')}
-                    </span>
-                  </div>
-                  {reocrStatus === 'error' ? (
-                    <div className="flex-1 flex flex-col items-center justify-center p-6 gap-4">
-                      <div className="text-sm text-red-600">{reocrError}</div>
-                      <button
-                        onClick={deleteOcrFile}
-                        className="px-4 py-1.5 text-xs font-medium text-white bg-red-600 hover:bg-red-700 rounded transition-colors"
-                      >
-                        {t('editor.reocr.deleteFile')}
-                      </button>
-                    </div>
-                  ) : (
-                    <>
-                      <p className="px-4 pt-3 pb-2 text-xs text-gray-500 shrink-0">{t('editor.reocr.modalHint')}</p>
-                      <div className="flex-1 overflow-auto px-4 pb-2">
-                        <pre className="font-serif text-[15px] leading-[1.7] text-gray-800 whitespace-pre-wrap">{reocrText}</pre>
-                      </div>
-                      <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200 shrink-0">
-                        <button
-                          onClick={() => {
-                            if (window.confirm(t('editor.reocr.deleteConfirm'))) deleteOcrFile();
-                          }}
-                          className="px-3 py-1.5 text-xs font-medium text-white bg-red-600 hover:bg-red-700 rounded transition-colors"
-                        >
-                          {t('editor.reocr.deleteFile')}
-                        </button>
-                        <button
-                          onClick={applyReOcr}
-                          className="px-4 py-1.5 text-xs font-bold text-white bg-emerald-600 hover:bg-emerald-700 rounded shadow-sm transition-colors"
-                        >
-                          {t('editor.reocr.apply')}
-                        </button>
-                      </div>
-                    </>
-                  )}
-                </div>
-              )}
+              <ReocrPanel
+                variant="overlay"
+                status={reocrStatus}
+                text={reocrText}
+                error={reocrError}
+                onApply={applyReOcr}
+                onDelete={deleteOcrFile}
+              />
               <div ref={editorContainerRef} className="flex-1 overflow-hidden" />
             </div>
 

--- a/src/components/editor/ReocrPanel.tsx
+++ b/src/components/editor/ReocrPanel.tsx
@@ -1,0 +1,73 @@
+import { Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { ReocrStatus } from './useReOcr';
+
+interface ReocrPanelProps {
+  status: ReocrStatus;
+  text: string | null;
+  error: string | null;
+  onApply: () => void;
+  onDelete: () => void | Promise<void>;
+  variant: 'banner' | 'overlay';
+}
+
+// Re-OCR oleku banner ja tulemuse/vea ülekate tekstiredaktoris.
+export default function ReocrPanel({ status, text, error, onApply, onDelete, variant }: ReocrPanelProps) {
+  const { t } = useTranslation(['workspace']);
+
+  if (variant === 'banner') {
+    if (status !== 'uploading' && status !== 'processing') return null;
+    return (
+      <div className="shrink-0 bg-emerald-50 border-b border-emerald-200 px-4 py-2 flex items-center gap-2 text-xs text-emerald-800">
+        <Loader2 className="animate-spin shrink-0" size={12} />
+        {t('editor.reocr.inProgress')}
+      </div>
+    );
+  }
+
+  if (status !== 'done' && status !== 'error') return null;
+
+  return (
+        <div className="absolute inset-0 z-20 bg-white/95 flex flex-col">
+          <div className="px-4 py-3 border-b border-gray-200 shrink-0">
+            <span className="text-sm font-semibold text-gray-800">
+              {status === 'error' ? t('editor.reocr.error') : t('editor.reocr.modalTitle')}
+            </span>
+          </div>
+          {status === 'error' ? (
+            <div className="flex-1 flex flex-col items-center justify-center p-6 gap-4">
+              <div className="text-sm text-red-600">{error}</div>
+              <button
+                onClick={onDelete}
+                className="px-4 py-1.5 text-xs font-medium text-white bg-red-600 hover:bg-red-700 rounded transition-colors"
+              >
+                {t('editor.reocr.deleteFile')}
+              </button>
+            </div>
+          ) : (
+            <>
+              <p className="px-4 pt-3 pb-2 text-xs text-gray-500 shrink-0">{t('editor.reocr.modalHint')}</p>
+              <div className="flex-1 overflow-auto px-4 pb-2">
+                <pre className="font-serif text-[15px] leading-[1.7] text-gray-800 whitespace-pre-wrap">{text}</pre>
+              </div>
+              <div className="flex items-center justify-between px-4 py-3 border-t border-gray-200 shrink-0">
+                <button
+                  onClick={() => {
+                    if (window.confirm(t('editor.reocr.deleteConfirm'))) onDelete();
+                  }}
+                  className="px-3 py-1.5 text-xs font-medium text-white bg-red-600 hover:bg-red-700 rounded transition-colors"
+                >
+                  {t('editor.reocr.deleteFile')}
+                </button>
+                <button
+                  onClick={onApply}
+                  className="px-4 py-1.5 text-xs font-bold text-white bg-emerald-600 hover:bg-emerald-700 rounded shadow-sm transition-colors"
+                >
+                  {t('editor.reocr.apply')}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+  );
+}


### PR DESCRIPTION
## Kokkuvõte
- tõstab TextEditor.tsx Re-OCR banneri ja overlay eraldi `ReocrPanel` komponendiks
- koondab Re-OCR progressi, tulemuse, vea ning apply/delete nupud
- vähendab TextEditor.tsx mahtu järgmise väikese refaktori sammuna

## Kontroll
- `npm run typecheck`
- `npm run build`

Refs #89