### PR TITLE
Luba tekstiannotatsioon ilma kommentaarita

### DIFF
--- a/src/components/editor/AnnotationDialog.tsx
+++ b/src/components/editor/AnnotationDialog.tsx
@@ -41,7 +41,7 @@ export default function AnnotationDialog({
               value={comment}
               onChange={e => onCommentChange(e.target.value)}
               onKeyDown={e => {
-                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && comment.trim()) onSave(comment.trim());
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) onSave(comment.trim());
                 if (e.key === 'Escape') onCancel();
               }}
             />
@@ -51,9 +51,8 @@ export default function AnnotationDialog({
               </button>
               <button
                 type="button"
-                disabled={!comment.trim()}
-                onClick={() => { if (comment.trim()) onSave(comment.trim()); }}
-                className="px-3 py-1.5 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded disabled:opacity-50"
+                onClick={() => onSave(comment.trim())}
+                className="px-3 py-1.5 text-sm bg-yellow-500 hover:bg-yellow-600 text-white rounded"
               >
                 {t('common:buttons.save', 'Salvesta')}
               </button>

--- a/src/components/editor/AnnotationPopover.tsx
+++ b/src/components/editor/AnnotationPopover.tsx
@@ -106,7 +106,11 @@ export default function AnnotationPopover({
           </div>
         ) : annotation ? (
           <>
-            <p className="text-sm text-gray-800 mb-2 leading-relaxed whitespace-pre-wrap">{annotation.comment}</p>
+            {annotation.comment.trim() ? (
+              <p className="text-sm text-gray-800 mb-2 leading-relaxed whitespace-pre-wrap">{annotation.comment}</p>
+            ) : (
+              <p className="text-sm text-gray-400 italic mb-2">{t('annotations.orphanedAnchor', 'Kommentaar puudub')}</p>
+            )}
             <div className="flex items-center justify-between border-t border-gray-100 pt-2">
               <span className="text-xs text-gray-400">{annotation.author}</span>
               {!readOnly && (


### PR DESCRIPTION
## Kokkuvõte
- Highlight-nupp lubab valiku salvestada ka **ilma kommentaarita** — kasutaja märgib teksti ära ja kommenteerib soovi korral hiljem
- `AnnotationDialog`: Salvesta-nupp ei ole enam keelatud tühja kommentaari korral (dialoog + Ctrl+Enter)
- `AnnotationPopover`: kommentaarita märkel kuvatakse summutatud „Kommentaar puudub", pliiats jääb hilisemaks muutmiseks alles

## Disain
- Valik on endiselt kohustuslik (`from === to` blokeerib) — muutub ainult kommentaari kohustuslikkus
- Tühja kommentaari annotatsioon salvestatakse **metaandmetesse** (mitte metaandmeteta ankruna), et `nextAnnId` näeks ID-d ega tekiks kokkupõrget järgmise annotatsiooniga
- `text_annotations` salvestatakse ilma pruninguta → tühi märge säilib reloadi järel

## Kontroll
- `npm run typecheck`
- `npm run build`
- Käsitsi testitud: loo tühja kommentaariga highlight → reload → popover „Kommentaar puudub" → pliiats → lisa kommentaar

🤖 Generated with [Claude Code](https://claude.com/claude-code)