### PR TITLE
Refactor TextEditor formatting actions

### DIFF
--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -14,26 +14,25 @@ import ReocrPanel from './editor/ReocrPanel';
 import SpecialCharsPanel from './editor/SpecialCharsPanel';
 import AnnotationDialog from './editor/AnnotationDialog';
 import AnnotationPopover from './editor/AnnotationPopover';
-import { vuttMarkupExtension, vuttMarkupField } from './editor/VuttMarkupExtension';
-import { marginaliaExtension, marginaliaField, openMarginalia, closeAllMarginalia, hiddenBlockRanges } from './editor/MarginaliaExtension';
+import { vuttMarkupExtension } from './editor/VuttMarkupExtension';
+import { marginaliaExtension, marginaliaField, closeAllMarginalia } from './editor/MarginaliaExtension';
 import type { MarginaliaMode } from './editor/MarginaliaExtension';
-import { cleanMarkupSpecs, marginaliaFromSelection } from '../utils/marginaliaUtils';
 import { vuttTheme } from './editor/VuttTheme';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 import { getLangCode } from '../utils/getLangCode';
 
 // CM6 impordid
 import { EditorView, lineNumbers, keymap } from '@codemirror/view';
-import { EditorState, EditorSelection, Compartment, Transaction } from '@codemirror/state';
+import { EditorState, Compartment, Transaction } from '@codemirror/state';
 import { history, historyKeymap, defaultKeymap } from '@codemirror/commands';
 import { search, searchKeymap, openSearchPanel } from '@codemirror/search';
 import { createVuttSearchPanel } from './editor/VuttSearchPanel';
-import { findContainer, findInnerPairs } from './editor/wrapTagUtils';
 import { useSpecialChars } from './editor/useSpecialChars';
 import { useCopyPastePlainMarkup } from './editor/useCopyPastePlainMarkup';
 import { useReOcr } from './editor/useReOcr';
 import { useEditorState } from './editor/useEditorState';
 import { useEditorSave } from './editor/useEditorSave';
+import { useEditorFormattingActions } from './editor/useEditorFormattingActions';
 import type { EditorTab } from './editor/types';
 
 interface TextEditorProps {
@@ -163,6 +162,14 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     commentFlushRef,
     authToken,
   });
+
+  const {
+    wrapWithTag,
+    insertAtCursor,
+    insertSpecialChar,
+    insertMarginalia,
+    cleanMarkup,
+  } = useEditorFormattingActions({ viewRef, readOnly });
 
   // --- Globaalne Ctrl+F käsitleja — avab CM6 otsingu capture-faasis enne brauserit ---
   useEffect(() => {
@@ -302,249 +309,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
     if (triggerSave) triggerSave.current = handleSaveWithDrafts;
   }, [handleSave, handleSaveWithDrafts, triggerSave]);
 
-  // --- Toolbar toimingud ---
-  const wrapWithTag = useCallback((tag: string) => {
-    const view = viewRef.current;
-    if (!view || readOnly) return;
-
-    const { from, to } = view.state.selection.main;
-    const docText = view.state.doc.toString();
-    const openTag = `<${tag}>`;
-    const closeTag = `</${tag}>`;
-
-    // 1. KÄSITLUS ILMA VALIKUTA (kursor)
-    if (from === to) {
-      const line = view.state.doc.lineAt(from);
-      const container = findContainer(tag, from, docText, line.from, line.to);
-      if (container) {
-        // Kui kursor on tägi sees, eemaldame tägi
-        const changes = [
-          { from: container.open, to: container.openEnd, insert: '' },
-          { from: container.close, to: container.closeEnd, insert: '' },
-        ];
-        view.dispatch({
-          changes,
-          selection: EditorSelection.cursor(view.state.changes(changes).mapPos(from))
-        });
-      } else {
-        // Muul juhul lisame tühjad tägid ja viime kursori vahele
-        view.dispatch({
-          changes: { from, insert: openTag + closeTag },
-          selection: EditorSelection.cursor(from + openTag.length),
-        });
-      }
-      view.focus();
-      return;
-    }
-
-    // 2. KÄSITLUS VALIKUGA (võib olla mitu rida)
-    const lineFrom = view.state.doc.lineAt(from);
-    const lineTo = view.state.doc.lineAt(to);
-    const changes: { from: number; to: number; insert: string }[] = [];
-
-    // OTSUSTAMINE: Kas me pakime lahti (unwrap) või paneme tägi ümber (wrap)?
-    // Reegel: Kui esimese valitud rea sisu on juba tägi sees, siis me pakime LAHTI kõik valitud read.
-    let mode: 'wrap' | 'unwrap' = 'wrap';
-    for (let i = lineFrom.number; i <= lineTo.number; i++) {
-      const line = view.state.doc.line(i);
-      let sFrom = Math.max(from, line.from);
-      let sTo = Math.min(to, line.to);
-      
-      // Puhastame servadest tühikud otsuse tegemiseks
-      while (sTo > sFrom && /\s/.test(docText[sTo - 1])) sTo--;
-      while (sFrom < sTo && /\s/.test(docText[sFrom])) sFrom++;
-      
-      if (sFrom < sTo) {
-        const container = findContainer(tag, sFrom, docText, line.from, line.to);
-        if (container && sTo <= container.closeEnd) {
-          mode = 'unwrap';
-        }
-        break; // Võtame esimese sisulise rea järgi otsuse vastu
-      }
-    }
-
-    // TEGEVUS: Käime read läbi ja rakendame muudatused
-    for (let i = lineFrom.number; i <= lineTo.number; i++) {
-      const line = view.state.doc.line(i);
-      let sFrom = Math.max(from, line.from);
-      let sTo = Math.min(to, line.to);
-
-      // Puhastame valiku servadest tühikud/reavahetused
-      while (sTo > sFrom && /\s/.test(docText[sTo - 1])) sTo--;
-      while (sFrom < sTo && /\s/.test(docText[sFrom])) sFrom++;
-
-      if (sFrom >= sTo) continue; // Tühi rida jääb vahele
-
-      // NUTIKAS PESASTAMINE: Kui mähime stiili-tägiga (i, b, cs), siis 
-      // liigume automaatselt struktuuri-tägide (m, hi, fn) SISSE.
-      if (mode === 'wrap' && ['i', 'b', 'cs'].includes(tag)) {
-        let adjusted = true;
-        while (adjusted) {
-          adjusted = false;
-          // 1. Kontrollime algust: kas sFrom juures algab suvaline täg?
-          const startTagMatch = docText.slice(sFrom, sFrom + 20).match(/^<[^>]+>/);
-          if (startTagMatch) {
-            const tagName = startTagMatch[0].match(/[a-z]+/)?.[0];
-            // Kui on struktuuri-täg, hüppame sisse
-            if (tagName && ['m', 'hi', 'fn'].includes(tagName)) {
-              sFrom += startTagMatch[0].length;
-              adjusted = true;
-            }
-          }
-
-          // 2. Kontrollime lõppu: kas sTo juures lõpeb suvaline täg?
-          const endTagMatch = docText.slice(Math.max(0, sTo - 15), sTo).match(/<\/[^>]+>$/);
-          if (endTagMatch) {
-            const tagName = endTagMatch[0].match(/[a-z]+/)?.[0];
-            if (tagName && ['m', 'hi', 'fn'].includes(tagName)) {
-              sTo -= endTagMatch[0].length;
-              adjusted = true;
-            }
-          }
-          
-          if (sFrom >= sTo) break;
-        }
-      }
-
-      if (mode === 'unwrap') {
-        const container = findContainer(tag, sFrom, docText, line.from, line.to);
-        if (container && sTo <= container.closeEnd) {
-          changes.push({ from: container.open, to: container.openEnd, insert: '' });
-          changes.push({ from: container.close, to: container.closeEnd, insert: '' });
-        }
-      } else {
-        // Kui sFrom/sTo asub olemasoleva sama tägi sees, laienda piir tägi alguse/lõpuni
-        const startContainer = findContainer(tag, sFrom, docText, line.from, line.to);
-        if (startContainer && sFrom > startContainer.open) sFrom = startContainer.open;
-        const endContainer = findContainer(tag, sTo, docText, line.from, line.to);
-        if (endContainer && sTo < endContainer.closeEnd) sTo = endContainer.closeEnd;
-
-        // WRAP: Eemaldame enne sisemised sama tüüpi tägid, et vältida dubleerimist
-        const innerPairs = findInnerPairs(tag, sFrom, sTo, docText);
-        // Kui selektsioon algab/lõpeb täpselt olemasoleva tägi piiril, kasuta seda tägina
-        // (ära loo uut tägi samale positsioonile — tekitaks konflikti ja pesastuse)
-        const leadingPair = innerPairs.length > 0 && innerPairs[0].open === sFrom ? innerPairs[0] : null;
-        const trailingPair = innerPairs.length > 0 && innerPairs[innerPairs.length - 1].closeEnd === sTo ? innerPairs[innerPairs.length - 1] : null;
-        if (!leadingPair) changes.push({ from: sFrom, to: sFrom, insert: openTag });
-        for (const p of innerPairs) {
-          if (p === leadingPair) {
-            changes.push({ from: p.close, to: p.closeEnd, insert: '' });
-          } else if (p === trailingPair) {
-            changes.push({ from: p.open, to: p.openEnd, insert: '' });
-          } else {
-            changes.push({ from: p.open, to: p.openEnd, insert: '' });
-            changes.push({ from: p.close, to: p.closeEnd, insert: '' });
-          }
-        }
-        if (!trailingPair) changes.push({ from: sTo, to: sTo, insert: closeTag });
-      }
-    }
-
-    if (changes.length > 0) {
-      const tr = view.state.update({
-        changes,
-        selection: EditorSelection.range(
-          view.state.changes(changes).mapPos(from, 1),
-          view.state.changes(changes).mapPos(to, -1)
-        ),
-        scrollIntoView: false,
-        annotations: Transaction.userEvent.of('input.format')
-      });
-      view.dispatch(tr);
-    }
-    view.focus();
-  }, [readOnly]);
-
-
   useEffect(() => { wrapWithTagRef.current = wrapWithTag; }, [wrapWithTag]);
-
-  const insertAtCursor = useCallback((text: string) => {
-    const view = viewRef.current;
-    if (!view || readOnly) return;
-    view.dispatch(view.state.replaceSelection(text));
-    view.focus();
-  }, [readOnly]);
-
-  const insertSpecialChar = useCallback((char: string, e?: React.MouseEvent) => {
-    if (e) e.preventDefault();
-    insertAtCursor(char);
-  }, [insertAtCursor]);
-
-  // Uus marginaalia: valik tõstetakse <m> plokki valiku algusrea kohale;
-  // ilma valikuta tühi <m></m> kursori rea kohale. Mõlemal juhul kohe avatuna.
-  const insertMarginalia = useCallback(() => {
-    const view = viewRef.current;
-    if (!view || readOnly) return;
-    let { from, to } = view.state.selection.main;
-
-    if (from === to) {
-      const line = view.state.doc.lineAt(from);
-      view.dispatch({
-        changes: { from: line.from, insert: '<m></m>\n' },
-        effects: openMarginalia.of(line.from + 3),
-        selection: EditorSelection.cursor(line.from + 3),
-        annotations: Transaction.userEvent.of('input.format'),
-      });
-      view.focus();
-      return;
-    }
-
-    // Laienda valikut üle poolikute tägide (sama loogika mis cleanMarkup)
-    const { tagRanges } = view.state.field(vuttMarkupField);
-    for (const r of tagRanges) {
-      if (r.from < to && r.to > from) {
-        from = Math.min(from, r.from);
-        to = Math.max(to, r.to);
-      }
-    }
-    const hidden = hiddenBlockRanges(view.state).filter(h => h.from < to && h.to > from);
-    const { changes, cursor } = marginaliaFromSelection(
-      view.state.doc.toString(), from, to, hidden,
-    );
-    view.dispatch({
-      changes,
-      effects: openMarginalia.of(changes[0].from + 3),
-      selection: EditorSelection.cursor(cursor),
-      annotations: Transaction.userEvent.of('input.format'),
-    });
-    view.focus();
-  }, [readOnly]);
-
-  const cleanMarkup = useCallback(() => {
-    const view = viewRef.current;
-    if (!view || readOnly) return;
-    let { from, to } = view.state.selection.main;
-    if (from === to) return;
-
-    // Laienda valikut, et hõlmata kõik osaliselt kattuvad tägid
-    // (mouse-valik võib lõppeda tägi sees → ilma laienduseta jääb poolik täg alles)
-    const { tagRanges } = view.state.field(vuttMarkupField);
-    for (const r of tagRanges) {
-      if (r.from < to && r.to > from) {
-        from = Math.min(from, r.from);
-        to = Math.max(to, r.to);
-      }
-    }
-
-    // Puhasta iga nähtav segment ERALDI muudatusena — peidetud marginaalia
-    // plokke ei puudutata üldse, nii jäävad nad oma ridadele ja ankrutele
-    // (üks valikut kattev muudatus laseks kaitsefiltril ploki valiku lõppu
-    // nihutada, kus ta degradeeruks inline-margiks)
-    const hidden = hiddenBlockRanges(view.state).filter(h => h.from < to && h.to > from);
-    const specs = cleanMarkupSpecs(
-      view.state.doc.toString(), from, to, hidden,
-      s => s.replace(/<\/?(?:i|b|cs|m|hi|fn|pb)[^>]*>/g, ''),
-    );
-    if (specs.length === 0) return;
-    const changes = view.state.changes(specs);
-
-    view.dispatch({
-      changes,
-      selection: EditorSelection.range(changes.mapPos(from, -1), changes.mapPos(to, 1)),
-      annotations: Transaction.userEvent.of('input.format'),
-    });
-    view.focus();
-  }, [readOnly]);
 
   const handleAnnotateSelection = useCallback(() => {
     const view = viewRef.current;

--- a/src/components/editor/useEditorFormattingActions.ts
+++ b/src/components/editor/useEditorFormattingActions.ts
@@ -1,0 +1,263 @@
+import { useCallback, type MouseEvent, type MutableRefObject } from 'react';
+import type { EditorView } from '@codemirror/view';
+import { EditorSelection, Transaction } from '@codemirror/state';
+import { vuttMarkupField } from './VuttMarkupExtension';
+import { hiddenBlockRanges, openMarginalia } from './MarginaliaExtension';
+import { findContainer, findInnerPairs } from './wrapTagUtils';
+import { cleanMarkupSpecs, marginaliaFromSelection } from '../../utils/marginaliaUtils';
+
+interface UseEditorFormattingActionsParams {
+  viewRef: MutableRefObject<EditorView | null>;
+  readOnly: boolean;
+}
+
+// Toolbar'i vormindus- ja sisestustoimingud CodeMirror dokumendile.
+export function useEditorFormattingActions({ viewRef, readOnly }: UseEditorFormattingActionsParams) {
+  const wrapWithTag = useCallback((tag: string) => {
+    const view = viewRef.current;
+    if (!view || readOnly) return;
+
+    const { from, to } = view.state.selection.main;
+    const docText = view.state.doc.toString();
+    const openTag = `<${tag}>`;
+    const closeTag = `</${tag}>`;
+
+    // 1. KÄSITLUS ILMA VALIKUTA (kursor)
+    if (from === to) {
+      const line = view.state.doc.lineAt(from);
+      const container = findContainer(tag, from, docText, line.from, line.to);
+      if (container) {
+        // Kui kursor on tägi sees, eemaldame tägi
+        const changes = [
+          { from: container.open, to: container.openEnd, insert: '' },
+          { from: container.close, to: container.closeEnd, insert: '' },
+        ];
+        view.dispatch({
+          changes,
+          selection: EditorSelection.cursor(view.state.changes(changes).mapPos(from))
+        });
+      } else {
+        // Muul juhul lisame tühjad tägid ja viime kursori vahele
+        view.dispatch({
+          changes: { from, insert: openTag + closeTag },
+          selection: EditorSelection.cursor(from + openTag.length),
+        });
+      }
+      view.focus();
+      return;
+    }
+
+    // 2. KÄSITLUS VALIKUGA (võib olla mitu rida)
+    const lineFrom = view.state.doc.lineAt(from);
+    const lineTo = view.state.doc.lineAt(to);
+    const changes: { from: number; to: number; insert: string }[] = [];
+
+    // OTSUSTAMINE: Kas me pakime lahti (unwrap) või paneme tägi ümber (wrap)?
+    // Reegel: Kui esimese valitud rea sisu on juba tägi sees, siis me pakime LAHTI kõik valitud read.
+    let mode: 'wrap' | 'unwrap' = 'wrap';
+    for (let i = lineFrom.number; i <= lineTo.number; i++) {
+      const line = view.state.doc.line(i);
+      let sFrom = Math.max(from, line.from);
+      let sTo = Math.min(to, line.to);
+
+      // Puhastame servadest tühikud otsuse tegemiseks
+      while (sTo > sFrom && /\s/.test(docText[sTo - 1])) sTo--;
+      while (sFrom < sTo && /\s/.test(docText[sFrom])) sFrom++;
+
+      if (sFrom < sTo) {
+        const container = findContainer(tag, sFrom, docText, line.from, line.to);
+        if (container && sTo <= container.closeEnd) {
+          mode = 'unwrap';
+        }
+        break; // Võtame esimese sisulise rea järgi otsuse vastu
+      }
+    }
+
+    // TEGEVUS: Käime read läbi ja rakendame muudatused
+    for (let i = lineFrom.number; i <= lineTo.number; i++) {
+      const line = view.state.doc.line(i);
+      let sFrom = Math.max(from, line.from);
+      let sTo = Math.min(to, line.to);
+
+      // Puhastame valiku servadest tühikud/reavahetused
+      while (sTo > sFrom && /\s/.test(docText[sTo - 1])) sTo--;
+      while (sFrom < sTo && /\s/.test(docText[sFrom])) sFrom++;
+
+      if (sFrom >= sTo) continue; // Tühi rida jääb vahele
+
+      // NUTIKAS PESASTAMINE: Kui mähime stiili-tägiga (i, b, cs), siis
+      // liigume automaatselt struktuuri-tägide (m, hi, fn) SISSE.
+      if (mode === 'wrap' && ['i', 'b', 'cs'].includes(tag)) {
+        let adjusted = true;
+        while (adjusted) {
+          adjusted = false;
+          // 1. Kontrollime algust: kas sFrom juures algab suvaline täg?
+          const startTagMatch = docText.slice(sFrom, sFrom + 20).match(/^<[^>]+>/);
+          if (startTagMatch) {
+            const tagName = startTagMatch[0].match(/[a-z]+/)?.[0];
+            // Kui on struktuuri-täg, hüppame sisse
+            if (tagName && ['m', 'hi', 'fn'].includes(tagName)) {
+              sFrom += startTagMatch[0].length;
+              adjusted = true;
+            }
+          }
+
+          // 2. Kontrollime lõppu: kas sTo juures lõpeb suvaline täg?
+          const endTagMatch = docText.slice(Math.max(0, sTo - 15), sTo).match(/<\/[^>]+>$/);
+          if (endTagMatch) {
+            const tagName = endTagMatch[0].match(/[a-z]+/)?.[0];
+            if (tagName && ['m', 'hi', 'fn'].includes(tagName)) {
+              sTo -= endTagMatch[0].length;
+              adjusted = true;
+            }
+          }
+
+          if (sFrom >= sTo) break;
+        }
+      }
+
+      if (mode === 'unwrap') {
+        const container = findContainer(tag, sFrom, docText, line.from, line.to);
+        if (container && sTo <= container.closeEnd) {
+          changes.push({ from: container.open, to: container.openEnd, insert: '' });
+          changes.push({ from: container.close, to: container.closeEnd, insert: '' });
+        }
+      } else {
+        // Kui sFrom/sTo asub olemasoleva sama tägi sees, laienda piir tägi alguse/lõpuni
+        const startContainer = findContainer(tag, sFrom, docText, line.from, line.to);
+        if (startContainer && sFrom > startContainer.open) sFrom = startContainer.open;
+        const endContainer = findContainer(tag, sTo, docText, line.from, line.to);
+        if (endContainer && sTo < endContainer.closeEnd) sTo = endContainer.closeEnd;
+
+        // WRAP: Eemaldame enne sisemised sama tüüpi tägid, et vältida dubleerimist
+        const innerPairs = findInnerPairs(tag, sFrom, sTo, docText);
+        // Kui selektsioon algab/lõpeb täpselt olemasoleva tägi piiril, kasuta seda tägina
+        // (ära loo uut tägi samale positsioonile — tekitaks konflikti ja pesastuse)
+        const leadingPair = innerPairs.length > 0 && innerPairs[0].open === sFrom ? innerPairs[0] : null;
+        const trailingPair = innerPairs.length > 0 && innerPairs[innerPairs.length - 1].closeEnd === sTo ? innerPairs[innerPairs.length - 1] : null;
+        if (!leadingPair) changes.push({ from: sFrom, to: sFrom, insert: openTag });
+        for (const p of innerPairs) {
+          if (p === leadingPair) {
+            changes.push({ from: p.close, to: p.closeEnd, insert: '' });
+          } else if (p === trailingPair) {
+            changes.push({ from: p.open, to: p.openEnd, insert: '' });
+          } else {
+            changes.push({ from: p.open, to: p.openEnd, insert: '' });
+            changes.push({ from: p.close, to: p.closeEnd, insert: '' });
+          }
+        }
+        if (!trailingPair) changes.push({ from: sTo, to: sTo, insert: closeTag });
+      }
+    }
+
+    if (changes.length > 0) {
+      const tr = view.state.update({
+        changes,
+        selection: EditorSelection.range(
+          view.state.changes(changes).mapPos(from, 1),
+          view.state.changes(changes).mapPos(to, -1)
+        ),
+        scrollIntoView: false,
+        annotations: Transaction.userEvent.of('input.format')
+      });
+      view.dispatch(tr);
+    }
+    view.focus();
+  }, [readOnly, viewRef]);
+
+  const insertAtCursor = useCallback((text: string) => {
+    const view = viewRef.current;
+    if (!view || readOnly) return;
+    view.dispatch(view.state.replaceSelection(text));
+    view.focus();
+  }, [readOnly, viewRef]);
+
+  const insertSpecialChar = useCallback((char: string, e?: MouseEvent) => {
+    if (e) e.preventDefault();
+    insertAtCursor(char);
+  }, [insertAtCursor]);
+
+  // Uus marginaalia: valik tõstetakse <m> plokki valiku algusrea kohale;
+  // ilma valikuta tühi <m></m> kursori rea kohale. Mõlemal juhul kohe avatuna.
+  const insertMarginalia = useCallback(() => {
+    const view = viewRef.current;
+    if (!view || readOnly) return;
+    let { from, to } = view.state.selection.main;
+
+    if (from === to) {
+      const line = view.state.doc.lineAt(from);
+      view.dispatch({
+        changes: { from: line.from, insert: '<m></m>\n' },
+        effects: openMarginalia.of(line.from + 3),
+        selection: EditorSelection.cursor(line.from + 3),
+        annotations: Transaction.userEvent.of('input.format'),
+      });
+      view.focus();
+      return;
+    }
+
+    // Laienda valikut üle poolikute tägide (sama loogika mis cleanMarkup)
+    const { tagRanges } = view.state.field(vuttMarkupField);
+    for (const r of tagRanges) {
+      if (r.from < to && r.to > from) {
+        from = Math.min(from, r.from);
+        to = Math.max(to, r.to);
+      }
+    }
+    const hidden = hiddenBlockRanges(view.state).filter(h => h.from < to && h.to > from);
+    const { changes, cursor } = marginaliaFromSelection(
+      view.state.doc.toString(), from, to, hidden,
+    );
+    view.dispatch({
+      changes,
+      effects: openMarginalia.of(changes[0].from + 3),
+      selection: EditorSelection.cursor(cursor),
+      annotations: Transaction.userEvent.of('input.format'),
+    });
+    view.focus();
+  }, [readOnly, viewRef]);
+
+  const cleanMarkup = useCallback(() => {
+    const view = viewRef.current;
+    if (!view || readOnly) return;
+    let { from, to } = view.state.selection.main;
+    if (from === to) return;
+
+    // Laienda valikut, et hõlmata kõik osaliselt kattuvad tägid
+    // (mouse-valik võib lõppeda tägi sees → ilma laienduseta jääb poolik täg alles)
+    const { tagRanges } = view.state.field(vuttMarkupField);
+    for (const r of tagRanges) {
+      if (r.from < to && r.to > from) {
+        from = Math.min(from, r.from);
+        to = Math.max(to, r.to);
+      }
+    }
+
+    // Puhasta iga nähtav segment ERALDI muudatusena — peidetud marginaalia
+    // plokke ei puudutata üldse, nii jäävad nad oma ridadele ja ankrutele
+    // (üks valikut kattev muudatus laseks kaitsefiltril ploki valiku lõppu
+    // nihutada, kus ta degradeeruks inline-margiks)
+    const hidden = hiddenBlockRanges(view.state).filter(h => h.from < to && h.to > from);
+    const specs = cleanMarkupSpecs(
+      view.state.doc.toString(), from, to, hidden,
+      s => s.replace(/<\/?(?:i|b|cs|m|hi|fn|pb)[^>]*>/g, ''),
+    );
+    if (specs.length === 0) return;
+    const changes = view.state.changes(specs);
+
+    view.dispatch({
+      changes,
+      selection: EditorSelection.range(changes.mapPos(from, -1), changes.mapPos(to, 1)),
+      annotations: Transaction.userEvent.of('input.format'),
+    });
+    view.focus();
+  }, [readOnly, viewRef]);
+
+  return {
+    wrapWithTag,
+    insertAtCursor,
+    insertSpecialChar,
+    insertMarginalia,
+    cleanMarkup,
+  };
+}


### PR DESCRIPTION
## Kokkuvõte
- tõstab TextEditor.tsx toolbar’i vormindusloogika eraldi `useEditorFormattingActions` hooki
- koondab `wrapWithTag`, `insertAtCursor`, `insertSpecialChar`, `insertMarginalia` ja `cleanMarkup`
- vähendab TextEditor.tsx mahtu järgmise väikese refaktori sammuna

## Kontroll
- `npm run typecheck`
- `npm run build`

Refs #89