### PR TITLE
fix: Review-lehel re-OCR tööde teose pealkiri (slug jääb)

### DIFF
--- a/server/routers/reocr.py
+++ b/server/routers/reocr.py
@@ -57,16 +57,42 @@ async def admin_reocr_status(job_id: str, user=Depends(require_role("admin"))):
     return {"status": "success", **poll_reocr_job(job_id)}
 
 
+def _enrich_titles(items: list) -> list:
+    """Lisab igale re-OCR kirjele 'title' (teose pealkiri work_id järgi). Slug jääb alles
+    (tehniline, OCR-serveris vaatamiseks). Fallback pealkirjale = slug. Per-call cache."""
+    title_cache: dict = {}
+    for it in items:
+        work_id = it.get("work_id")
+        slug = it.get("slug", "")
+        if not work_id:
+            it["title"] = slug
+            continue
+        if work_id not in title_cache:
+            title = slug
+            path = find_directory_by_id(work_id)
+            if path:
+                try:
+                    with open(os.path.join(path, "_metadata.json"), "r", encoding="utf-8") as f:
+                        title = json.load(f).get("title") or slug
+                except Exception:
+                    pass
+            title_cache[work_id] = title
+        it["title"] = title_cache[work_id]
+    return items
+
+
 @router.get("/admin/reocr/jobs")
 async def admin_reocr_jobs(user=Depends(require_role("admin"))):
     """Tagastab kõigi aktiivsete ja hiljutiste re-OCR tööde loendi."""
-    return {"status": "success", "jobs": list_reocr_jobs()}
+    return {"status": "success", "jobs": _enrich_titles(list_reocr_jobs())}
 
 
 @router.get("/admin/reocr/log")
 async def admin_reocr_log(offset: int = 0, limit: int = 50, user=Depends(require_role("admin"))):
     """Tagastab re-OCR ajalogi (püsiv, uuemad ees)."""
-    return {"status": "success", **get_reocr_log(offset, limit)}
+    log = get_reocr_log(offset, limit)
+    log["entries"] = _enrich_titles(log["entries"])
+    return {"status": "success", **log}
 
 
 @router.get("/admin/work/{work_id}/page-ocr")

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -69,6 +69,7 @@ interface ReocrJob {
   slow?: boolean;
   slow_since?: number | null;
   queue_ahead?: number;
+  title?: string;
 }
 
 interface DiffData {
@@ -569,7 +570,10 @@ const Review: React.FC = () => {
                         {/* Info */}
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 flex-wrap">
-                            <span className="font-medium text-gray-800 text-sm">{job.slug}</span>
+                            <span className="font-medium text-gray-800 text-sm">{job.title || job.slug}</span>
+                            {job.title && (
+                              <span className="text-xs text-gray-400 font-mono" title={job.slug}>{job.slug}</span>
+                            )}
                             {job.page_number && (
                               <span className="text-xs text-gray-500">lk {job.page_number}</span>
                             )}
@@ -651,7 +655,8 @@ const Review: React.FC = () => {
                           </div>
                           <div className="flex-1 min-w-0">
                             <div className="flex items-center gap-2 flex-wrap">
-                              <span className="text-gray-700">{entry.slug}</span>
+                              <span className="text-gray-700">{entry.title || entry.slug}</span>
+                              {entry.title && <span className="text-xs text-gray-400 font-mono" title={entry.slug}>{entry.slug}</span>}
                               {entry.page_number && <span className="text-xs text-gray-400">lk {entry.page_number}</span>}
                               {entry.work_id && entry.page_number && (
                                 <a href={`/work/${entry.work_id}/${entry.page_number}`} target="_blank" rel="noreferrer"


### PR DESCRIPTION
Review-leht näitas re-OCR tööde juures ainult tehnilist slug'i (nt `1834-lysiae-defensio-adversus-simonem-3jxlnc`).

Nüüd: **teose pealkiri esile**, slug jääb kõrvale monospace-tehnilise infona (kasulik OCR-serveris vaatamiseks).

- Backend `_enrich_titles` (`routers/reocr.py`) rikastab jobs + log endpointid `work_id` → `_metadata.json` `title` (per-call cache, fallback slug). `reocr_ops` jääb puhtaks.
- Frontend `Review.tsx`: aktiivsed tööd + ajalugu näitavad `title || slug`; slug `title`-attribuudiga hover'il.

Typecheck puhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)