### PR TITLE
Refactor TextEditor info and history tabs

### DIFF
--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -3,10 +3,9 @@ import { Page, PageStatus, Annotation, Work } from '../types';
 import type { Collections } from '../services/collectionService';
 import type { TextAnnotation } from '../types';
 import { useUser } from '../contexts/UserContext';
-import AnnotationsTab from './editor/AnnotationsTab';
-import HistoryTab from './editor/HistoryTab';
 import EditorHeader from './editor/EditorHeader';
 import EditorEditTab from './editor/EditorEditTab';
+import EditorInfoHistoryTabs from './editor/EditorInfoHistoryTabs';
 import AnnotationDialog from './editor/AnnotationDialog';
 import AnnotationPopover from './editor/AnnotationPopover';
 
@@ -259,57 +258,36 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
           insertSpecialChar={insertSpecialChar}
         />
 
-        {activeTab === 'annotate' && (
-          <AnnotationsTab
-            work={work}
-            page={page}
-            page_tags={page_tags}
-            setPageTags={setPageTags}
-            comments={comments}
-            setComments={setComments}
-            onDraftChange={setAnnotationDraftDirty}
-            flushRef={commentFlushRef}
-            onSaveAnnotations={handleSaveAnnotations}
-            onCommentsRestored={handleCommentsRestored}
-            onReplyToComment={handleReplyToComment}
-            readOnly={readOnly || false}
-            user={user}
-            authToken={authToken}
-            onOpenMetaModal={onOpenMetaModal}
-            lang={lang}
-            textAnnotations={textAnnotations}
-            textContent={viewRef.current?.state.doc.toString() ?? page.text_content}
-            onSaveTextAnnotations={handleSaveTextAnnotations}
-            onDeleteTextAnnotation={handleDeleteAndSaveTextAnnotation}
-          />
-        )}
-
-        {activeTab === 'history' && (
-          <HistoryTab
-            page={page}
-            work={work}
-            user={user}
-            authToken={authToken}
-            handleReOcr={handleReOcr}
-            reocrStatus={reocrStatus}
-            onShareableChange={(shareable) => onWorkUpdate?.({ shareable })}
-            collections={collections}
-            onRestore={(content, restoredTextAnnotations) => {
-              const view = viewRef.current;
-              if (view) {
-                view.dispatch({
-                  changes: { from: 0, to: view.state.doc.length, insert: content },
-                });
-                setIsDirty(true);
-              }
-              if (Array.isArray(restoredTextAnnotations)) {
-                setTextAnnotations(restoredTextAnnotations);
-              }
-              setActiveTab('edit');
-            }}
-            readOnly={readOnly || false}
-          />
-        )}
+        <EditorInfoHistoryTabs
+          activeTab={activeTab}
+          page={page}
+          work={work}
+          user={user}
+          authToken={authToken}
+          readOnly={readOnly}
+          collections={collections}
+          onOpenMetaModal={onOpenMetaModal}
+          onWorkUpdate={onWorkUpdate}
+          lang={lang}
+          viewRef={viewRef}
+          setIsDirty={setIsDirty}
+          setActiveTab={setActiveTab}
+          page_tags={page_tags}
+          setPageTags={setPageTags}
+          comments={comments}
+          setComments={setComments}
+          setAnnotationDraftDirty={setAnnotationDraftDirty}
+          commentFlushRef={commentFlushRef}
+          handleSaveAnnotations={handleSaveAnnotations}
+          handleCommentsRestored={handleCommentsRestored}
+          handleReplyToComment={handleReplyToComment}
+          textAnnotations={textAnnotations}
+          setTextAnnotations={setTextAnnotations}
+          handleSaveTextAnnotations={handleSaveTextAnnotations}
+          handleDeleteAndSaveTextAnnotation={handleDeleteAndSaveTextAnnotation}
+          handleReOcr={handleReOcr}
+          reocrStatus={reocrStatus}
+        />
       </div>
     </div>
 

--- a/src/components/editor/EditorInfoHistoryTabs.tsx
+++ b/src/components/editor/EditorInfoHistoryTabs.tsx
@@ -1,0 +1,130 @@
+import type { MutableRefObject } from 'react';
+import type { EditorView } from '@codemirror/view';
+import type { Annotation, Page, Work, TextAnnotation } from '../../types';
+import type { Collections } from '../../services/collectionService';
+import AnnotationsTab from './AnnotationsTab';
+import HistoryTab from './HistoryTab';
+import type { EditorTab } from './types';
+import type { ReocrStatus } from './useReOcr';
+
+interface EditorInfoHistoryTabsProps {
+  activeTab: EditorTab;
+  page: Page;
+  work?: Work;
+  user: unknown;
+  authToken: string | null;
+  readOnly: boolean;
+  collections?: Collections;
+  onOpenMetaModal?: () => void;
+  onWorkUpdate?: (updatedWork: Partial<Work>) => void;
+  lang: string;
+  viewRef: MutableRefObject<EditorView | null>;
+  setIsDirty: (dirty: boolean) => void;
+  setActiveTab: (tab: EditorTab) => void;
+
+  page_tags: Page['page_tags'];
+  setPageTags: (tags: Page['page_tags']) => void;
+  comments: Annotation[];
+  setComments: (comments: Annotation[]) => void;
+  setAnnotationDraftDirty: (dirty: boolean) => void;
+  commentFlushRef: MutableRefObject<(() => Annotation[] | null) | null>;
+  handleSaveAnnotations: (comments: Annotation[]) => Promise<void>;
+  handleCommentsRestored: (comments: Annotation[]) => void;
+  handleReplyToComment: (commentId: string, replyText: string) => Promise<void>;
+
+  textAnnotations: TextAnnotation[];
+  setTextAnnotations: (annotations: TextAnnotation[]) => void;
+  handleSaveTextAnnotations: (annotations: TextAnnotation[]) => Promise<void>;
+  handleDeleteAndSaveTextAnnotation: (annId: number) => Promise<void>;
+
+  handleReOcr: () => Promise<void>;
+  reocrStatus: ReocrStatus;
+}
+
+// Info- ja ajaloo-vahekaardid. Edit-tab jääb alati DOM-i eraldi komponendis.
+export default function EditorInfoHistoryTabs({
+  activeTab,
+  page,
+  work,
+  user,
+  authToken,
+  readOnly,
+  collections,
+  onOpenMetaModal,
+  onWorkUpdate,
+  lang,
+  viewRef,
+  setIsDirty,
+  setActiveTab,
+  page_tags,
+  setPageTags,
+  comments,
+  setComments,
+  setAnnotationDraftDirty,
+  commentFlushRef,
+  handleSaveAnnotations,
+  handleCommentsRestored,
+  handleReplyToComment,
+  textAnnotations,
+  setTextAnnotations,
+  handleSaveTextAnnotations,
+  handleDeleteAndSaveTextAnnotation,
+  handleReOcr,
+  reocrStatus,
+}: EditorInfoHistoryTabsProps) {
+  return (
+    <>
+      {activeTab === 'annotate' && (
+        <AnnotationsTab
+          work={work}
+          page={page}
+          page_tags={page_tags}
+          setPageTags={setPageTags}
+          comments={comments}
+          setComments={setComments}
+          onDraftChange={setAnnotationDraftDirty}
+          flushRef={commentFlushRef}
+          onSaveAnnotations={handleSaveAnnotations}
+          onCommentsRestored={handleCommentsRestored}
+          onReplyToComment={handleReplyToComment}
+          readOnly={readOnly || false}
+          user={user}
+          authToken={authToken}
+          onOpenMetaModal={onOpenMetaModal}
+          lang={lang}
+          textAnnotations={textAnnotations}
+          textContent={viewRef.current?.state.doc.toString() ?? page.text_content}
+          onSaveTextAnnotations={handleSaveTextAnnotations}
+          onDeleteTextAnnotation={handleDeleteAndSaveTextAnnotation}
+        />
+      )}
+
+      {activeTab === 'history' && (
+        <HistoryTab
+          page={page}
+          work={work}
+          user={user}
+          authToken={authToken}
+          handleReOcr={handleReOcr}
+          reocrStatus={reocrStatus}
+          onShareableChange={(shareable) => onWorkUpdate?.({ shareable })}
+          collections={collections}
+          onRestore={(content, restoredTextAnnotations) => {
+            const view = viewRef.current;
+            if (view) {
+              view.dispatch({
+                changes: { from: 0, to: view.state.doc.length, insert: content },
+              });
+              setIsDirty(true);
+            }
+            if (Array.isArray(restoredTextAnnotations)) {
+              setTextAnnotations(restoredTextAnnotations);
+            }
+            setActiveTab('edit');
+          }}
+          readOnly={readOnly || false}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Kokkuvõte
- tõstab TextEditor.tsx info- ja ajaloo-vahekaardid eraldi `EditorInfoHistoryTabs` komponendiks
- koondab `AnnotationsTab`/`HistoryTab` renderduse ja history restore callbacki
- vähendab TextEditor.tsx mahtu järgmise väikese refaktori sammuna

## Kontroll
- `npm run typecheck`
- `npm run build`

Refs #89