### PR TITLE
feat: OCR recovery hardening (Faas 1) — batch-orbude taaste + taastatud page_number

### DIFF
--- a/docs/superpowers/plans/2026-07-01-ocr-jobs-unified-view-phase2.md
+++ b/docs/superpowers/plans/2026-07-01-ocr-jobs-unified-view-phase2.md
@@ -1,0 +1,712 @@
+# OCR-tööde ühtne vaade (Faas 2) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Review-lehel üks ajajärjestatud nimekiri, mis näitab KÕIKI OCR-serveri töid (upload + üksik re-OCR + batch) tüübi-badge'i, ühtse staatuse ja järjekindla lingiga.
+
+**Architecture:** Uus backend endpoint `GET /admin/ocr/jobs` kutsub puhast normaliseerijat `normalize_ocr_jobs(uploads, reocr_singles, reocr_batches, title_of)`, mis toodab ühtse kirje-kuju (tüüp, staatus, eelarvutatud link). Frontend renderdab ühe nimekirja. Upload-lingid deep-linkivad `/upload?resumeUpload={id}` → progress kohe näha.
+
+**Tech Stack:** Python 3.9 (FastAPI), pytest; React 19 + TS, react-router, i18next.
+
+**Eeldus:** Faas 1 (`2026-07-01-ocr-recovery-hardening-phase1.md`) on tarnitud (page_number lingid, batch-recovery). Faas 2 ei sõltu Faas 1 koodist otseselt, aga tarnitakse pärast.
+
+## Global Constraints
+
+- **Python 3.9 compat:** `Optional[X]`, `Dict`, `List` — MITTE `X | None`.
+- **Testid:** `.venv/bin/python -m pytest tests/ -q`. Frontend: `npm run typecheck`.
+- **Normaliseerija = puhas funktsioon** — DOM-/IO-vaba, `title_of` süstitakse; testitav ilma serverita.
+- **`slow` on lipp** (status_key jääb `processing`, slow eraldi boolean).
+- **Link arvutatakse backendis** (üks tõeallikas; frontend ei dubleeri tingimusi).
+- **Sort-võti `started_at or 0.0`** — None ei tohi crash'ida (Py TypeError / JS ebastabiilne).
+- **Commit-lõpp:** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+## File Structure
+
+| Fail | Vastutus | Muudatus |
+|------|----------|----------|
+| `server/reocr_ops.py` | + `list_reocr_batch_jobs()` (batch-summaarid globaalselt) | Lisa funktsioon |
+| `server/ocr_jobs_normalize.py` | Puhas `normalize_ocr_jobs(...)` + `status_key`/`link` loogika | **Uus** |
+| `server/routers/ocr_jobs.py` | `GET /admin/ocr/jobs` endpoint + title-cache | **Uus** |
+| `server/main.py` | Registreeri `ocr_jobs` router | 2 rida |
+| `src/pages/Review.tsx` | Fetch `/admin/ocr/jobs`; ühtne nimekiri, tüübi-badge | Edit |
+| `src/pages/upload/useUploadWizard.ts` | Deep-link `?resumeUpload=` → `handleResume` | Lisa effect |
+| `src/locales/{et,en}/review.json` | Tüübi-badge'id, uued status-kuvad | Edit |
+| `tests/test_ocr_jobs_normalize.py` | Normaliseerija testid | **Uus** |
+| `tests/test_reocr_batch.py` | `list_reocr_batch_jobs` test | Lisa |
+
+---
+
+## Task 1: `list_reocr_batch_jobs()` (`reocr_ops.py`)
+
+**Files:**
+- Modify: `server/reocr_ops.py` (lisa funktsioon `list_reocr_jobs` juurde)
+- Test: `tests/test_reocr_batch.py` (lisa)
+
+**Interfaces:**
+- Produces: `list_reocr_batch_jobs() -> list` — iga batch-jobi kohta `{job_id, work_id, slug, username, status, slow, started_at, ready, total}`.
+
+- [ ] **Step 1: Write the failing test** (lisa `tests/test_reocr_batch.py` lõppu)
+
+```python
+def test_list_reocr_batch_jobs_summary():
+    import server.reocr_ops as r
+    with r._reocr_batch_jobs_lock:
+        r._reocr_batch_jobs.clear()
+        r._reocr_batch_jobs["b1"] = {
+            "kind": "batch", "work_id": "wid", "slug": "w1", "username": "u",
+            "status": "processing", "slow": True, "started_at": 123.0,
+            "pages": [{"status": "ready"}, {"status": "processing"}, {"status": "error"}],
+        }
+    out = {j["job_id"]: j for j in r.list_reocr_batch_jobs()}
+    assert out["b1"]["work_id"] == "wid"
+    assert out["b1"]["ready"] == 1        # ainult "ready"
+    assert out["b1"]["total"] == 3
+    assert out["b1"]["slow"] is True
+    assert out["b1"]["started_at"] == 123.0
+    with r._reocr_batch_jobs_lock:
+        r._reocr_batch_jobs.clear()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_batch.py::test_list_reocr_batch_jobs_summary -q`
+Expected: FAIL — `AttributeError: ... 'list_reocr_batch_jobs'`
+
+- [ ] **Step 3: Implement** (lisa `server/reocr_ops.py`-sse, `list_reocr_jobs` järele)
+
+```python
+def list_reocr_batch_jobs() -> list:
+    """Batch re-OCR tööde summaarid (ühtse OCR-vaate jaoks)."""
+    with _reocr_batch_jobs_lock:
+        items = list(_reocr_batch_jobs.items())
+    out = []
+    for jid, j in items:
+        pages = j.get("pages", [])
+        out.append({
+            "job_id": jid,
+            "work_id": j.get("work_id"),
+            "slug": j.get("slug", ""),
+            "username": j.get("username", ""),
+            "status": j.get("status"),
+            "slow": bool(j.get("slow", False)),
+            "started_at": j.get("started_at"),
+            "ready": sum(1 for e in pages if e.get("status") == "ready"),
+            "total": len(pages),
+        })
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_batch.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/reocr_ops.py tests/test_reocr_batch.py
+git commit -m "feat: list_reocr_batch_jobs — batch-summaarid ühtse OCR-vaate jaoks
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Puhas normaliseerija (`ocr_jobs_normalize.py`)
+
+**Files:**
+- Create: `server/ocr_jobs_normalize.py`
+- Test: `tests/test_ocr_jobs_normalize.py`
+
+**Interfaces:**
+- Consumes: upload-state dict'id (`list_uploads`), reocr-single dict'id (`list_reocr_jobs`), reocr-batch dict'id (`list_reocr_batch_jobs`, Task 1).
+- Produces:
+  - `normalize_ocr_jobs(uploads: List[dict], singles: List[dict], batches: List[dict], title_of: Callable[[Optional[str]], str]) -> List[dict]` — ühtne, ajajärjestatud (started_at DESC, None→0.0) kirjete loend kujuga: `{id, type, title, slug, work_id, page_number, status_key, slow, started_at, progress, link, error}`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_ocr_jobs_normalize.py
+"""normalize_ocr_jobs — puhas OCR-tööde normaliseerija."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from server.ocr_jobs_normalize import normalize_ocr_jobs
+
+
+def _title_of(work_id):
+    return {"wid": "Teose Pealkiri"}.get(work_id, work_id or "")
+
+
+def test_normalize_upload_reviewing():
+    uploads = [{
+        "id": "u1", "status": "reviewing",
+        "meta": {"title": "Uus teos", "slug": "uus-teos-x", "work_id": "wx"},
+        "expected_pages": 12, "created_at": "2026-07-01T10:00:00",
+        "files": [{"has_ocr": True, "deleted": False}, {"has_ocr": False, "deleted": False}],
+    }]
+    out = normalize_ocr_jobs(uploads, [], [], _title_of)
+    e = out[0]
+    assert e["type"] == "upload"
+    assert e["title"] == "Uus teos"
+    assert e["status_key"] == "review"
+    assert e["progress"] == {"ready": 1, "total": 12}
+    assert e["link"] == "/upload?resumeUpload=u1"
+    assert e["started_at"] > 0
+
+
+def test_normalize_upload_import_error():
+    uploads = [{"id": "u2", "status": "error", "error_message": "import ebaõnnestus",
+                "meta": {"title": "X", "slug": "x", "work_id": "wx"},
+                "expected_pages": None, "created_at": "2026-07-01T10:00:00", "files": []}]
+    e = normalize_ocr_jobs(uploads, [], [], _title_of)[0]
+    assert e["status_key"] == "error"
+    assert e["error"] == "import ebaõnnestus"
+    assert e["link"] == "/upload?resumeUpload=u2"
+
+
+def test_normalize_reocr_single_done_links_page():
+    singles = [{"job_id": "s1", "work_id": "wid", "slug": "w1", "page_number": 42,
+                "status": "done", "slow": False, "started_at": 100.0, "error": None}]
+    e = normalize_ocr_jobs([], singles, [], _title_of)[0]
+    assert e["type"] == "reocr"
+    assert e["title"] == "Teose Pealkiri"
+    assert e["status_key"] == "ready"
+    assert e["link"] == "/work/wid/42"
+    assert e["page_number"] == 42
+
+
+def test_normalize_reocr_single_no_page_links_work():
+    singles = [{"job_id": "s2", "work_id": "wid", "slug": "w1", "page_number": None,
+                "status": "done", "slow": False, "started_at": 100.0, "error": None}]
+    e = normalize_ocr_jobs([], singles, [], _title_of)[0]
+    assert e["link"] == "/work/wid"
+
+
+def test_normalize_reocr_batch():
+    batches = [{"job_id": "b1", "work_id": "wid", "slug": "w1", "status": "processing",
+                "slow": True, "started_at": 50.0, "ready": 3, "total": 8}]
+    e = normalize_ocr_jobs([], [], batches, _title_of)[0]
+    assert e["type"] == "batch"
+    assert e["status_key"] == "processing"
+    assert e["slow"] is True
+    assert e["progress"] == {"ready": 3, "total": 8}
+    assert e["link"] == "/work/wid"
+
+
+def test_normalize_missing_fields_and_sort():
+    # started_at=None ei tohi sort'i crash'ida; title puudub → slug
+    uploads = [{"id": "u3", "status": "processing",
+                "meta": {"title": "", "slug": "slug-only", "work_id": None},
+                "expected_pages": None, "created_at": "vigane-kuupäev", "files": []}]
+    singles = [{"job_id": "s3", "work_id": "wid", "slug": "w1", "page_number": 1,
+                "status": "processing", "slow": False, "started_at": None, "error": None}]
+    out = normalize_ocr_jobs(uploads, singles, [], _title_of)
+    assert len(out) == 2
+    u = next(x for x in out if x["id"] == "u3")
+    assert u["title"] == "slug-only"          # tühi title → slug
+    assert u["started_at"] == 0.0             # vigane created_at → 0.0
+    assert u["link"] == "/upload?resumeUpload=u3"
+
+
+def test_normalize_sorted_desc():
+    singles = [
+        {"job_id": "a", "work_id": "wid", "slug": "w", "page_number": 1, "status": "done", "slow": False, "started_at": 10.0, "error": None},
+        {"job_id": "b", "work_id": "wid", "slug": "w", "page_number": 2, "status": "done", "slow": False, "started_at": 30.0, "error": None},
+        {"job_id": "c", "work_id": "wid", "slug": "w", "page_number": 3, "status": "done", "slow": False, "started_at": 20.0, "error": None},
+    ]
+    ids = [e["id"] for e in normalize_ocr_jobs([], singles, [], _title_of)]
+    assert ids == ["b", "c", "a"]  # started_at DESC
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.ocr_jobs_normalize'`
+
+- [ ] **Step 3: Implement**
+
+```python
+# server/ocr_jobs_normalize.py
+"""Puhas normaliseerija: upload + üksik/batch re-OCR tööd ÜHE kujuni ühtse vaate jaoks.
+
+DOM-/IO-vaba. title_of süstitakse (endpoint annab cache'itud lugeja, test lambda).
+"""
+from datetime import datetime
+from typing import Callable, Dict, List, Optional
+
+
+def _parse_ts(value) -> float:
+    """ISO-string VÕI float → timestamp; parse-viga → 0.0 (sort-turvaline)."""
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return datetime.fromisoformat(str(value)).timestamp()
+    except Exception:
+        return 0.0
+
+
+def _upload_status_key(status: str) -> str:
+    if status in ("pending", "uploading", "collecting_images"):
+        return "uploading"
+    if status == "processing":
+        return "processing"
+    if status in ("reviewing", "done"):
+        return "review"
+    if status == "imported":
+        return "imported"
+    return "error"
+
+
+def _upload_link(state: dict, status_key: str) -> str:
+    if status_key == "imported":
+        wid = state.get("meta", {}).get("work_id")
+        return f"/work/{wid}" if wid else "/upload"
+    return f"/upload?resumeUpload={state.get('id')}"
+
+
+def _normalize_upload(state: dict, title_of) -> dict:
+    meta = state.get("meta", {}) or {}
+    status = state.get("status", "pending")
+    status_key = _upload_status_key(status)
+    files = state.get("files", []) or []
+    ready = sum(1 for f in files if f.get("has_ocr") and not f.get("deleted"))
+    total = state.get("expected_pages") or len(files)
+    title = meta.get("title") or meta.get("slug", "")
+    return {
+        "id": state.get("id"),
+        "type": "upload",
+        "title": title,
+        "slug": meta.get("slug", ""),
+        "work_id": meta.get("work_id"),
+        "page_number": None,
+        "status_key": status_key,
+        "slow": False,
+        "started_at": _parse_ts(state.get("created_at")),
+        "progress": {"ready": ready, "total": total} if total else None,
+        "link": _upload_link(state, status_key),
+        "error": state.get("error_message"),
+    }
+
+
+def _reocr_status_key(status: str) -> str:
+    if status in ("uploading",):
+        return "uploading"
+    if status == "processing":
+        return "processing"
+    if status == "done":
+        return "ready"
+    return "error"
+
+
+def _work_link(work_id: Optional[str], page_number) -> str:
+    if not work_id:
+        return ""
+    return f"/work/{work_id}/{page_number}" if page_number else f"/work/{work_id}"
+
+
+def _normalize_single(job: dict, title_of) -> dict:
+    return {
+        "id": job.get("job_id"),
+        "type": "reocr",
+        "title": title_of(job.get("work_id")) or job.get("slug", ""),
+        "slug": job.get("slug", ""),
+        "work_id": job.get("work_id"),
+        "page_number": job.get("page_number"),
+        "status_key": _reocr_status_key(job.get("status")),
+        "slow": bool(job.get("slow", False)),
+        "started_at": _parse_ts(job.get("started_at")),
+        "progress": None,
+        "link": _work_link(job.get("work_id"), job.get("page_number")),
+        "error": job.get("error"),
+    }
+
+
+def _normalize_batch(job: dict, title_of) -> dict:
+    total = job.get("total", 0)
+    return {
+        "id": job.get("job_id"),
+        "type": "batch",
+        "title": title_of(job.get("work_id")) or job.get("slug", ""),
+        "slug": job.get("slug", ""),
+        "work_id": job.get("work_id"),
+        "page_number": None,
+        "status_key": _reocr_status_key(job.get("status")),
+        "slow": bool(job.get("slow", False)),
+        "started_at": _parse_ts(job.get("started_at")),
+        "progress": {"ready": job.get("ready", 0), "total": total} if total else None,
+        "link": _work_link(job.get("work_id"), None),
+        "error": job.get("error"),
+    }
+
+
+def normalize_ocr_jobs(uploads: List[dict], singles: List[dict], batches: List[dict],
+                       title_of: Callable[[Optional[str]], str]) -> List[dict]:
+    """Ühtne, ajajärjestatud (started_at DESC, None→0.0) OCR-tööde loend."""
+    out: List[dict] = []
+    out += [_normalize_upload(u, title_of) for u in uploads]
+    out += [_normalize_single(s, title_of) for s in singles]
+    out += [_normalize_batch(b, title_of) for b in batches]
+    out.sort(key=lambda e: e.get("started_at") or 0.0, reverse=True)
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/ocr_jobs_normalize.py tests/test_ocr_jobs_normalize.py
+git commit -m "feat: normalize_ocr_jobs — puhas upload+re-OCR normaliseerija
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Endpoint `GET /admin/ocr/jobs` (`routers/ocr_jobs.py`)
+
+**Files:**
+- Create: `server/routers/ocr_jobs.py`
+- Modify: `server/main.py` (registreeri router)
+
+**Interfaces:**
+- Consumes: `normalize_ocr_jobs` (Task 2), `list_uploads`, `list_reocr_jobs`, `list_reocr_batch_jobs` (Task 1), `find_directory_by_id`.
+- Produces: `GET /admin/ocr/jobs` → `{status:"success", jobs:[...]}`.
+
+- [ ] **Step 1: Write the failing test** (lisa `tests/test_ocr_jobs_normalize.py` lõppu — endpoint-tasandi title-cache lugeja)
+
+```python
+def test_title_reader_reads_metadata(tmp_path, monkeypatch):
+    import json
+    import server.routers.ocr_jobs as oj
+    work = tmp_path / "w1"
+    work.mkdir()
+    (work / "_metadata.json").write_text(json.dumps({"title": "Loetud Pealkiri"}), encoding="utf-8")
+    monkeypatch.setattr(oj, "find_directory_by_id", lambda wid: str(work) if wid == "wid" else None)
+    reader = oj._make_title_reader()
+    assert reader("wid") == "Loetud Pealkiri"
+    assert reader("puudub") == ""     # ei leidu → tühi (normaliseerija fallback slug'ile)
+    # cache: teine kutse ei ava faili uuesti (sama tulemus)
+    assert reader("wid") == "Loetud Pealkiri"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py::test_title_reader_reads_metadata -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'server.routers.ocr_jobs'`
+
+- [ ] **Step 3: Implement router**
+
+```python
+# server/routers/ocr_jobs.py
+"""Ühtne OCR-tööde vaade: upload + üksik/batch re-OCR ühes normaliseeritud loendis."""
+import json
+import os
+
+from fastapi import APIRouter, Depends
+
+from ..deps import require_role
+from ..ocr_jobs_normalize import normalize_ocr_jobs
+from ..reocr_ops import list_reocr_jobs, list_reocr_batch_jobs
+from ..upload_ops import list_uploads
+from ..utils import find_directory_by_id
+
+router = APIRouter()
+
+
+def _make_title_reader():
+    """Tagastab title_of(work_id) -> str, mis loeb _metadata.json ja cache'ib per-päring."""
+    cache = {}
+
+    def title_of(work_id):
+        if not work_id:
+            return ""
+        if work_id in cache:
+            return cache[work_id]
+        title = ""
+        path = find_directory_by_id(work_id)
+        if path:
+            try:
+                with open(os.path.join(path, "_metadata.json"), "r", encoding="utf-8") as f:
+                    title = json.load(f).get("title") or ""
+            except Exception:
+                title = ""
+        cache[work_id] = title
+        return title
+
+    return title_of
+
+
+@router.get("/admin/ocr/jobs")
+async def admin_ocr_jobs(user=Depends(require_role("admin"))):
+    """Kõik OCR-serveri tööd (upload + üksik + batch) ühes normaliseeritud loendis."""
+    jobs = normalize_ocr_jobs(
+        list_uploads(), list_reocr_jobs(), list_reocr_batch_jobs(), _make_title_reader()
+    )
+    return {"status": "success", "jobs": jobs}
+```
+
+- [ ] **Step 4: Register router in main.py**
+
+`server/main.py` — lisa import (`from .routers.reocr import router as reocr_router` juurde, rida ~19):
+
+```python
+from .routers.ocr_jobs import router as ocr_jobs_router
+```
+
+Ja registreerimise juurde (`app.include_router(reocr_router)` juurde, rida ~56):
+
+```python
+app.include_router(ocr_jobs_router)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py -q && .venv/bin/python -c "import server.main; print('main imports OK')"`
+Expected: PASS + "main imports OK"
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/routers/ocr_jobs.py server/main.py tests/test_ocr_jobs_normalize.py
+git commit -m "feat: GET /admin/ocr/jobs — ühtne OCR-tööde endpoint
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Upload deep-link (`useUploadWizard.ts`)
+
+**Files:**
+- Modify: `src/pages/upload/useUploadWizard.ts` (lisa effect resume-param'ile)
+
+**Interfaces:**
+- Consumes: `searchParams`, `pendingUploads`, `handleResume` (olemas).
+- Produces: `/upload?resumeUpload={id}` avab otse selle uploadi ülevaatusele; param eemaldatakse pärast.
+
+- [ ] **Step 1: Add deep-link resume effect**
+
+`src/pages/upload/useUploadWizard.ts` — lisa `useRef` import kui puudub (`import { useRef } from 'react'`) ja `useNavigate` on juba imporditud. Lisa `handleResume` funktsiooni JÄREL (rida ~471) effect:
+
+```typescript
+  const resumeHandledRef = useRef(false);
+  useEffect(() => {
+    if (resumeHandledRef.current) return;
+    const targetId = searchParams.get('resumeUpload');
+    if (!targetId || pendingUploads.length === 0) return;
+    const match = pendingUploads.find((u) => u.id === targetId);
+    if (!match) return;
+    resumeHandledRef.current = true;
+    handleResume(match);
+    // Eemalda param, et back/forward remount ei käivitaks resume't uuesti
+    navigate(location.pathname, { replace: true });
+  }, [pendingUploads, searchParams, navigate]);
+```
+
+**NB:** kontrolli, et `location` on saadaval (`useLocation`) või kasuta `window.location.pathname`. Kui `useLocation` pole imporditud, lisa `import { useLocation } from 'react-router-dom'` ja `const location = useLocation()`. `handleResume` on funktsioon samas hookis — effect'i deps ei vaja seda (stabiilne closure); kui lint nõuab, lisa `// eslint-disable-next-line react-hooks/exhaustive-deps`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: 0 errorit
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/upload/useUploadWizard.ts
+git commit -m "feat: upload deep-link ?resumeUpload= avab otse uploadi ülevaatusele
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Frontend — ühtne nimekiri Review-lehel
+
+**Files:**
+- Modify: `src/pages/Review.tsx` (tüüp, fetch, render)
+- Modify: `src/locales/et/review.json`, `src/locales/en/review.json`
+
+**Interfaces:**
+- Consumes: `GET /admin/ocr/jobs` (Task 3) → `{jobs:[{id,type,title,slug,work_id,page_number,status_key,slow,started_at,progress,link,error}]}`.
+
+- [ ] **Step 1: Replace ReocrJob type with unified OcrJob**
+
+`src/pages/Review.tsx` — asenda `interface ReocrJob {...}` (aktiivsete tööde tüüp) järgnevaga (jäta `reocrLog` tüüp ReocrJob-iks eraldi — vt allpool):
+
+```typescript
+interface OcrJob {
+  id: string;
+  type: 'upload' | 'reocr' | 'batch';
+  title: string;
+  slug: string;
+  work_id: string | null;
+  page_number: number | null;
+  status_key: 'uploading' | 'processing' | 'review' | 'ready' | 'imported' | 'error';
+  slow: boolean;
+  started_at: number | null;
+  progress: { ready: number; total: number } | null;
+  link: string;
+  error: string | null;
+}
+```
+
+Muuda `reocrJobs` olek: `const [reocrJobs, setReocrJobs] = useState<OcrJob[]>([]);` (ajaloo `reocrLog` jääb ReocrJob-iks, mille tüüp on juba failis — kui see kasutab slow/queue_ahead välju, jäta need alles).
+
+- [ ] **Step 2: Point fetch at unified endpoint**
+
+`loadReocrJobs`-is asenda URL:
+
+```typescript
+      const res = await fetchWithTimeout(`${FILE_API_URL}/admin/ocr/jobs`, { headers: getAuthHeaders(token), timeout: 10000 });
+```
+
+Ja pollimise `hasActive` kontroll (`j.status === ...`) → `status_key`:
+
+```typescript
+    const hasActive = reocrJobs.some(j => j.status_key === 'uploading' || j.status_key === 'processing');
+```
+
+- [ ] **Step 3: Replace active-jobs render with unified rows**
+
+Asenda aktiivsete tööde `.map(job => {...})` plokk järgnevaga (kasutab `status_key`, `type`, `link`, `progress`; kulunud aeg + slow badge nagu enne):
+
+```tsx
+                  {[...reocrJobs].sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0)).map(job => {
+                    const isActive = job.status_key === 'uploading' || job.status_key === 'processing';
+                    const isSlow = isActive && job.slow;
+                    const isError = job.status_key === 'error';
+                    return (
+                      <div key={job.id}
+                        className={`flex items-center gap-4 px-4 py-3 rounded-lg border ${
+                          isActive ? 'border-amber-200 bg-amber-50' :
+                          isError ? 'border-red-200 bg-red-50' : 'border-green-200 bg-green-50'
+                        }`}>
+                        <div className="shrink-0">
+                          {isActive ? <Loader2 size={18} className="animate-spin text-amber-600" />
+                            : isError ? <XCircle size={18} className="text-red-500" />
+                            : <CheckCircle size={18} className="text-green-600" />}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded bg-gray-100 text-gray-500">
+                              {t(`ocr.type.${job.type}`)}
+                            </span>
+                            <span className="font-medium text-gray-800 text-sm">{job.title || job.slug}</span>
+                            {job.title && <span className="text-xs text-gray-400 font-mono" title={job.slug}>{job.slug}</span>}
+                            {job.page_number && <span className="text-xs text-gray-500">lk {job.page_number}</span>}
+                            {job.progress && <span className="text-xs text-gray-500">{job.progress.ready}/{job.progress.total} lk</span>}
+                            {job.work_id && (
+                              <a href={job.link} target="_blank" rel="noreferrer"
+                                className="text-xs text-primary-600 hover:underline flex items-center gap-0.5">
+                                <ExternalLink size={11} />
+                              </a>
+                            )}
+                          </div>
+                          {job.error && <p className="text-xs text-red-600 mt-0.5">{job.error}</p>}
+                        </div>
+                        <div className="text-xs text-gray-500 text-right shrink-0">
+                          {job.started_at && (
+                            <div className="flex items-center gap-1 justify-end">
+                              <Clock size={11} />
+                              {isActive ? formatElapsed(job.started_at)
+                                : new Date(job.started_at * 1000).toLocaleTimeString('et-EE', { hour: '2-digit', minute: '2-digit' })}
+                            </div>
+                          )}
+                        </div>
+                        <a href={job.link} target={job.link.startsWith('/work') ? '_blank' : undefined} rel="noreferrer"
+                          className={`shrink-0 text-xs font-medium px-2 py-1 rounded ${
+                            isSlow ? 'bg-amber-100 text-amber-800' :
+                            isActive ? 'bg-amber-100 text-amber-700' :
+                            isError ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+                          }`}>
+                          {isSlow ? t('reocr.slow') : t(`ocr.statusKey.${job.status_key}`)}
+                        </a>
+                      </div>
+                    );
+                  })}
+```
+
+**NB:** `formatElapsed` on juba failis (eelmisest featuurist). Kui `reocrJobs.filter(...)` loendurit kasutatakse mujal (nt aktiivsete arv, rida ~510), muuda `j.status === ...` → `j.status_key === ...`.
+
+- [ ] **Step 4: Add i18n keys**
+
+`src/locales/et/review.json` — `reocr` bloki KÕRVALE (juur-tasand) lisa `ocr` blokk:
+
+```json
+  "ocr": {
+    "type": { "upload": "Üleslaadimine", "reocr": "Re-OCR", "batch": "Batch" },
+    "statusKey": {
+      "uploading": "üleslaadimine",
+      "processing": "OCR töötleb",
+      "review": "ülevaatusel",
+      "ready": "valmis",
+      "imported": "imporditud",
+      "error": "viga"
+    }
+  },
+```
+
+`src/locales/en/review.json` — sama:
+
+```json
+  "ocr": {
+    "type": { "upload": "Upload", "reocr": "Re-OCR", "batch": "Batch" },
+    "statusKey": {
+      "uploading": "uploading",
+      "processing": "OCR running",
+      "review": "in review",
+      "ready": "ready",
+      "imported": "imported",
+      "error": "error"
+    }
+  },
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: 0 errorit
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/Review.tsx src/locales/et/review.json src/locales/en/review.json
+git commit -m "feat: Review ühtne OCR-tööde nimekiri (upload+reocr+batch, tüübi-badge)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Deploy (pärast kõiki taske)
+
+Backend (`--no-cache`):
+```bash
+ssh vutt && cd ~/VUTT && git pull
+docker compose build --no-cache backend && docker compose up -d backend
+curl -s -H "Authorization: Bearer <admin-token>" https://vutt.utlib.ut.ee/admin/ocr/jobs | head
+```
+Frontend: `npm run build && rsync -avz dist/ vutt:~/VUTT/dist/`
+
+**Verifitseeri:** lae teos üles (`/upload`) → Review-lehel ilmub "Üleslaadimine"-badge'iga rida progressiga; klõps badge'il → deep-link `/upload?resumeUpload=…` avab ülevaatuse; re-OCR/batch read näitavad tüübi-badge'i + linki.
+
+## Self-Review — spec coverage
+
+- ✅ 2a ühtne endpoint + puhas normaliseerija + title-cache: Task 2 (normaliseerija) + Task 3 (endpoint/cache).
+- ✅ Batch nimekirjas: Task 1 `list_reocr_batch_jobs` + normaliseerija `_normalize_batch`.
+- ✅ status_key sõnavara: Task 2 `_upload_status_key`/`_reocr_status_key` + Task 5 i18n.
+- ✅ Link backendis (üks tõeallikas): Task 2 `_upload_link`/`_work_link`; frontend kasutab `job.link`.
+- ✅ Sort `started_at or 0.0`: Task 2 `normalize_ocr_jobs` + `test_normalize_missing_fields_and_sort`.
+- ✅ Upload import-viga → error + deep-link: Task 2 `test_normalize_upload_import_error`.
+- ✅ 2b üks nimekiri tüübi-badge'iga: Task 5 render + i18n.
+- ✅ 2c deep-link effect (pendingUploads laadimisel) + param-strip: Task 4.
+- ✅ Slug jääb (tehniline) + title esile: Task 5 render.

--- a/docs/superpowers/plans/2026-07-01-ocr-recovery-hardening-phase1.md
+++ b/docs/superpowers/plans/2026-07-01-ocr-recovery-hardening-phase1.md
@@ -1,0 +1,653 @@
+# OCR Recovery Hardening (Faas 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Taastatud re-OCR kirjed saavad `page_number`-i (link + "lk N" ilmuvad) ja batch-orvud muutuvad automaatselt taastatavaks püsiva mapping-faili kaudu.
+
+**Architecture:** Batch-jobi lehe-mapping (`remote_txt_name → page_filename`) kirjutatakse batch ALGUSES püsivasse faili (`state/reocr_batch_maps/{job_id}.json`), kustutatakse koristusel — restart/error/crash-kindel. Reaper kasutab mapping-faili olemasolu deterministliku single/batch-eristajana; puuduv → üksik-tee (`reocr_log`). Frontend link-tingimust lõdvendatakse: `work_id` olemas → alati link.
+
+**Tech Stack:** Python 3.9 (FastAPI, Dockeris), pytest; React 19 + TS.
+
+## Global Constraints
+
+- **Python 3.9 compat:** `Optional[X]`, `Dict[...]`, `List[...]` — MITTE `X | None` / `dict[...]`.
+- **Testid:** `.venv/bin/python -m pytest tests/ -q`. Frontend gate: `npm run typecheck`.
+- **`slow` on lipp, mitte staatus** (eelmisest featuurist); `status ∈ {uploading,processing,done,error}`.
+- **Recovery-eristaja deterministlik:** batch-mapping fail olemas → batch; puudub → üksik. MITTE `_pg_NNN`-loenduse heuristika.
+- **Reaper puutub ainult mitte-aktiivseid** töid (`_reocr_jobs` EGA `_reocr_batch_jobs`-is pole `uploading`/`processing`).
+- **`reocr_log` cap jääb 500** (batch ei floodi logi — mapping eraldi failis).
+- **Commit-lõpp:** `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+## File Structure
+
+| Fail | Vastutus | Muudatus |
+|------|----------|----------|
+| `server/reocr_state.py` | + batch-mapping püsivus (persist/load/remove/list) | Lisa funktsioonid |
+| `server/reocr_ops.py` | `start_reocr_batch` kirjutab mapping'u; `_poll_batch_job` kustutab koristusel | Kirurgiline edit |
+| `server/reocr_recovery.py` | `_resolve_job_meta`+page_number; batch-taaste mapping'ust; aktiivsuse-check mõlemast dict'ist; skip-müra | Edit |
+| `src/pages/Review.tsx` | Link `work_id` olemasolul (leht kui page_number, muidu teos) | 2 kohta |
+| `tests/test_reocr_state.py` | batch-mapping testid | Lisa |
+| `tests/test_reocr_recovery.py` | page_number, batch-taaste, skip-live-batch, mapping-remove | Lisa |
+
+---
+
+## Task 1: Batch-mapping püsivus (`reocr_state.py`)
+
+**Files:**
+- Modify: `server/reocr_state.py` (lisa funktsioonid faili lõppu)
+- Test: `tests/test_reocr_state.py` (lisa)
+
+**Interfaces:**
+- Produces:
+  - `persist_batch_mapping(job_id: str, work_id, slug: str, pages: Dict[str, dict]) -> None` — kirjutab `state/reocr_batch_maps/{job_id}.json` = `{"work_id", "slug", "pages"}`, kus `pages = {remote_txt_name: {"page_filename", "page_number"}}`. Atomaarne.
+  - `load_batch_mapping(job_id: str) -> Optional[dict]` — dict või None (puuduv/vigane).
+  - `remove_batch_mapping(job_id: str) -> None` — kustutab faili (best-effort).
+  - `BATCH_MAPS_DIR: str` — kausta absoluuttee.
+
+- [ ] **Step 1: Write the failing test** (lisa `tests/test_reocr_state.py` lõppu)
+
+```python
+def test_batch_mapping_roundtrip(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "reocr_batch_maps"))
+    pages = {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-005.jpg", "page_number": 5},
+        "w1_pg_002.txt": {"page_filename": "w1-lk-006.jpg", "page_number": 6},
+    }
+    st.persist_batch_mapping("b1", "wid", "w1", pages)
+    loaded = st.load_batch_mapping("b1")
+    assert loaded["work_id"] == "wid"
+    assert loaded["slug"] == "w1"
+    assert loaded["pages"]["w1_pg_002.txt"]["page_filename"] == "w1-lk-006.jpg"
+    assert loaded["pages"]["w1_pg_002.txt"]["page_number"] == 6
+
+
+def test_batch_mapping_missing_returns_none(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "reocr_batch_maps"))
+    assert st.load_batch_mapping("puudub") is None
+
+
+def test_batch_mapping_corrupt_returns_none(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    d = tmp_path / "reocr_batch_maps"
+    d.mkdir()
+    (d / "b1.json").write_text("{ vigane", encoding="utf-8")
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(d))
+    assert st.load_batch_mapping("b1") is None
+
+
+def test_batch_mapping_remove(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "reocr_batch_maps"))
+    st.persist_batch_mapping("b1", "wid", "w1", {})
+    assert st.load_batch_mapping("b1") is not None
+    st.remove_batch_mapping("b1")
+    assert st.load_batch_mapping("b1") is None
+    st.remove_batch_mapping("b1")  # teist korda — ei crash'i
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_state.py -k batch_mapping -q`
+Expected: FAIL — `AttributeError: module 'server.reocr_state' has no attribute 'BATCH_MAPS_DIR'`
+
+- [ ] **Step 3: Implement** (lisa `server/reocr_state.py` lõppu; `os`/`json`/`STATE_DIR` juba imporditud)
+
+```python
+BATCH_MAPS_DIR = os.path.join(STATE_DIR, "reocr_batch_maps")
+
+
+def _batch_map_path(job_id: str) -> str:
+    return os.path.join(BATCH_MAPS_DIR, f"{job_id}.json")
+
+
+def persist_batch_mapping(job_id: str, work_id, slug: str, pages: Dict[str, dict]) -> None:
+    """Kirjuta batch lehe-mapping püsivalt (recovery vundament). Atomaarne."""
+    data = {"work_id": work_id, "slug": slug, "pages": pages}
+    with _file_lock:
+        try:
+            os.makedirs(BATCH_MAPS_DIR, exist_ok=True)
+            path = _batch_map_path(job_id)
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, path)
+        except Exception as e:
+            logger.warning(f"batch-mapping kirjutamine ebaõnnestus ({job_id}): {e}")
+
+
+def load_batch_mapping(job_id: str) -> Optional[dict]:
+    """Batch lehe-mapping või None (puuduv/vigane)."""
+    with _file_lock:
+        try:
+            path = _batch_map_path(job_id)
+            if not os.path.exists(path):
+                return None
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else None
+        except Exception as e:
+            logger.warning(f"batch-mapping lugemine ebaõnnestus ({job_id}): {e}")
+            return None
+
+
+def remove_batch_mapping(job_id: str) -> None:
+    """Kustuta batch-mapping fail (best-effort, koristusel)."""
+    with _file_lock:
+        try:
+            os.remove(_batch_map_path(job_id))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.warning(f"batch-mapping kustutamine ebaõnnestus ({job_id}): {e}")
+
+
+def list_batch_mapping_ids() -> list:
+    """job_id-d, millel on batch-mapping fail (reaperile)."""
+    try:
+        return [os.path.splitext(f)[0] for f in os.listdir(BATCH_MAPS_DIR) if f.endswith(".json")]
+    except FileNotFoundError:
+        return []
+```
+
+Lisa `Optional` importi (fail impordib juba `from typing import Dict`):
+```python
+from typing import Dict, Optional
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_state.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/reocr_state.py tests/test_reocr_state.py
+git commit -m "feat: reocr_state batch-mapping püsivus (recovery vundament)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Batch mapping wiring (`reocr_ops.py`)
+
+**Files:**
+- Modify: `server/reocr_ops.py` (`start_reocr_batch` ~130-148; `_poll_batch_job` all_resolved ~283-290)
+- Test: `tests/test_reocr_slow_flag.py` (lisa)
+
+**Interfaces:**
+- Consumes: `reocr_state.persist_batch_mapping`, `reocr_state.remove_batch_mapping` (Task 1).
+- Produces: batch-mapping fail eksisteerib batch algusest kuni täieliku koristuseni.
+
+- [ ] **Step 1: Write the failing test** (lisa `tests/test_reocr_slow_flag.py` lõppu)
+
+```python
+def test_start_reocr_batch_persists_mapping(tmp_path, monkeypatch):
+    import server.reocr_ops as r
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    monkeypatch.setattr(st, "REOCR_ACTIVE_FILE", str(tmp_path / "active.json"))
+    # Ära ava päris SFTP-d — upload-thread ebaõnnestub vaikselt, mapping on juba kirjutatud
+    monkeypatch.setattr(r, "_sftp_open", lambda jid: (_ for _ in ()).throw(RuntimeError("no ssh")))
+    work_dir = tmp_path / "w1"; work_dir.mkdir()
+    (work_dir / "w1-a.jpg").write_bytes(b"x")
+    monkeypatch.setattr(r, "BASE_DIR", str(tmp_path))
+
+    job_id = r.start_reocr_batch("wid", "w1", str(work_dir),
+                                 [("w1-a.jpg", 7)], material_type="print", username="u")
+    mapping = st.load_batch_mapping(job_id)
+    assert mapping is not None
+    assert mapping["slug"] == "w1" and mapping["work_id"] == "wid"
+    # remote_txt_name → page_filename + page_number
+    names = list(mapping["pages"].values())
+    assert names[0]["page_filename"] == "w1-a.jpg"
+    assert names[0]["page_number"] == 7
+    assert "w1_pg_001.txt" in mapping["pages"]
+    with r._reocr_batch_jobs_lock:
+        r._reocr_batch_jobs.clear()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_slow_flag.py::test_start_reocr_batch_persists_mapping -q`
+Expected: FAIL — `load_batch_mapping` returns None (mapping veel ei kirjutata)
+
+- [ ] **Step 3: Persist mapping at batch start**
+
+`server/reocr_ops.py` `start_reocr_batch`-is, pärast `page_entries = _build_batch_pages(slug, pages)` (rida ~130) ja ENNE `_reocr_batch_jobs[job_id] = job` bloki, lisa mapping-ehitus; pärast `_persist_active_jobs()` (rida ~148) lisa mapping-persist:
+
+```python
+    page_entries = _build_batch_pages(slug, pages)
+    now = datetime.now().timestamp()
+    _batch_map_pages = {
+        e["remote_txt_name"]: {"page_filename": e["page_filename"], "page_number": e["page_number"]}
+        for e in page_entries
+    }
+```
+
+Ja pärast olemasolevat `_persist_active_jobs()` kutset (rida ~148):
+
+```python
+    with _reocr_batch_jobs_lock:
+        _reocr_batch_jobs[job_id] = job
+    _persist_active_jobs()
+    reocr_state.persist_batch_mapping(job_id, work_id, slug, _batch_map_pages)
+```
+
+- [ ] **Step 4: Remove mapping after full cleanup**
+
+`_poll_batch_job`-is, `all_resolved` blokis (rida ~283-290), pärast staging rmdir'i lisa mapping-remove:
+
+```python
+        all_resolved = all(e["status"] in ("ready", "error") for e in job["pages"])
+        if all_resolved:
+            staging_abs = f"{OCR_SERVER_PATH}/{job['remote_staging']}"
+            for d in (work_abs, staging_abs):
+                try:
+                    sftp.rmdir(d)
+                except Exception:
+                    pass
+            reocr_state.remove_batch_mapping(job_id)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_slow_flag.py tests/test_reocr_batch.py -q`
+Expected: PASS (uus + olemasolevad batch-testid)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/reocr_ops.py tests/test_reocr_slow_flag.py
+git commit -m "feat: batch mapping kirjutatakse algul, kustutatakse koristusel
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Reaper — page_number (1a) + batch-taaste + aktiivsuse-check
+
+**Files:**
+- Modify: `server/reocr_recovery.py` (`_resolve_job_meta` ~32-42; `_is_actively_tracked` ~45-48; `_recover_one` ~83-123)
+- Test: `tests/test_reocr_recovery.py` (lisa + kohanda olemasolevaid)
+
+**Interfaces:**
+- Consumes: `reocr_state.load_batch_mapping`, `reocr_state.remove_batch_mapping`, `reocr_ops._reocr_batch_jobs`, `reocr_ops._reocr_batch_jobs_lock`.
+- Produces: reaper taastab batch-orvud mapping'ust; recovery-kirjed sisaldavad `page_number`; skip-müra dedupe.
+
+- [ ] **Step 1: Write the failing tests** (lisa `tests/test_reocr_recovery.py` lõppu)
+
+```python
+def test_resolve_job_meta_includes_page_number(monkeypatch, tmp_path):
+    monkeypatch.setattr(reocr_ops, "REOCR_LOG_FILE", str(tmp_path / "log.json"))
+    reocr_ops._append_to_log(
+        {"work_id": "wid", "slug": "w1", "page_filename": "w1-lk-7.jpg",
+         "page_number": 7, "status": "error", "started_at": 1.0, "finished_at": 2.0}, "j1")
+    meta = rec._resolve_job_meta("j1")
+    assert meta["page_filename"] == "w1-lk-7.jpg"
+    assert meta["page_number"] == 7
+
+
+def test_batch_orphan_recovered_via_mapping(monkeypatch, tmp_path):
+    import server.reocr_state as st
+    monkeypatch.setattr(reocr_ops, "OCR_SERVER_PATH", "/OCR")
+    monkeypatch.setattr(rec, "OCR_SERVER_PATH", "/OCR")
+    monkeypatch.setattr(reocr_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(reocr_ops, "REOCR_LOG_FILE", str(tmp_path / "log.json"))
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    (tmp_path / "w1").mkdir()
+    st.persist_batch_mapping("borb", "wid", "w1", {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-1.jpg", "page_number": 1},
+        "w1_pg_002.txt": {"page_filename": "w1-lk-2.jpg", "page_number": 2},
+    })
+    tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
+            "/OCR/AUTO-OCR/print/borb": ["w1"],
+            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.txt", "w1_pg_002.txt"]}
+    files = {"/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt": b"tekst1",
+             "/OCR/AUTO-OCR/print/borb/w1/w1_pg_002.txt": b"tekst2"}
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: _FakeSftp(tree, files))
+    monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
+    with reocr_ops._reocr_jobs_lock:
+        reocr_ops._reocr_jobs.clear()
+    rec._recovering.clear()
+
+    result = rec.scan_and_recover()
+
+    assert "borb" in result["recovered"]
+    assert (tmp_path / "w1" / "w1-lk-1.ocr").read_text(encoding="utf-8") == "tekst1"
+    assert (tmp_path / "w1" / "w1-lk-2.ocr").read_text(encoding="utf-8") == "tekst2"
+    # Logi recovery-kirjed page_number-iga
+    entries = reocr_ops.get_reocr_log(0, 100)["entries"]
+    recs = [e for e in entries if e.get("recovered")]
+    assert {e["page_number"] for e in recs} == {1, 2}
+    # Mapping kustutatud pärast taastet
+    assert st.load_batch_mapping("borb") is None
+
+
+def test_reaper_skips_live_batch_job(monkeypatch, tmp_path):
+    import server.reocr_state as st
+    monkeypatch.setattr(reocr_ops, "OCR_SERVER_PATH", "/OCR")
+    monkeypatch.setattr(rec, "OCR_SERVER_PATH", "/OCR")
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    st.persist_batch_mapping("borb", "wid", "w1", {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-1.jpg", "page_number": 1}})
+    tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
+            "/OCR/AUTO-OCR/print/borb": ["w1"],
+            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.txt"]}
+    sftp = _FakeSftp(tree, {"/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt": b"x"})
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: sftp)
+    monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
+    with reocr_ops._reocr_batch_jobs_lock:
+        reocr_ops._reocr_batch_jobs.clear()
+        reocr_ops._reocr_batch_jobs["borb"] = {"status": "processing", "kind": "batch"}
+    rec._recovering.clear()
+
+    result = rec.scan_and_recover()
+
+    assert result["recovered"] == []
+    assert sftp.removed == []
+    with reocr_ops._reocr_batch_jobs_lock:
+        reocr_ops._reocr_batch_jobs.clear()
+```
+
+**NB:** `_FakeSftp` (olemasolev testis) vajab, et `listdir` toetaks vahepealseid katalooge (`/borb/w1`). Kontrolli, et `_env` fixture ei sega `BATCH_MAPS_DIR`-i — kui vaja, lisa `monkeypatch.setattr(st, "BATCH_MAPS_DIR", ...)` ka `_env`-i.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_recovery.py -k "batch_orphan or job_meta_includes or skips_live_batch" -q`
+Expected: FAIL — `_resolve_job_meta` ei tagasta `page_number`; batch-taastet pole.
+
+- [ ] **Step 3: Add page_number to `_resolve_job_meta`**
+
+`server/reocr_recovery.py` `_resolve_job_meta` (rida ~32-42) — lisa `page_number` mõlemasse harru:
+
+```python
+def _resolve_job_meta(job_id: str) -> Optional[dict]:
+    """Leia {page_filename, work_id, page_number} logist (põhi) või active.json-ist (varu)."""
+    log = reocr_ops.get_reocr_log(0, reocr_ops.REOCR_LOG_MAX).get("entries", [])
+    for e in log:
+        if e.get("job_id") == job_id and e.get("page_filename"):
+            return {"page_filename": e["page_filename"], "work_id": e.get("work_id"),
+                    "page_number": e.get("page_number")}
+    active = reocr_state.load_active_jobs()
+    j = active.get(job_id)
+    if j and j.get("page_filename"):
+        return {"page_filename": j["page_filename"], "work_id": j.get("work_id"),
+                "page_number": j.get("page_number")}
+    return None
+```
+
+Ja `_recover_one` üksik-harus (rida ~110-117) lisa recovery-sündmusesse `page_number`:
+
+```python
+            reocr_ops._append_to_log(
+                {"work_id": meta.get("work_id"), "slug": slug,
+                 "page_filename": meta["page_filename"],
+                 "page_number": meta.get("page_number"),
+                 "status": "done", "error": None, "started_at": None,
+                 "finished_at": now,
+                 "recovered": True, "original_status": "error", "recovered_at": now},
+                job_id)
+```
+
+- [ ] **Step 4: Update active-check + dispatch batch vs single + skip-warn**
+
+Asenda `_is_actively_tracked` (rida ~45-48) ja `_recover_one` (rida ~83-123) järgnevaga (lisa ka `_warned_skips` mooduli-tasandile `_recovering` juurde ja `import server.reocr_state as reocr_state` on juba olemas):
+
+```python
+_warned_skips = set()  # job_id-d, mille skip-hoiatust juba logitud (müra vältimine)
+
+
+def _is_actively_tracked(job_id: str) -> bool:
+    with reocr_ops._reocr_jobs_lock:
+        j = reocr_ops._reocr_jobs.get(job_id)
+        if j and j.get("status") in ("uploading", "processing"):
+            return True
+    with reocr_ops._reocr_batch_jobs_lock:
+        b = reocr_ops._reocr_batch_jobs.get(job_id)
+        if b and b.get("status") in ("uploading", "processing"):
+            return True
+    return False
+
+
+def _warn_skip_once(job_id: str, msg: str) -> None:
+    if job_id not in _warned_skips:
+        _warned_skips.add(job_id)
+        logger.warning(f"Reaper skip {job_id}: {msg}")
+
+
+def _recover_one(sftp, base: str, job_id: str, recovered: list, skipped: list) -> None:
+    if _is_actively_tracked(job_id):
+        return
+    mapping = reocr_state.load_batch_mapping(job_id)
+    if mapping is not None:
+        _recover_batch(sftp, base, job_id, mapping, recovered, skipped)
+    else:
+        _recover_single(sftp, base, job_id, recovered, skipped)
+
+
+def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: list, skipped: list) -> None:
+    slug = mapping.get("slug")
+    work_id = mapping.get("work_id")
+    pages = mapping.get("pages", {})
+    job_dir = f"{base}/{job_id}"
+    work_dir = f"{job_dir}/{slug}"
+    try:
+        files = sftp.listdir(work_dir)
+    except FileNotFoundError:
+        reocr_state.remove_batch_mapping(job_id)  # staging kadunud → mapping aegunud
+        return
+    for fname in files:
+        if not fname.endswith(".txt"):
+            continue
+        info = pages.get(fname)
+        if not info:
+            _warn_skip_once(job_id, f"{fname} pole mapping'us")
+            skipped.append(job_id)
+            continue
+        key = (job_id, fname)
+        if not _claim(key):
+            continue
+        try:
+            buf = io.BytesIO()
+            sftp.getfo(f"{work_dir}/{fname}", buf)
+            text = buf.getvalue().decode("utf-8", errors="replace")
+            reocr_ops._write_ocr_file(slug, info["page_filename"], text)
+            now = datetime.now().timestamp()
+            reocr_ops._append_to_log(
+                {"work_id": work_id, "slug": slug, "page_filename": info["page_filename"],
+                 "page_number": info.get("page_number"), "status": "done", "error": None,
+                 "started_at": None, "finished_at": now,
+                 "recovered": True, "original_status": "error", "recovered_at": now}, job_id)
+            try:
+                sftp.remove(f"{work_dir}/{fname}")
+            except Exception:
+                pass
+            recovered.append(job_id)
+        finally:
+            _release(key)
+    # Kui rohkem .txt pole, koorista kaust + mapping
+    try:
+        remaining = [f for f in sftp.listdir(work_dir) if f.endswith(".txt")]
+    except FileNotFoundError:
+        remaining = []
+    if not remaining:
+        for d in (work_dir, job_dir):
+            try:
+                sftp.rmdir(d)
+            except Exception:
+                pass
+        reocr_state.remove_batch_mapping(job_id)
+
+
+def _recover_single(sftp, base: str, job_id: str, recovered: list, skipped: list) -> None:
+    job_dir = f"{base}/{job_id}"
+    try:
+        slugs = sftp.listdir(job_dir)
+    except FileNotFoundError:
+        return
+    for slug in slugs:
+        txt_abs = f"{job_dir}/{slug}/{slug}_pg_001.txt"
+        try:
+            sftp.stat(txt_abs)
+        except FileNotFoundError:
+            continue
+        if not _claim(job_id):
+            return
+        try:
+            meta = _resolve_job_meta(job_id)
+            if not meta:
+                _warn_skip_once(job_id, ".txt olemas, aga page_filename teadmata")
+                skipped.append(job_id)
+                return
+            buf = io.BytesIO()
+            sftp.getfo(txt_abs, buf)
+            text = buf.getvalue().decode("utf-8", errors="replace")
+            reocr_ops._write_ocr_file(slug, meta["page_filename"], text)
+            now = datetime.now().timestamp()
+            reocr_ops._append_to_log(
+                {"work_id": meta.get("work_id"), "slug": slug, "page_filename": meta["page_filename"],
+                 "page_number": meta.get("page_number"), "status": "done", "error": None,
+                 "started_at": None, "finished_at": now,
+                 "recovered": True, "original_status": "error", "recovered_at": now}, job_id)
+            _cleanup_staging(sftp, job_dir, slug)
+            recovered.append(job_id)
+        finally:
+            _release(job_id)
+        return
+```
+
+Asenda ka olemasolev `_claim` (rida ~51-60) generic-key versiooniga (töötab nii job_id kui `(job_id, name)` võtmega):
+
+```python
+def _claim(key) -> bool:
+    """Claim recovery-võti (job_id VÕI (job_id, txt_name)). Tagastab False kui juba claimitud."""
+    job_id = key[0] if isinstance(key, tuple) else key
+    with reocr_ops._reocr_jobs_lock:
+        if key in _recovering:
+            return False
+        j = reocr_ops._reocr_jobs.get(job_id)
+        if j and j.get("status") in ("uploading", "processing"):
+            return False
+        _recovering.add(key)
+        return True
+
+
+def _release(key) -> None:
+    with reocr_ops._reocr_jobs_lock:
+        _recovering.discard(key)
+```
+
+**NB:** vana `_recover_one` sisaldas otse üksik-loogika + skip'i `skipped.append` sõnumiga "page_filename teadmata" — see kolib nüüd `_recover_single`-i. Veendu, et vana keha on täielikult asendatud (mitte duplikaat).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_reocr_recovery.py -q`
+Expected: PASS (uued + olemasolevad; olemasolev `test_skips_unmapped_orphan` peab ikka läbima — üksik-tee)
+
+- [ ] **Step 6: Full backend suite**
+
+Run: `.venv/bin/python -m pytest tests/ -q`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/reocr_recovery.py tests/test_reocr_recovery.py
+git commit -m "feat: reaper taastab batch-orvud mapping'ust + recovery page_number + skip-dedupe
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Frontend — link `work_id` olemasolul (leht kui page_number)
+
+**Files:**
+- Modify: `src/pages/Review.tsx` (aktiivsete tööde link ~565-574; ajaloo link ~656-661)
+
+**Interfaces:**
+- Consumes: `ReocrJob.work_id`, `ReocrJob.page_number` (olemas).
+- Produces: iga kirje, millel `work_id`, on klõpsatav (leht kui `page_number`, muidu teos).
+
+- [ ] **Step 1: Relax active-jobs link**
+
+`src/pages/Review.tsx` — aktiivsete tööde renderis asenda praegune link-plokk (`{job.work_id && job.page_number && (<a href={`/work/${job.work_id}/${job.page_number}`}...`) järgnevaga:
+
+```tsx
+                            {job.work_id && (
+                              <a
+                                href={job.page_number ? `/work/${job.work_id}/${job.page_number}` : `/work/${job.work_id}`}
+                                className="text-xs text-primary-600 hover:underline flex items-center gap-0.5"
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                <ExternalLink size={11} />
+                              </a>
+                            )}
+```
+
+- [ ] **Step 2: Relax history-log link**
+
+Sama failis, ajaloo (`reocrLog`) renderis asenda `{entry.work_id && entry.page_number && (<a href={`/work/${entry.work_id}/${entry.page_number}`}...` järgnevaga:
+
+```tsx
+                              {entry.work_id && (
+                                <a href={entry.page_number ? `/work/${entry.work_id}/${entry.page_number}` : `/work/${entry.work_id}`} target="_blank" rel="noreferrer"
+                                  className="text-xs text-primary-600 hover:underline flex items-center gap-0.5">
+                                  <ExternalLink size={11} />
+                                </a>
+                              )}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: 0 errorit
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/Review.tsx
+git commit -m "fix: Review re-OCR link ka ilma page_number-ita (teosele); taastatud kirjed klõpsatavad
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Deploy (pärast kõiki taske)
+
+Backend (`--no-cache`):
+```bash
+ssh vutt
+cd ~/VUTT && git pull
+docker compose build --no-cache backend && docker compose up -d backend
+docker logs vutt-backend --tail 30 | grep -i reaper
+```
+
+Frontend:
+```bash
+npm run build && rsync -avz dist/ vutt:~/VUTT/dist/
+```
+
+**Käsitsi: praegune 5 batch-orvu koristus.** Neil mapping puudub → reaper `skip` (üks hoiatus/protsess). Leia nende `job_id`-d logist ja koorista staging käsitsi, et ei jääks vedelema:
+```bash
+docker logs vutt-backend 2>&1 | grep "Reaper skip" | grep "page_filename teadmata"
+# iga job_id kohta serveris (OCR-host kaudu): vaata AUTO-OCR/{print,hand}/{job_id}/ ja
+# kas .txt on väärtuslik — kui jah, käsitsi õigele lehele; kui ei, kustuta staging-kaust
+```
+
+## Self-Review — spec coverage
+
+- ✅ 1a page_number: Task 3 `_resolve_job_meta` + recovery event; Task 4 frontend link.
+- ✅ 1b püsiv batch-mapping: Task 1 (reocr_state) + Task 2 (wiring start/cleanup).
+- ✅ 1c reaper batch-taaste, deterministlik eristaja (mapping olemas → batch): Task 3 `_recover_batch`/`_recover_single`.
+- ✅ Reaper skip aktiivsed (mõlemad dict'id): Task 3 `_is_actively_tracked` + `test_reaper_skips_live_batch_job`.
+- ✅ Claim per `(job_id, remote_txt_name)`: Task 3 generic `_claim`.
+- ✅ 1d skip-müra dedupe: Task 3 `_warned_skips`; praegune 5 käsitsi: Deploy-sektsioon.
+- ✅ Mapping kustutamine koristusel: Task 2 (`_poll_batch_job`) + Task 3 (`_recover_batch`).

--- a/docs/superpowers/plans/2026-07-01-ocr-recovery-hardening-phase1.md
+++ b/docs/superpowers/plans/2026-07-01-ocr-recovery-hardening-phase1.md
@@ -1,6 +1,6 @@
 # OCR Recovery Hardening (Faas 1) — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Taastatud re-OCR kirjed saavad `page_number`-i (link + "lk N" ilmuvad) ja batch-orvud muutuvad automaatselt taastatavaks püsiva mapping-faili kaudu.
 
@@ -44,7 +44,7 @@
   - `remove_batch_mapping(job_id: str) -> None` — kustutab faili (best-effort).
   - `BATCH_MAPS_DIR: str` — kausta absoluuttee.
 
-- [ ] **Step 1: Write the failing test** (lisa `tests/test_reocr_state.py` lõppu)
+- [x] **Step 1: Write the failing test** (lisa `tests/test_reocr_state.py` lõppu)
 
 ```python
 def test_batch_mapping_roundtrip(tmp_path, monkeypatch):
@@ -87,12 +87,12 @@ def test_batch_mapping_remove(tmp_path, monkeypatch):
     st.remove_batch_mapping("b1")  # teist korda — ei crash'i
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_state.py -k batch_mapping -q`
 Expected: FAIL — `AttributeError: module 'server.reocr_state' has no attribute 'BATCH_MAPS_DIR'`
 
-- [ ] **Step 3: Implement** (lisa `server/reocr_state.py` lõppu; `os`/`json`/`STATE_DIR` juba imporditud)
+- [x] **Step 3: Implement** (lisa `server/reocr_state.py` lõppu; `os`/`json`/`STATE_DIR` juba imporditud)
 
 ```python
 BATCH_MAPS_DIR = os.path.join(STATE_DIR, "reocr_batch_maps")
@@ -156,12 +156,12 @@ Lisa `Optional` importi (fail impordib juba `from typing import Dict`):
 from typing import Dict, Optional
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_state.py -q`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add server/reocr_state.py tests/test_reocr_state.py
@@ -182,7 +182,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Consumes: `reocr_state.persist_batch_mapping`, `reocr_state.remove_batch_mapping` (Task 1).
 - Produces: batch-mapping fail eksisteerib batch algusest kuni täieliku koristuseni.
 
-- [ ] **Step 1: Write the failing test** (lisa `tests/test_reocr_slow_flag.py` lõppu)
+- [x] **Step 1: Write the failing test** (lisa `tests/test_reocr_slow_flag.py` lõppu)
 
 ```python
 def test_start_reocr_batch_persists_mapping(tmp_path, monkeypatch):
@@ -210,12 +210,12 @@ def test_start_reocr_batch_persists_mapping(tmp_path, monkeypatch):
         r._reocr_batch_jobs.clear()
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_slow_flag.py::test_start_reocr_batch_persists_mapping -q`
 Expected: FAIL — `load_batch_mapping` returns None (mapping veel ei kirjutata)
 
-- [ ] **Step 3: Persist mapping at batch start**
+- [x] **Step 3: Persist mapping at batch start**
 
 `server/reocr_ops.py` `start_reocr_batch`-is, pärast `page_entries = _build_batch_pages(slug, pages)` (rida ~130) ja ENNE `_reocr_batch_jobs[job_id] = job` bloki, lisa mapping-ehitus; pärast `_persist_active_jobs()` (rida ~148) lisa mapping-persist:
 
@@ -237,7 +237,7 @@ Ja pärast olemasolevat `_persist_active_jobs()` kutset (rida ~148):
     reocr_state.persist_batch_mapping(job_id, work_id, slug, _batch_map_pages)
 ```
 
-- [ ] **Step 4: Remove mapping after full cleanup**
+- [x] **Step 4: Remove mapping after full cleanup**
 
 `_poll_batch_job`-is, `all_resolved` blokis (rida ~283-290), pärast staging rmdir'i lisa mapping-remove:
 
@@ -253,12 +253,12 @@ Ja pärast olemasolevat `_persist_active_jobs()` kutset (rida ~148):
             reocr_state.remove_batch_mapping(job_id)
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [x] **Step 5: Run tests to verify they pass**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_slow_flag.py tests/test_reocr_batch.py -q`
 Expected: PASS (uus + olemasolevad batch-testid)
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add server/reocr_ops.py tests/test_reocr_slow_flag.py
@@ -279,7 +279,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Consumes: `reocr_state.load_batch_mapping`, `reocr_state.remove_batch_mapping`, `reocr_ops._reocr_batch_jobs`, `reocr_ops._reocr_batch_jobs_lock`.
 - Produces: reaper taastab batch-orvud mapping'ust; recovery-kirjed sisaldavad `page_number`; skip-müra dedupe.
 
-- [ ] **Step 1: Write the failing tests** (lisa `tests/test_reocr_recovery.py` lõppu)
+- [x] **Step 1: Write the failing tests** (lisa `tests/test_reocr_recovery.py` lõppu)
 
 ```python
 def test_resolve_job_meta_includes_page_number(monkeypatch, tmp_path):
@@ -356,12 +356,12 @@ def test_reaper_skips_live_batch_job(monkeypatch, tmp_path):
 
 **NB:** `_FakeSftp` (olemasolev testis) vajab, et `listdir` toetaks vahepealseid katalooge (`/borb/w1`). Kontrolli, et `_env` fixture ei sega `BATCH_MAPS_DIR`-i — kui vaja, lisa `monkeypatch.setattr(st, "BATCH_MAPS_DIR", ...)` ka `_env`-i.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_recovery.py -k "batch_orphan or job_meta_includes or skips_live_batch" -q`
 Expected: FAIL — `_resolve_job_meta` ei tagasta `page_number`; batch-taastet pole.
 
-- [ ] **Step 3: Add page_number to `_resolve_job_meta`**
+- [x] **Step 3: Add page_number to `_resolve_job_meta`**
 
 `server/reocr_recovery.py` `_resolve_job_meta` (rida ~32-42) — lisa `page_number` mõlemasse harru:
 
@@ -394,7 +394,7 @@ Ja `_recover_one` üksik-harus (rida ~110-117) lisa recovery-sündmusesse `page_
                 job_id)
 ```
 
-- [ ] **Step 4: Update active-check + dispatch batch vs single + skip-warn**
+- [x] **Step 4: Update active-check + dispatch batch vs single + skip-warn**
 
 Asenda `_is_actively_tracked` (rida ~45-48) ja `_recover_one` (rida ~83-123) järgnevaga (lisa ka `_warned_skips` mooduli-tasandile `_recovering` juurde ja `import server.reocr_state as reocr_state` on juba olemas):
 
@@ -544,17 +544,17 @@ def _release(key) -> None:
 
 **NB:** vana `_recover_one` sisaldas otse üksik-loogika + skip'i `skipped.append` sõnumiga "page_filename teadmata" — see kolib nüüd `_recover_single`-i. Veendu, et vana keha on täielikult asendatud (mitte duplikaat).
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [x] **Step 5: Run tests to verify they pass**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_recovery.py -q`
 Expected: PASS (uued + olemasolevad; olemasolev `test_skips_unmapped_orphan` peab ikka läbima — üksik-tee)
 
-- [ ] **Step 6: Full backend suite**
+- [x] **Step 6: Full backend suite**
 
 Run: `.venv/bin/python -m pytest tests/ -q`
 Expected: PASS
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add server/reocr_recovery.py tests/test_reocr_recovery.py
@@ -574,7 +574,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Consumes: `ReocrJob.work_id`, `ReocrJob.page_number` (olemas).
 - Produces: iga kirje, millel `work_id`, on klõpsatav (leht kui `page_number`, muidu teos).
 
-- [ ] **Step 1: Relax active-jobs link**
+- [x] **Step 1: Relax active-jobs link**
 
 `src/pages/Review.tsx` — aktiivsete tööde renderis asenda praegune link-plokk (`{job.work_id && job.page_number && (<a href={`/work/${job.work_id}/${job.page_number}`}...`) järgnevaga:
 
@@ -591,7 +591,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
                             )}
 ```
 
-- [ ] **Step 2: Relax history-log link**
+- [x] **Step 2: Relax history-log link**
 
 Sama failis, ajaloo (`reocrLog`) renderis asenda `{entry.work_id && entry.page_number && (<a href={`/work/${entry.work_id}/${entry.page_number}`}...` järgnevaga:
 
@@ -604,12 +604,12 @@ Sama failis, ajaloo (`reocrLog`) renderis asenda `{entry.work_id && entry.page_n
                               )}
 ```
 
-- [ ] **Step 3: Typecheck**
+- [x] **Step 3: Typecheck**
 
 Run: `npm run typecheck`
 Expected: 0 errorit
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add src/pages/Review.tsx

--- a/docs/superpowers/specs/2026-07-01-ocr-jobs-unified-view-design.md
+++ b/docs/superpowers/specs/2026-07-01-ocr-jobs-unified-view-design.md
@@ -22,7 +22,11 @@ Kaks eraldi tähelepanekut deploy'tud re-OCR recovery järel:
 | Lingi siht | Leht (`/work/{id}/{lk}`) kui `page_number` teada; muidu teos (`/work/{id}`); upload → `/upload` deep-link. Iga kirje ALATI klõpsatav |
 | Paigutus | ÜKS ajajärjestatud nimekiri, iga rida märgib tüübi (Upload / Re-OCR / Batch) |
 | Batch-orbud | Logi batch edaspidi `reocr_log`-i → reaper taastab edaspidised batch-orvud; praegune 5 (mapping kadunud) käsitsi/jäta |
-| Upload-link | Deep-link `/upload?resumeUpload={id}` → progress kohe näha |
+| Batch idempotentsus | **Logi vastu, MITTE mälu vastu** — `_batch_logged_txt_names(job_id)` loeb logist, restart-kindel (review-punkt 1) |
+| Recovery-tee | **ÜKS koodirada** — mappi `(job_id, remote_txt_name)` järgi; single/batch eristust pole (review-punkt 3) |
+| Reaper-turvalisus | Puutub ainult töid, mida POLE `_reocr_jobs` EGA `_reocr_batch_jobs`-is; claim per `(job_id, remote_txt_name)` (review-punkt 2) |
+| Logi maht | `REOCR_LOG_MAX` 500 → 5000; pagineeritud; skip-hoiatus üks kord/protsess (review-punkt 4, 7) |
+| Upload-link | Deep-link `/upload?resumeUpload={id}` → progress kohe näha; param eemaldatakse pärast resume't (review-punkt 5) |
 | Tarne | Kaks faasi: Komponent 1 (backend, parandab kohe) → Komponent 2 (feature) |
 
 ## Arhitektuur
@@ -32,16 +36,26 @@ Kaks eraldi tähelepanekut deploy'tud re-OCR recovery järel:
 **1a. Taastatud `page_number` (bugfix).**
 `server/reocr_recovery.py` `_resolve_job_meta` tagastab lisaks `page_number` (loetud sama logi-error-kirjest, kust `page_filename` tuleb). `_recover_one` recovery-sündmus (`_append_to_log`) salvestab `page_number` → link + "lk N" ilmuvad. Frontend link-tingimust lõdvendatakse: `work_id` olemas → link (lehele kui `page_number`, muidu teosele).
 
-**1b. Batch logimine.**
-`server/reocr_ops.py` `_poll_batch_job` (ja batch abs-timeout/inactivity haru) lisab iga lahenenud lehe kohta `reocr_log`-i kirje: `{job_id, work_id, slug, page_filename, page_number, username, status: "done"|"error", started_at, finished_at}`. Nii on batch-tulemused ajaloos JA reaperi jaoks mappitavad. Idempotentne: leht logitakse ainult üleminekul `processing → ready/error` (mitte igal pollil).
+**1b. Batch logimine — idempotentsus LOGI vastu (mitte mälu vastu).**
+`server/reocr_ops.py` `_poll_batch_job` (ja batch abs-timeout/inactivity haru) lisab iga lahenenud lehe kohta `reocr_log`-i kirje. Kirje sisaldab **`remote_txt_name`** (nt `{slug}_pg_007.txt`), et taaste saaks staging-faili → page_filename mappida:
+```
+{job_id, work_id, slug, page_filename, page_number, remote_txt_name, username,
+ status: "done"|"error", started_at, finished_at}
+```
+**Idempotentsus on logi vastu, MITTE in-memory "eelmine seis" vastu** (see kaoks restardil → topeltkirje või puuduv kirje). Helper `_batch_logged_txt_names(job_id) -> set` loeb `reocr_log`-ist selle job_id juba-logitud `remote_txt_name`-id; leht logitakse AINULT kui tema `remote_txt_name` pole hulgas. Nii on log-i seis taastuv üle restardi ja 1c vundament kindel. **NB: üksik-lehe logimine (`start_reocr_job` done/error) saab samuti `remote_txt_name` välja** (alati `{slug}_pg_001.txt`), et recovery-tee oleks ÜKS.
 
-**1c. Batch-orbude taaste.**
-`server/reocr_recovery.py` reaper laiendatud: staging-kaustas mitme `{slug}_pg_NNN.txt` korral (batch) taastab iga lehe, kasutades `reocr_log` per-lehe kirjeid (`job_id` + `remote_txt_name`/`_pg_NNN` → `page_filename`). Skoop: batch-kaust tuvastatakse >1 `_pg_NNN.txt` järgi VÕI job puudub üksik-`_pg_001` mustrist. Praegune 5 orvu (enne 1b logimist tehtud) jääb käsitsi — mapping puudub, reaper `skip`.
+**1c. Batch-orbude taaste — ÜKS koodirada (single/batch eristust POLE).**
+`server/reocr_recovery.py` reaper: iga staging-faili `{slug}_pg_NNN.txt` korral (olgu üksik `_pg_001` või batch `_pg_NNN`) lahenda page_filename `reocr_log`-ist matchides `job_id` JA `remote_txt_name == {slug}_pg_NNN.txt` (tagurpidiühilduvus: kui logi-kirjel pole `remote_txt_name`-i — vana üksik-kirje — ja job_id-l on ainult üks kirje, kasuta seda). Batch-heuristikat (">1 _pg_NNN") EI ole vaja — üks tee katab mõlemad.
+**Reaper puutub AINULT töid, mida aktiivses mälus POLE** (ei `_reocr_jobs` ega `_reocr_batch_jobs`) → väldib elava polleri ja reaperi võidujooksu batch-lehtede kirjutamisel. Claim-mehhanism (eelmisest spec'ist) laiendatakse batch-lehe granulaarsuseni: claim per `(job_id, remote_txt_name)`.
+Praegune 5 orvu (enne 1b logimist tehtud) jääb käsitsi — mapping puudub, reaper `skip`.
+
+**1d. Logi maht ja skip-müra (teadlik otsus).**
+Per-lehe batch-logimine tähendab, et 400-leheline batch = 400 kirjet. `reocr_log` on **cap'itud** (`REOCR_LOG_MAX`, praegu 500, kärbib viimase N-ni) ja `get_reocr_log` on **pagineeritud** (50/lk). Otsus: **tõsta `REOCR_LOG_MAX` 5000-ni**, et suured batch'id ei sööks ajalugu tühjaks (5000-kirjeline JSON-fail loeb ikka <ms). Aktsepteerime kärpe 5000 juures; kui kunagi liiga aeglane, siis rotatsioon (out of scope). **Skip-müra:** reaper hoiab protsessi-taseme `_warned_skips` set'i → sama unmappable `job_id` hoiatust logitakse ÜKS kord (mitte igal 5-min skannil). Praegune 5 orvu koristatakse **käsitsi Faas 1 deploy'l** (nende `job_id`-d on logides), et need üldse kaoksid staging'ust.
 
 ### Komponent 2 — Ühtne OCR-tööde vaade (faas 2)
 
-**2a. Backend ühtne endpoint** `GET /admin/ocr/jobs` (`server/routers/reocr.py` või uus `ocr_jobs.py`):
-normaliseerib upload-tööd (`list_uploads`) + re-OCR (`list_reocr_jobs` üksik + batch-summaarid) ÜHE kujuni. Normaliseerija on **puhas funktsioon** (testitav): `normalize_ocr_jobs(uploads, reocr_jobs) -> list`.
+**2a. Backend ühtne endpoint** `GET /admin/ocr/jobs` (uus `server/routers/ocr_jobs.py`):
+normaliseerib upload-tööd (`list_uploads`) + re-OCR (`list_reocr_jobs` üksik + batch-summaarid) ÜHE kujuni. Normaliseerija on **puhas funktsioon** (testitav, DOM-/IO-vaba): `normalize_ocr_jobs(uploads, reocr_jobs, title_of) -> list`, kus `title_of(work_id) -> str` on süstitav (test annab lambda; endpoint annab cache'itud lugeja). **Title-cache:** endpoint kasutab lühikese TTL-iga cache'i `work_id → title` (`server/cache.py` muster), et vältida N `_metadata.json` avamist igal 4s pollil.
 
 Ühtne kirje:
 ```
@@ -81,11 +95,12 @@ normaliseerib upload-tööd (`list_uploads`) + re-OCR (`list_reocr_jobs` üksik 
 **2b. Frontend** `src/pages/Review.tsx`:
 - Asenda re-OCR-spetsiifiline nimekiri ühtse nimekirjaga, mis loeb `/admin/ocr/jobs`.
 - Iga rida: tüübi-badge (Upload/Re-OCR/Batch), `title` + `slug` (monospace tehniline), `status_key` kuva, `slow` kollane märk, kulunud aeg (aktiivsele), `progress` "X/Y lk" (upload/batch), link (`link` väljalt).
-- Ajajärjestatud (`started_at` DESC).
+- Ajajärjestatud `started_at` DESC. **Sort-võti coerc'itakse `started_at or 0`** (None → 0 → järjestuse lõppu), et vältida `TypeError`-it (Py) / ebastabiilset võrdlust (JS) kui `started_at=None`. Normaliseerija väljastab alati võrreldava `started_at` (float, vaikimisi 0.0).
 - Säilib olemasolev "Ajalugu" (püsiv `reocr_log`) sektsioon all — nüüd ka batch-kirjetega (1b).
 
 **2c. Upload deep-link** `src/pages/upload/useUploadWizard.ts`:
-- Loe `searchParams.get('resumeUpload')` mount'il. Kui `pendingUploads` laetud ja match leitud (ja veel resume'imata — `useRef` valvur), kutsu olemasolev `handleResume(saved)`. Ei muuda `handleResume` loogikat.
+- Loe `searchParams.get('resumeUpload')`. Resume-loogika elab **effect'is, mis sõltub `pendingUploads` laadimisest** (mitte paljast mount'ist, sest nimekiri laetakse asünkroonselt). Kui match leitud ja veel resume'imata (`useRef` valvur), kutsu olemasolev `handleResume(saved)` (loogikat ei muuda).
+- **Pärast õnnestunud resume't `navigate(pathname, { replace: true })`** — eemalda `resumeUpload` param, et back/forward remount ei käivitaks resume't uuesti. Puuduv/vale id → ignoreeritakse vaikselt.
 
 ## Andmevoog
 
@@ -109,26 +124,32 @@ Faas 2:
 - Reaper batch-taaste per-leht isoleeritud; puuduv mapping → `skip` + hoiatus (ei arva lehte).
 - Deep-link: puuduv/vale `resumeUpload` id → ignoreeritakse vaikselt (jääb tavaline `/upload` vaade).
 - `page_number` puudub taastatud üksik-kirjel (vana, 1a-eelne) → link teosele (fallback), mitte katki.
+- **Upload import-viga** (`import_as_work` ebaõnnestus) → upload state `error` + `error_message` → normaliseerija `status_key=error`, `link=/upload?resumeUpload={id}` (admin näeb/proovib uuesti). Sama rida mis muud error'id.
+- **Sort `started_at=None`** → normaliseerija coerc'ib `0.0`, ei crash'i.
+- **Reaper skip-müra:** unmappable `job_id` hoiatus ÜKS kord protsessi kohta (`_warned_skips`).
 
 ## Testid (`.venv/bin/python -m pytest` + `npm run typecheck`)
 
 **Faas 1:**
 - `test_resolve_job_meta_includes_page_number`: logi-error-kirjest loetakse `page_number`.
 - `test_recovery_event_has_page_number`: taastatud kirje sisaldab `page_number`-i.
-- `test_batch_page_logged_on_ready`: batch leht `ready` → `reocr_log` kirje `page_number`-iga.
-- `test_batch_page_logged_once`: sama leht ei logita topelt (idempotentsus).
-- `test_reaper_recovers_batch_orphan_from_log`: batch-staging (mitu `_pg_NNN`) + logi → taastatud.
+- `test_batch_page_logged_on_ready`: batch leht `ready` → `reocr_log` kirje `page_number` + `remote_txt_name`-iga.
+- `test_batch_page_logged_once_across_restart`: `_batch_logged_txt_names` loeb logist → juba-logitud leht EI logita uuesti, ka kui in-memory seis tühi (restart-simulatsioon). **(review-punkt 1)**
+- `test_reaper_recovers_batch_orphan_from_log`: batch-staging (mitu `_pg_NNN`) + per-lehe logi → kõik lehed taastatud õigetele `page_filename`-idele.
+- `test_reaper_skips_live_batch_job`: kui `job_id` on `_reocr_batch_jobs`-is aktiivne, reaper EI puutu selle staging'ut. **(review-punkt 2)**
+- `test_reaper_single_path_matches_by_remote_txt_name`: nii üksik (`_pg_001`) kui batch-fail lahendatakse ÜHE tee kaudu (`job_id`+`remote_txt_name`); vana kirje ilma `remote_txt_name`-ita → job_id-fallback.
 
 **Faas 2:**
 - `test_normalize_upload_job`: upload reviewing → `status_key=review`, `link=/upload?resumeUpload=…`, `progress`.
 - `test_normalize_reocr_single`: done + page_number → `link=/work/{id}/{lk}`.
 - `test_normalize_reocr_batch`: `type=batch`, `link=/work/{id}`, `progress`.
-- `test_normalize_missing_fields_safe`: puuduv title → slug; puuduv work_id → link fallback.
-- Frontend: `npm run typecheck`; olemasolevad upload/reocr testid ei regresseeru.
+- `test_normalize_missing_fields_safe`: puuduv title → slug; puuduv work_id → link fallback; **`started_at=None` → sort-võti 0.0, sort ei crash'i (review-punkt 6)**.
+- `test_normalize_upload_import_error`: upload import-viga → `status_key=error`, `link=/upload?resumeUpload=…`.
+- Frontend: `npm run typecheck`; olemasolevad upload/reocr testid ei regresseeru. Deep-link resume käivitub `pendingUploads` laadimisel (mitte enne), param eemaldatakse pärast (review-punkt 5).
 
 ## Tarne (kaks faasi)
 
-- **Faas 1 (PR): recovery hardening** — 1a+1b+1c. Backend `--no-cache` deploy. Parandab lingid + batch-taaste kohe.
+- **Faas 1 (PR): recovery hardening** — 1a+1b+1c+1d. Backend `--no-cache` deploy. Parandab lingid + batch-taaste kohe. **Deploy-samm:** korista käsitsi praegune 5 unmappable batch-orvu staging'ust (nende `job_id`-d logides), et skip-müra kaoks.
 - **Faas 2 (PR): ühtne vaade** — 2a+2b+2c. Backend + frontend deploy.
 
 ## Väljaspool skoopi

--- a/docs/superpowers/specs/2026-07-01-ocr-jobs-unified-view-design.md
+++ b/docs/superpowers/specs/2026-07-01-ocr-jobs-unified-view-design.md
@@ -1,0 +1,143 @@
+# OCR-tööde koondvaade + recovery hardening
+
+**Kuupäev:** 2026-07-01
+**Staatus:** disain kinnitatud, ootab implementatsiooni-plaani
+**Eelnev:** `2026-07-01-reocr-slow-jobs-recovery-design.md` (slow-lipp + orbude taaste, deploy'tud)
+
+## Probleem
+
+Kaks eraldi tähelepanekut deploy'tud re-OCR recovery järel:
+
+1. **Batch-orbe ei taastata + logi puudub.** Batch re-OCR tööd EI lähe `reocr_log`-i (ainult üksik-lehe tööd). Startup-recovery jättis 5 batch-orvu vahele (`skip 5`), sest mapping `{slug}_pg_NNN → page_filename` elab ainult batch-jobi mälus.
+
+2. **Nähtavus killustatud + lingid ebajärjekindlad.** Review-lehe OCR-nimekiri näitab AINULT üksik-lehe re-OCR töid. Kui keegi laadib teose üles (`/upload`), seda seal ei näe — peab vaatama eraldi lehel. Lisaks: mõnel kirjel puudub link teosele (rohelised taastatud), teisel on (punased). Kasutaja: "natuke raske on aru saada, mis toimub, mis staatus on."
+
+**Lingi-ebajärjekindluse juurpõhjus:** link renderdatakse ainult kui `work_id && page_number`. Reaperi taastatud kirjed salvestasid `page_filename`, aga MITTE `page_number` → `page_number=None` → pole linki ega "lk N".
+
+## Otsused (kinnitatud)
+
+| Teema | Otsus |
+|-------|-------|
+| Koondvaate roll | Ühtne **nähtavus**; tegevused (import, .ocr rakendus) jäävad oma lehtedele, koondvaatest lingid sinna |
+| Lingi siht | Leht (`/work/{id}/{lk}`) kui `page_number` teada; muidu teos (`/work/{id}`); upload → `/upload` deep-link. Iga kirje ALATI klõpsatav |
+| Paigutus | ÜKS ajajärjestatud nimekiri, iga rida märgib tüübi (Upload / Re-OCR / Batch) |
+| Batch-orbud | Logi batch edaspidi `reocr_log`-i → reaper taastab edaspidised batch-orvud; praegune 5 (mapping kadunud) käsitsi/jäta |
+| Upload-link | Deep-link `/upload?resumeUpload={id}` → progress kohe näha |
+| Tarne | Kaks faasi: Komponent 1 (backend, parandab kohe) → Komponent 2 (feature) |
+
+## Arhitektuur
+
+### Komponent 1 — Recovery hardening (backend, faas 1)
+
+**1a. Taastatud `page_number` (bugfix).**
+`server/reocr_recovery.py` `_resolve_job_meta` tagastab lisaks `page_number` (loetud sama logi-error-kirjest, kust `page_filename` tuleb). `_recover_one` recovery-sündmus (`_append_to_log`) salvestab `page_number` → link + "lk N" ilmuvad. Frontend link-tingimust lõdvendatakse: `work_id` olemas → link (lehele kui `page_number`, muidu teosele).
+
+**1b. Batch logimine.**
+`server/reocr_ops.py` `_poll_batch_job` (ja batch abs-timeout/inactivity haru) lisab iga lahenenud lehe kohta `reocr_log`-i kirje: `{job_id, work_id, slug, page_filename, page_number, username, status: "done"|"error", started_at, finished_at}`. Nii on batch-tulemused ajaloos JA reaperi jaoks mappitavad. Idempotentne: leht logitakse ainult üleminekul `processing → ready/error` (mitte igal pollil).
+
+**1c. Batch-orbude taaste.**
+`server/reocr_recovery.py` reaper laiendatud: staging-kaustas mitme `{slug}_pg_NNN.txt` korral (batch) taastab iga lehe, kasutades `reocr_log` per-lehe kirjeid (`job_id` + `remote_txt_name`/`_pg_NNN` → `page_filename`). Skoop: batch-kaust tuvastatakse >1 `_pg_NNN.txt` järgi VÕI job puudub üksik-`_pg_001` mustrist. Praegune 5 orvu (enne 1b logimist tehtud) jääb käsitsi — mapping puudub, reaper `skip`.
+
+### Komponent 2 — Ühtne OCR-tööde vaade (faas 2)
+
+**2a. Backend ühtne endpoint** `GET /admin/ocr/jobs` (`server/routers/reocr.py` või uus `ocr_jobs.py`):
+normaliseerib upload-tööd (`list_uploads`) + re-OCR (`list_reocr_jobs` üksik + batch-summaarid) ÜHE kujuni. Normaliseerija on **puhas funktsioon** (testitav): `normalize_ocr_jobs(uploads, reocr_jobs) -> list`.
+
+Ühtne kirje:
+```
+{
+  "id": str,                      # upload_id VÕI reocr job_id
+  "type": "upload"|"reocr"|"batch",
+  "title": str,                   # teose pealkiri (upload meta / _metadata.json)
+  "slug": str,                    # tehniline, OCR-serveris vaatamiseks
+  "work_id": str|None,            # None upload-il enne importi
+  "page_number": int|None,        # re-OCR üksik; None batch/upload
+  "status_key": str,              # normaliseeritud (vt allpool)
+  "slow": bool,                   # re-OCR slow-lipp
+  "started_at": float|None,
+  "progress": {"ready": int, "total": int}|None,  # upload + batch; None üksik
+  "link": str,                    # eelarvutatud siht (vt Lingi siht)
+  "error": str|None
+}
+```
+
+**Status_key normaliseerimine:**
+| Allikas (upload / reocr) | status_key | Kuva (i18n) | Tegevus |
+|--------------------------|-----------|-------------|---------|
+| upload: pending/uploading/collecting_images | `uploading` | "üleslaadimine" | — |
+| upload+reocr: processing | `processing` | "OCR töötleb" | — |
+| (processing + slow=true) | `processing` +slow | "aeglane, töötab edasi" | — |
+| upload: reviewing/done | `review` | "ülevaatusel" | → impordi |
+| reocr: done | `ready` | "valmis" | → rakenda (Manage) |
+| upload: imported | `imported` | "imporditud" | → teos |
+| upload+reocr: error | `error` | "viga" | → leht/teos |
+
+**Lingi siht (backend arvutab):**
+- reocr üksik done/error: `/work/{work_id}/{page_number}` kui `page_number`, muidu `/work/{work_id}`
+- reocr batch: `/work/{work_id}` (mitu lehte)
+- upload aktiivne/review: `/upload?resumeUpload={upload_id}`
+- upload imported: `/work/{work_id}` (kui teada)
+
+**2b. Frontend** `src/pages/Review.tsx`:
+- Asenda re-OCR-spetsiifiline nimekiri ühtse nimekirjaga, mis loeb `/admin/ocr/jobs`.
+- Iga rida: tüübi-badge (Upload/Re-OCR/Batch), `title` + `slug` (monospace tehniline), `status_key` kuva, `slow` kollane märk, kulunud aeg (aktiivsele), `progress` "X/Y lk" (upload/batch), link (`link` väljalt).
+- Ajajärjestatud (`started_at` DESC).
+- Säilib olemasolev "Ajalugu" (püsiv `reocr_log`) sektsioon all — nüüd ka batch-kirjetega (1b).
+
+**2c. Upload deep-link** `src/pages/upload/useUploadWizard.ts`:
+- Loe `searchParams.get('resumeUpload')` mount'il. Kui `pendingUploads` laetud ja match leitud (ja veel resume'imata — `useRef` valvur), kutsu olemasolev `handleResume(saved)`. Ei muuda `handleResume` loogikat.
+
+## Andmevoog
+
+```
+Faas 1:
+  batch _poll_batch_job → leht ready/error → _append_to_log (per leht)
+  reaper scan → batch staging (_pg_NNN) → log-mapping → _write_ocr_file → recovery event
+  reaper üksik → _resolve_job_meta (nüüd + page_number) → recovery event page_number-iga
+
+Faas 2:
+  GET /admin/ocr/jobs → normalize_ocr_jobs(list_uploads(), list_reocr_jobs())
+                      → ühtne nimekiri (title-enrich, status_key, link)
+  Review.tsx → üks nimekiri, tüübi-badge, järjekindel link
+  upload link → /upload?resumeUpload={id} → handleResume → progress kohe
+```
+
+## Veakäsitlus
+
+- `normalize_ocr_jobs` on puhas: vigane/puuduv väli → turvaline vaikeväärtus (title=slug, progress=None), ei crash'i.
+- Batch logimine idempotentne (üleminekul, mitte igal pollil) → logi ei paisu.
+- Reaper batch-taaste per-leht isoleeritud; puuduv mapping → `skip` + hoiatus (ei arva lehte).
+- Deep-link: puuduv/vale `resumeUpload` id → ignoreeritakse vaikselt (jääb tavaline `/upload` vaade).
+- `page_number` puudub taastatud üksik-kirjel (vana, 1a-eelne) → link teosele (fallback), mitte katki.
+
+## Testid (`.venv/bin/python -m pytest` + `npm run typecheck`)
+
+**Faas 1:**
+- `test_resolve_job_meta_includes_page_number`: logi-error-kirjest loetakse `page_number`.
+- `test_recovery_event_has_page_number`: taastatud kirje sisaldab `page_number`-i.
+- `test_batch_page_logged_on_ready`: batch leht `ready` → `reocr_log` kirje `page_number`-iga.
+- `test_batch_page_logged_once`: sama leht ei logita topelt (idempotentsus).
+- `test_reaper_recovers_batch_orphan_from_log`: batch-staging (mitu `_pg_NNN`) + logi → taastatud.
+
+**Faas 2:**
+- `test_normalize_upload_job`: upload reviewing → `status_key=review`, `link=/upload?resumeUpload=…`, `progress`.
+- `test_normalize_reocr_single`: done + page_number → `link=/work/{id}/{lk}`.
+- `test_normalize_reocr_batch`: `type=batch`, `link=/work/{id}`, `progress`.
+- `test_normalize_missing_fields_safe`: puuduv title → slug; puuduv work_id → link fallback.
+- Frontend: `npm run typecheck`; olemasolevad upload/reocr testid ei regresseeru.
+
+## Tarne (kaks faasi)
+
+- **Faas 1 (PR): recovery hardening** — 1a+1b+1c. Backend `--no-cache` deploy. Parandab lingid + batch-taaste kohe.
+- **Faas 2 (PR): ühtne vaade** — 2a+2b+2c. Backend + frontend deploy.
+
+## Väljaspool skoopi
+
+- Tegevuste (import/apply) toomine Review-lehele — jäävad oma lehtedele (otsus: ühtne nähtavus).
+- Praeguse 5 batch-orvu automaatne taaste — mapping kadunud, käsitsi.
+- OCR-serveri päris järjekorra-API — `queue_ahead` lokaalne lähend piisab (eelmine spec).
+- Upload-tööde `reocr_log`-i-laadne püsiv ajalugu — uploadid kaovad importimisel; koondvaade näitab aktiivseid + re-OCR ajalugu.
+
+## Issue #65 mõju
+
+Komponent 1 on `reocr_ops.py`/`reocr_recovery.py`-s (ei mõjuta). Komponent 2a normaliseerija loeb `list_uploads` (upload_ops) + `list_reocr_jobs` — ainult LUGEMINE avalike funktsioonide kaudu; kui #65 splitib upload_ops, muutub ainult import. Normaliseerija ise võiks elada uues `server/routers/ocr_jobs.py`-s (puhas, upload_ops-ist sõltumatu peale ühe import-rea).

--- a/docs/superpowers/specs/2026-07-01-ocr-jobs-unified-view-design.md
+++ b/docs/superpowers/specs/2026-07-01-ocr-jobs-unified-view-design.md
@@ -21,11 +21,11 @@ Kaks eraldi tähelepanekut deploy'tud re-OCR recovery järel:
 | Koondvaate roll | Ühtne **nähtavus**; tegevused (import, .ocr rakendus) jäävad oma lehtedele, koondvaatest lingid sinna |
 | Lingi siht | Leht (`/work/{id}/{lk}`) kui `page_number` teada; muidu teos (`/work/{id}`); upload → `/upload` deep-link. Iga kirje ALATI klõpsatav |
 | Paigutus | ÜKS ajajärjestatud nimekiri, iga rida märgib tüübi (Upload / Re-OCR / Batch) |
-| Batch-orbud | Logi batch edaspidi `reocr_log`-i → reaper taastab edaspidised batch-orvud; praegune 5 (mapping kadunud) käsitsi/jäta |
-| Batch idempotentsus | **Logi vastu, MITTE mälu vastu** — `_batch_logged_txt_names(job_id)` loeb logist, restart-kindel (review-punkt 1) |
-| Recovery-tee | **ÜKS koodirada** — mappi `(job_id, remote_txt_name)` järgi; single/batch eristust pole (review-punkt 3) |
+| Batch-orbud | **Püsiv batch-mapping fail** (`state/reocr_batch_maps/{job_id}.json`) batch ALGUSES → reaper taastab; praegune 5 (mapping kadunud) käsitsi |
+| Batch mapping püsivus | Fail kirjutatud alguses, kustutatud koristusel → restart/error/crash-kindel (review-punkt 1); orb EI valmi kunagi, seega valmimis-logimine EI sobiks |
+| Recovery-eristaja | **Deterministlik: mapping-fail olemas → batch, muidu üksik (log)** — mitte `_pg_NNN`-loenduse heuristika (review-punkt 3) |
 | Reaper-turvalisus | Puutub ainult töid, mida POLE `_reocr_jobs` EGA `_reocr_batch_jobs`-is; claim per `(job_id, remote_txt_name)` (review-punkt 2) |
-| Logi maht | `REOCR_LOG_MAX` 500 → 5000; pagineeritud; skip-hoiatus üks kord/protsess (review-punkt 4, 7) |
+| Logi maht | `REOCR_LOG_MAX` jääb 500 (batch ei floodi logi — mapping eraldi failis); skip-hoiatus üks kord/protsess (review-punkt 4, 7) |
 | Upload-link | Deep-link `/upload?resumeUpload={id}` → progress kohe näha; param eemaldatakse pärast resume't (review-punkt 5) |
 | Tarne | Kaks faasi: Komponent 1 (backend, parandab kohe) → Komponent 2 (feature) |
 
@@ -36,21 +36,40 @@ Kaks eraldi tähelepanekut deploy'tud re-OCR recovery järel:
 **1a. Taastatud `page_number` (bugfix).**
 `server/reocr_recovery.py` `_resolve_job_meta` tagastab lisaks `page_number` (loetud sama logi-error-kirjest, kust `page_filename` tuleb). `_recover_one` recovery-sündmus (`_append_to_log`) salvestab `page_number` → link + "lk N" ilmuvad. Frontend link-tingimust lõdvendatakse: `work_id` olemas → link (lehele kui `page_number`, muidu teosele).
 
-**1b. Batch logimine — idempotentsus LOGI vastu (mitte mälu vastu).**
-`server/reocr_ops.py` `_poll_batch_job` (ja batch abs-timeout/inactivity haru) lisab iga lahenenud lehe kohta `reocr_log`-i kirje. Kirje sisaldab **`remote_txt_name`** (nt `{slug}_pg_007.txt`), et taaste saaks staging-faili → page_filename mappida:
-```
-{job_id, work_id, slug, page_filename, page_number, remote_txt_name, username,
- status: "done"|"error", started_at, finished_at}
-```
-**Idempotentsus on logi vastu, MITTE in-memory "eelmine seis" vastu** (see kaoks restardil → topeltkirje või puuduv kirje). Helper `_batch_logged_txt_names(job_id) -> set` loeb `reocr_log`-ist selle job_id juba-logitud `remote_txt_name`-id; leht logitakse AINULT kui tema `remote_txt_name` pole hulgas. Nii on log-i seis taastuv üle restardi ja 1c vundament kindel. **NB: üksik-lehe logimine (`start_reocr_job` done/error) saab samuti `remote_txt_name` välja** (alati `{slug}_pg_001.txt`), et recovery-tee oleks ÜKS.
+**KRIITILINE mõistmine (miks mitte "logi valmimisel"):** batch-**orb** on leht, mis EI valmi
+kunagi VUTT-i poolel — OCR tootis `.txt` serverisse, aga VUTT kaotas jobi (restart/crash/12h-error)
+ENNE allalaadimist. Leht jääb `processing`-uks → valmimis-logimine EI salvesta selle mappingut.
+Seega mapping `_pg_NNN → page_filename` peab olema **püsiv batch'i ALGUSEST**. (Batch restardi-kadu
+on juba kaetud — batch persist'itakse `reocr_active.json`-i ja resume'ib. Jääb 12h-error-siis-hiline-txt.)
 
-**1c. Batch-orbude taaste — ÜKS koodirada (single/batch eristust POLE).**
-`server/reocr_recovery.py` reaper: iga staging-faili `{slug}_pg_NNN.txt` korral (olgu üksik `_pg_001` või batch `_pg_NNN`) lahenda page_filename `reocr_log`-ist matchides `job_id` JA `remote_txt_name == {slug}_pg_NNN.txt` (tagurpidiühilduvus: kui logi-kirjel pole `remote_txt_name`-i — vana üksik-kirje — ja job_id-l on ainult üks kirje, kasuta seda). Batch-heuristikat (">1 _pg_NNN") EI ole vaja — üks tee katab mõlemad.
-**Reaper puutub AINULT töid, mida aktiivses mälus POLE** (ei `_reocr_jobs` ega `_reocr_batch_jobs`) → väldib elava polleri ja reaperi võidujooksu batch-lehtede kirjutamisel. Claim-mehhanism (eelmisest spec'ist) laiendatakse batch-lehe granulaarsuseni: claim per `(job_id, remote_txt_name)`.
-Praegune 5 orvu (enne 1b logimist tehtud) jääb käsitsi — mapping puudub, reaper `skip`.
+**1b. Püsiv batch-mapping fail (recovery vundament).**
+`server/reocr_state.py` saab batch-mapping'u püsivuse (eraldi aktiivsete tööde failist):
+- `persist_batch_mapping(job_id, work_id, slug, pages) -> None` — kirjutab
+  `state/reocr_batch_maps/{job_id}.json` = `{work_id, slug, pages: {remote_txt_name: {page_filename, page_number}}}`.
+  Kutsutakse `start_reocr_batch`-is (batch ALGUSES, `_build_batch_pages` järel). Atomaarne (tmp+replace). Idempotentne.
+- `load_batch_mapping(job_id) -> dict|None` — reaperile.
+- `remove_batch_mapping(job_id) -> None` — kutsutakse kui batch täielikult koristatud (kõik lehed
+  resolved + staging eemaldatud `_poll_batch_job`-is) VÕI reaper koristas staging'u.
+- `list_batch_mapping_ids() -> list` — job_id-d, millel mapping-fail (reaperile eristajaks).
 
-**1d. Logi maht ja skip-müra (teadlik otsus).**
-Per-lehe batch-logimine tähendab, et 400-leheline batch = 400 kirjet. `reocr_log` on **cap'itud** (`REOCR_LOG_MAX`, praegu 500, kärbib viimase N-ni) ja `get_reocr_log` on **pagineeritud** (50/lk). Otsus: **tõsta `REOCR_LOG_MAX` 5000-ni**, et suured batch'id ei sööks ajalugu tühjaks (5000-kirjeline JSON-fail loeb ikka <ms). Aktsepteerime kärpe 5000 juures; kui kunagi liiga aeglane, siis rotatsioon (out of scope). **Skip-müra:** reaper hoiab protsessi-taseme `_warned_skips` set'i → sama unmappable `job_id` hoiatust logitakse ÜKS kord (mitte igal 5-min skannil). Praegune 5 orvu koristatakse **käsitsi Faas 1 deploy'l** (nende `job_id`-d on logides), et need üldse kaoksid staging'ust.
+See on **restart-, error- JA crash-kindel** (fail kirjutatud alguses, kustutatakse alles koristusel)
+ja hoiab `reocr_log`-i puhtana (EI floodi ajalugu 400 kirjega — dissolveerib logi-mahu mure).
+
+**1c. Batch-orbude taaste — deterministlik eristaja (mitte habras heuristika).**
+`server/reocr_recovery.py` reaper, iga staging job_id-kausta korral:
+- **Eristaja = `load_batch_mapping(job_id)`.** Kui mapping olemas → **batch**: iga staging-fail
+  `{slug}_pg_NNN.txt` → `page_filename` = `mapping["pages"][remote_txt_name]` → `_write_ocr_file` →
+  recovery-sündmus (`page_number`-iga). Kui mapping puudub → **üksik**: nagu praegu, `reocr_log`
+  `job_id` järgi (`_pg_001`). Ei mingit `_pg_NNN`-loenduse heuristikat.
+- **Reaper puutub AINULT töid, mida aktiivses mälus POLE** (ei `_reocr_jobs` EGA `_reocr_batch_jobs`)
+  → väldib elava polleri ja reaperi võidujooksu. Claim per `(job_id, remote_txt_name)`.
+- Batch täielikult taastatud/koristatud → `remove_batch_mapping(job_id)`.
+Praegune 5 orvu (enne 1b mapping'ut tehtud) jääb käsitsi — mapping puudub, reaper `skip`.
+
+**1d. Skip-müra.**
+Reaper hoiab protsessi-taseme `_warned_skips` set'i → sama unmappable `job_id` hoiatust logitakse
+ÜKS kord (mitte igal 5-min skannil). Praegune 5 orvu koristatakse **käsitsi Faas 1 deploy'l**, et
+need staging'ust kaoksid. **`reocr_log` cap jääb 500-ks** (batch ei floodi enam logi → mahumure kadus).
 
 ### Komponent 2 — Ühtne OCR-tööde vaade (faas 2)
 
@@ -106,13 +125,17 @@ normaliseerib upload-tööd (`list_uploads`) + re-OCR (`list_reocr_jobs` üksik 
 
 ```
 Faas 1:
-  batch _poll_batch_job → leht ready/error → _append_to_log (per leht)
-  reaper scan → batch staging (_pg_NNN) → log-mapping → _write_ocr_file → recovery event
+  start_reocr_batch → persist_batch_mapping(job_id, pages)  [state/reocr_batch_maps/]
+  _poll_batch_job → kõik lehed resolved + staging koristatud → remove_batch_mapping(job_id)
+  reaper scan, iga job_id-kaust:
+    load_batch_mapping(job_id)?  ── jah → BATCH: iga _pg_NNN → mapping[pages] → recover → remove_mapping
+                                 └─ ei  → ÜKSIK: reocr_log (job_id, _pg_001) → recover
+    (skip kui job_id aktiivne _reocr_jobs VÕI _reocr_batch_jobs-is)
   reaper üksik → _resolve_job_meta (nüüd + page_number) → recovery event page_number-iga
 
 Faas 2:
-  GET /admin/ocr/jobs → normalize_ocr_jobs(list_uploads(), list_reocr_jobs())
-                      → ühtne nimekiri (title-enrich, status_key, link)
+  GET /admin/ocr/jobs → normalize_ocr_jobs(list_uploads(), list_reocr_jobs(), title_of)
+                      → ühtne nimekiri (status_key, eelarvutatud link, sort started_at or 0)
   Review.tsx → üks nimekiri, tüübi-badge, järjekindel link
   upload link → /upload?resumeUpload={id} → handleResume → progress kohe
 ```
@@ -120,8 +143,8 @@ Faas 2:
 ## Veakäsitlus
 
 - `normalize_ocr_jobs` on puhas: vigane/puuduv väli → turvaline vaikeväärtus (title=slug, progress=None), ei crash'i.
-- Batch logimine idempotentne (üleminekul, mitte igal pollil) → logi ei paisu.
-- Reaper batch-taaste per-leht isoleeritud; puuduv mapping → `skip` + hoiatus (ei arva lehte).
+- Batch-mapping fail atomaarne (tmp+replace); vigane/puuduv → `None` (üksik-tee fallback), ei crash'i.
+- Reaper batch-taaste per-leht isoleeritud; mapping'us puuduv `_pg_NNN` → `skip` + hoiatus (ei arva lehte).
 - Deep-link: puuduv/vale `resumeUpload` id → ignoreeritakse vaikselt (jääb tavaline `/upload` vaade).
 - `page_number` puudub taastatud üksik-kirjel (vana, 1a-eelne) → link teosele (fallback), mitte katki.
 - **Upload import-viga** (`import_as_work` ebaõnnestus) → upload state `error` + `error_message` → normaliseerija `status_key=error`, `link=/upload?resumeUpload={id}` (admin näeb/proovib uuesti). Sama rida mis muud error'id.
@@ -133,11 +156,12 @@ Faas 2:
 **Faas 1:**
 - `test_resolve_job_meta_includes_page_number`: logi-error-kirjest loetakse `page_number`.
 - `test_recovery_event_has_page_number`: taastatud kirje sisaldab `page_number`-i.
-- `test_batch_page_logged_on_ready`: batch leht `ready` → `reocr_log` kirje `page_number` + `remote_txt_name`-iga.
-- `test_batch_page_logged_once_across_restart`: `_batch_logged_txt_names` loeb logist → juba-logitud leht EI logita uuesti, ka kui in-memory seis tühi (restart-simulatsioon). **(review-punkt 1)**
-- `test_reaper_recovers_batch_orphan_from_log`: batch-staging (mitu `_pg_NNN`) + per-lehe logi → kõik lehed taastatud õigetele `page_filename`-idele.
+- `test_batch_mapping_roundtrip`: `persist_batch_mapping` → `load_batch_mapping` tagastab sama; `remove_batch_mapping` kustutab; puuduv → None. **(review-punkt 1)**
+- `test_batch_mapping_persisted_at_start`: `start_reocr_batch` kirjutab mapping-faili (pages: remote_txt_name → page_filename+page_number).
+- `test_reaper_recovers_batch_orphan_via_mapping`: batch-staging (mitu `_pg_NNN`) + mapping-fail → kõik lehed taastatud õigetele `page_filename`-idele, `page_number`-iga.
+- `test_reaper_single_when_no_mapping`: mapping-fail puudub → üksik-tee (log `job_id` järgi, `_pg_001`).
 - `test_reaper_skips_live_batch_job`: kui `job_id` on `_reocr_batch_jobs`-is aktiivne, reaper EI puutu selle staging'ut. **(review-punkt 2)**
-- `test_reaper_single_path_matches_by_remote_txt_name`: nii üksik (`_pg_001`) kui batch-fail lahendatakse ÜHE tee kaudu (`job_id`+`remote_txt_name`); vana kirje ilma `remote_txt_name`-ita → job_id-fallback.
+- `test_reaper_removes_mapping_after_recovery`: batch täielikult taastatud → mapping-fail kustutatud.
 
 **Faas 2:**
 - `test_normalize_upload_job`: upload reviewing → `status_key=review`, `link=/upload?resumeUpload=…`, `progress`.

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -163,6 +163,10 @@ def start_reocr_batch(work_id: str, slug: str, work_path: str,
     remote_work = f"AUTO-OCR/{material_type}/{job_id}/{slug}"
     page_entries = _build_batch_pages(slug, pages)
     now = datetime.now().timestamp()
+    _batch_map_pages = {
+        e["remote_txt_name"]: {"page_filename": e["page_filename"], "page_number": e["page_number"]}
+        for e in page_entries
+    }
 
     job = {
         "kind": "batch",
@@ -181,6 +185,7 @@ def start_reocr_batch(work_id: str, slug: str, work_path: str,
     with _reocr_batch_jobs_lock:
         _reocr_batch_jobs[job_id] = job
     _persist_active_jobs()
+    reocr_state.persist_batch_mapping(job_id, work_id, slug, _batch_map_pages)
 
     def _upload():
         try:
@@ -288,6 +293,7 @@ def _poll_batch_job(job_id: str) -> None:
                     sftp.rmdir(d)
                 except Exception:
                     pass
+            reocr_state.remove_batch_mapping(job_id)
     finally:
         try:
             sftp.close()

--- a/server/reocr_recovery.py
+++ b/server/reocr_recovery.py
@@ -1,12 +1,15 @@
-"""Reconciliation-reaper: leiab OCR-serveri staging'usse orvuks jäänud VALMIS üksik-lehe
-re-OCR tulemused ja taastab need (kirjutab .ocr faili, lisab reocr_log-i recovery-sündmuse,
-koristab staging'u).
+"""Reconciliation-reaper: leiab OCR-serveri staging'usse orvuks jäänud VALMIS re-OCR
+tulemused (nii üksik-lehe kui batch) ja taastab need (kirjutab .ocr faili, lisab reocr_log-i
+recovery-sündmuse, koristab staging'u).
 
-Skoop: AINULT üksik-lehe orvud (AUTO-OCR/{print,hand}/{job_id}/{slug}/{slug}_pg_001.txt).
+Skoop: orvud — tööd, mis pole aktiivselt jälitatud (_reocr_jobs EGA _reocr_batch_jobs-is).
 Batch restardi-jätkamine käib load_active_jobs → resume polling kaudu, MITTE siit.
 
-Mapping-allikad (järjekorras): (1) reocr_log — orbude PÕHI-allikas (error-kirjed);
-(2) reocr_active.json — restardi-jätkamise varu.
+Deterministlik eristaja: batch-mapping fail olemas → batch-tee; puudub → üksik-tee.
+
+Mapping-allikad üksik-tee jaoks (järjekorras): (1) reocr_log — orbude PÕHI-allikas
+(error-kirjed); (2) reocr_active.json — restardi-jätkamise varu.
+Batch-tee kasutab püsivat mapping-faili (reocr_state.load_batch_mapping).
 """
 import io
 import os
@@ -26,43 +29,60 @@ _MATERIAL_TYPES = ("print", "hand")
 
 # Claim-set: kaitseb tavalise polleri ja reaperi võistluse eest (sama .txt topelt-töötlus).
 # Kaitstud reocr_ops._reocr_jobs_lock-iga (jagatud lukk, ei loo uut).
+# Võtmeks võib olla job_id (üksik-tee) VÕI (job_id, remote_txt_name) (batch-tee).
 _recovering = set()
+_warned_skips = set()  # job_id-d, mille skip-hoiatust juba logitud (müra vältimine)
 
 
 def _resolve_job_meta(job_id: str) -> Optional[dict]:
-    """Leia {page_filename, work_id} logist (põhi) või active.json-ist (varu)."""
+    """Leia {page_filename, work_id, page_number} logist (põhi) või active.json-ist (varu)."""
     log = reocr_ops.get_reocr_log(0, reocr_ops.REOCR_LOG_MAX).get("entries", [])
     for e in log:
         if e.get("job_id") == job_id and e.get("page_filename"):
-            return {"page_filename": e["page_filename"], "work_id": e.get("work_id")}
+            return {"page_filename": e["page_filename"], "work_id": e.get("work_id"),
+                    "page_number": e.get("page_number")}
     active = reocr_state.load_active_jobs()
     j = active.get(job_id)
     if j and j.get("page_filename"):
-        return {"page_filename": j["page_filename"], "work_id": j.get("work_id")}
+        return {"page_filename": j["page_filename"], "work_id": j.get("work_id"),
+                "page_number": j.get("page_number")}
     return None
 
 
 def _is_actively_tracked(job_id: str) -> bool:
     with reocr_ops._reocr_jobs_lock:
         j = reocr_ops._reocr_jobs.get(job_id)
-        return bool(j and j.get("status") in ("uploading", "processing"))
+        if j and j.get("status") in ("uploading", "processing"):
+            return True
+    with reocr_ops._reocr_batch_jobs_lock:
+        b = reocr_ops._reocr_batch_jobs.get(job_id)
+        if b and b.get("status") in ("uploading", "processing"):
+            return True
+    return False
 
 
-def _claim(job_id: str) -> bool:
-    """Proovi claimida job. Tagastab False kui juba claimitud või aktiivne."""
+def _warn_skip_once(job_id: str, msg: str) -> None:
+    if job_id not in _warned_skips:
+        _warned_skips.add(job_id)
+        logger.warning(f"Reaper skip {job_id}: {msg}")
+
+
+def _claim(key) -> bool:
+    """Claim recovery-võti (job_id VÕI (job_id, txt_name)). Tagastab False kui juba claimitud."""
+    job_id = key[0] if isinstance(key, tuple) else key
     with reocr_ops._reocr_jobs_lock:
-        if job_id in _recovering:
+        if key in _recovering:
             return False
         j = reocr_ops._reocr_jobs.get(job_id)
         if j and j.get("status") in ("uploading", "processing"):
             return False
-        _recovering.add(job_id)
+        _recovering.add(key)
         return True
 
 
-def _release(job_id: str) -> None:
+def _release(key) -> None:
     with reocr_ops._reocr_jobs_lock:
-        _recovering.discard(job_id)
+        _recovering.discard(key)
 
 
 def _cleanup_staging(sftp, job_dir: str, slug: str) -> None:
@@ -83,6 +103,69 @@ def _cleanup_staging(sftp, job_dir: str, slug: str) -> None:
 def _recover_one(sftp, base: str, job_id: str, recovered: List[str], skipped: List[str]) -> None:
     if _is_actively_tracked(job_id):
         return
+    mapping = reocr_state.load_batch_mapping(job_id)
+    if mapping is not None:
+        _recover_batch(sftp, base, job_id, mapping, recovered, skipped)
+    else:
+        _recover_single(sftp, base, job_id, recovered, skipped)
+
+
+def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[str], skipped: List[str]) -> None:
+    slug = mapping.get("slug")
+    work_id = mapping.get("work_id")
+    pages = mapping.get("pages", {})
+    job_dir = f"{base}/{job_id}"
+    work_dir = f"{job_dir}/{slug}"
+    try:
+        files = sftp.listdir(work_dir)
+    except FileNotFoundError:
+        reocr_state.remove_batch_mapping(job_id)  # staging kadunud → mapping aegunud
+        return
+    for fname in files:
+        if not fname.endswith(".txt"):
+            continue
+        info = pages.get(fname)
+        if not info:
+            _warn_skip_once(job_id, f"{fname} pole mapping'us")
+            skipped.append(job_id)
+            continue
+        key = (job_id, fname)
+        if not _claim(key):
+            continue
+        try:
+            buf = io.BytesIO()
+            sftp.getfo(f"{work_dir}/{fname}", buf)
+            text = buf.getvalue().decode("utf-8", errors="replace")
+            reocr_ops._write_ocr_file(slug, info["page_filename"], text)
+            now = datetime.now().timestamp()
+            reocr_ops._append_to_log(
+                {"work_id": work_id, "slug": slug, "page_filename": info["page_filename"],
+                 "page_number": info.get("page_number"), "status": "done", "error": None,
+                 "started_at": None, "finished_at": now,
+                 "recovered": True, "original_status": "error", "recovered_at": now}, job_id)
+            try:
+                sftp.remove(f"{work_dir}/{fname}")
+            except Exception:
+                pass
+            recovered.append(job_id)
+            logger.info(f"Reaper taastas batch {job_id}/{fname} ({slug}/{info['page_filename']})")
+        finally:
+            _release(key)
+    # Kui rohkem .txt pole, koorista kaust + mapping
+    try:
+        remaining = [f for f in sftp.listdir(work_dir) if f.endswith(".txt")]
+    except FileNotFoundError:
+        remaining = []
+    if not remaining:
+        for d in (work_dir, job_dir):
+            try:
+                sftp.rmdir(d)
+            except Exception:
+                pass
+        reocr_state.remove_batch_mapping(job_id)
+
+
+def _recover_single(sftp, base: str, job_id: str, recovered: List[str], skipped: List[str]) -> None:
     job_dir = f"{base}/{job_id}"
     try:
         slugs = sftp.listdir(job_dir)
@@ -100,7 +183,7 @@ def _recover_one(sftp, base: str, job_id: str, recovered: List[str], skipped: Li
             meta = _resolve_job_meta(job_id)
             if not meta:
                 skipped.append(job_id)
-                logger.warning(f"Reaper: {job_id} .txt olemas, aga page_filename teadmata → skip")
+                _warn_skip_once(job_id, ".txt olemas, aga page_filename teadmata")
                 return
             buf = io.BytesIO()
             sftp.getfo(txt_abs, buf)
@@ -108,13 +191,10 @@ def _recover_one(sftp, base: str, job_id: str, recovered: List[str], skipped: Li
             reocr_ops._write_ocr_file(slug, meta["page_filename"], text)
             now = datetime.now().timestamp()
             reocr_ops._append_to_log(
-                {"work_id": meta.get("work_id"), "slug": slug,
-                 "page_filename": meta["page_filename"], "status": "done",
-                 "error": None, "started_at": None,
-                 "finished_at": now,
-                 "recovered": True, "original_status": "error",
-                 "recovered_at": now},
-                job_id)
+                {"work_id": meta.get("work_id"), "slug": slug, "page_filename": meta["page_filename"],
+                 "page_number": meta.get("page_number"), "status": "done", "error": None,
+                 "started_at": None, "finished_at": now,
+                 "recovered": True, "original_status": "error", "recovered_at": now}, job_id)
             _cleanup_staging(sftp, job_dir, slug)
             recovered.append(job_id)
             logger.info(f"Reaper taastas {job_id} ({slug}/{meta['page_filename']})")

--- a/server/reocr_state.py
+++ b/server/reocr_state.py
@@ -7,7 +7,7 @@ reocr_log (vt reocr_recovery.py), sest error/crash'itud tööd on siit juba eema
 import json
 import os
 import threading
-from typing import Dict
+from typing import Dict, Optional
 
 from .config import STATE_DIR, get_logger
 
@@ -44,3 +44,59 @@ def load_active_jobs() -> Dict[str, dict]:
         except Exception as e:
             logger.warning(f"reocr_active.json lugemine ebaõnnestus: {e}")
             return {}
+
+
+BATCH_MAPS_DIR = os.path.join(STATE_DIR, "reocr_batch_maps")
+
+
+def _batch_map_path(job_id: str) -> str:
+    return os.path.join(BATCH_MAPS_DIR, f"{job_id}.json")
+
+
+def persist_batch_mapping(job_id: str, work_id, slug: str, pages: Dict[str, dict]) -> None:
+    """Kirjuta batch lehe-mapping püsivalt (recovery vundament). Atomaarne."""
+    data = {"work_id": work_id, "slug": slug, "pages": pages}
+    with _file_lock:
+        try:
+            os.makedirs(BATCH_MAPS_DIR, exist_ok=True)
+            path = _batch_map_path(job_id)
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, path)
+        except Exception as e:
+            logger.warning(f"batch-mapping kirjutamine ebaõnnestus ({job_id}): {e}")
+
+
+def load_batch_mapping(job_id: str) -> Optional[dict]:
+    """Batch lehe-mapping või None (puuduv/vigane)."""
+    with _file_lock:
+        try:
+            path = _batch_map_path(job_id)
+            if not os.path.exists(path):
+                return None
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else None
+        except Exception as e:
+            logger.warning(f"batch-mapping lugemine ebaõnnestus ({job_id}): {e}")
+            return None
+
+
+def remove_batch_mapping(job_id: str) -> None:
+    """Kustuta batch-mapping fail (best-effort, koristusel)."""
+    with _file_lock:
+        try:
+            os.remove(_batch_map_path(job_id))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.warning(f"batch-mapping kustutamine ebaõnnestus ({job_id}): {e}")
+
+
+def list_batch_mapping_ids() -> list:
+    """job_id-d, millel on batch-mapping fail (reaperile)."""
+    try:
+        return [os.path.splitext(f)[0] for f in os.listdir(BATCH_MAPS_DIR) if f.endswith(".json")]
+    except FileNotFoundError:
+        return []

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -577,9 +577,9 @@ const Review: React.FC = () => {
                             {job.page_number && (
                               <span className="text-xs text-gray-500">lk {job.page_number}</span>
                             )}
-                            {job.work_id && job.page_number && (
+                            {job.work_id && (
                               <a
-                                href={`/work/${job.work_id}/${job.page_number}`}
+                                href={job.page_number ? `/work/${job.work_id}/${job.page_number}` : `/work/${job.work_id}`}
                                 className="text-xs text-primary-600 hover:underline flex items-center gap-0.5"
                                 target="_blank"
                                 rel="noreferrer"
@@ -658,8 +658,8 @@ const Review: React.FC = () => {
                               <span className="text-gray-700">{entry.title || entry.slug}</span>
                               {entry.title && <span className="text-xs text-gray-400 font-mono" title={entry.slug}>{entry.slug}</span>}
                               {entry.page_number && <span className="text-xs text-gray-400">lk {entry.page_number}</span>}
-                              {entry.work_id && entry.page_number && (
-                                <a href={`/work/${entry.work_id}/${entry.page_number}`} target="_blank" rel="noreferrer"
+                              {entry.work_id && (
+                                <a href={entry.page_number ? `/work/${entry.work_id}/${entry.page_number}` : `/work/${entry.work_id}`} target="_blank" rel="noreferrer"
                                   className="text-xs text-primary-600 hover:underline flex items-center gap-0.5">
                                   <ExternalLink size={11} />
                                 </a>

--- a/tests/test_reocr_recovery.py
+++ b/tests/test_reocr_recovery.py
@@ -1,4 +1,5 @@
 """Reconciliation-reaper: taastab OCR-staging'usse orvuks jäänud üksik-lehe tulemused."""
+import os
 import sys
 from pathlib import Path
 
@@ -10,7 +11,8 @@ import server.reocr_recovery as rec
 
 
 class _FakeSftp:
-    """Mockib OCR-serveri staging'ut. tree: {abs_dir: [names]}, files: {abs_path: bytes}."""
+    """Mockib OCR-serveri staging'ut. tree: {abs_dir: [names]}, files: {abs_path: bytes}.
+    Käitub realistlikult: remove/rmdir muteerivad olekut, et listdir peegeldaks kustutusi."""
     def __init__(self, tree, files):
         self.tree = tree
         self.files = files
@@ -28,8 +30,16 @@ class _FakeSftp:
         buf.write(self.files[path])
     def remove(self, path):
         self.removed.append(path)
+        self.files.pop(path, None)
+        parent, base = os.path.split(path)
+        if parent in self.tree and base in self.tree[parent]:
+            self.tree[parent].remove(base)
     def rmdir(self, path):
         self.rmdired.append(path)
+        self.tree.pop(path, None)
+        parent, base = os.path.split(path)
+        if parent in self.tree and base in self.tree[parent]:
+            self.tree[parent].remove(base)
     def close(self):
         pass
 
@@ -42,10 +52,12 @@ def _env(tmp_path, monkeypatch):
     monkeypatch.setattr(reocr_ops, "REOCR_LOG_FILE", str(tmp_path / "reocr_log.json"))
     import server.reocr_state as st
     monkeypatch.setattr(st, "REOCR_ACTIVE_FILE", str(tmp_path / "reocr_active.json"))
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "reocr_batch_maps"))
     (tmp_path / "w1").mkdir()
     with reocr_ops._reocr_jobs_lock:
         reocr_ops._reocr_jobs.clear()
     rec._recovering.clear()
+    rec._warned_skips.clear()
     yield
     with reocr_ops._reocr_jobs_lock:
         reocr_ops._reocr_jobs.clear()
@@ -182,3 +194,67 @@ def test_revive_dead_uploads_counts_only_uploading():
     assert r._revive_dead_uploads(jobs) == 2
     assert jobs["a"]["status"] == "processing"
     assert jobs["b"]["status"] == "processing"
+
+
+def test_resolve_job_meta_includes_page_number(monkeypatch, tmp_path):
+    reocr_ops._append_to_log(
+        {"work_id": "wid", "slug": "w1", "page_filename": "w1-lk-7.jpg",
+         "page_number": 7, "status": "error", "started_at": 1.0, "finished_at": 2.0}, "j1")
+    meta = rec._resolve_job_meta("j1")
+    assert meta["page_filename"] == "w1-lk-7.jpg"
+    assert meta["page_number"] == 7
+
+
+def test_batch_orphan_recovered_via_mapping(monkeypatch, tmp_path):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    st.persist_batch_mapping("borb", "wid", "w1", {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-1.jpg", "page_number": 1},
+        "w1_pg_002.txt": {"page_filename": "w1-lk-2.jpg", "page_number": 2},
+    })
+    tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
+            "/OCR/AUTO-OCR/print/borb": ["w1"],
+            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.txt", "w1_pg_002.txt"]}
+    files = {"/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt": b"tekst1",
+             "/OCR/AUTO-OCR/print/borb/w1/w1_pg_002.txt": b"tekst2"}
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: _FakeSftp(tree, files))
+    monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
+    with reocr_ops._reocr_jobs_lock:
+        reocr_ops._reocr_jobs.clear()
+    rec._recovering.clear()
+
+    result = rec.scan_and_recover()
+
+    assert "borb" in result["recovered"]
+    assert (tmp_path / "w1" / "w1-lk-1.ocr").read_text(encoding="utf-8") == "tekst1"
+    assert (tmp_path / "w1" / "w1-lk-2.ocr").read_text(encoding="utf-8") == "tekst2"
+    # Logi recovery-kirjed page_number-iga
+    entries = reocr_ops.get_reocr_log(0, 100)["entries"]
+    recs = [e for e in entries if e.get("recovered")]
+    assert {e["page_number"] for e in recs} == {1, 2}
+    # Mapping kustutatud pärast taastet
+    assert st.load_batch_mapping("borb") is None
+
+
+def test_reaper_skips_live_batch_job(monkeypatch, tmp_path):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    st.persist_batch_mapping("borb", "wid", "w1", {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-1.jpg", "page_number": 1}})
+    tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
+            "/OCR/AUTO-OCR/print/borb": ["w1"],
+            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.txt"]}
+    sftp = _FakeSftp(tree, {"/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt": b"x"})
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: sftp)
+    monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
+    with reocr_ops._reocr_batch_jobs_lock:
+        reocr_ops._reocr_batch_jobs.clear()
+        reocr_ops._reocr_batch_jobs["borb"] = {"status": "processing", "kind": "batch"}
+    rec._recovering.clear()
+
+    result = rec.scan_and_recover()
+
+    assert result["recovered"] == []
+    assert sftp.removed == []
+    with reocr_ops._reocr_batch_jobs_lock:
+        reocr_ops._reocr_batch_jobs.clear()

--- a/tests/test_reocr_slow_flag.py
+++ b/tests/test_reocr_slow_flag.py
@@ -105,3 +105,28 @@ def test_batch_absolute_timeout_errors_remaining_after_final_poll(monkeypatch):
     j = reocr_ops._reocr_batch_jobs["b1"]
     assert j["status"] == "done"
     assert j["pages"][0]["status"] == "error"
+
+
+def test_start_reocr_batch_persists_mapping(tmp_path, monkeypatch):
+    import server.reocr_ops as r
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    monkeypatch.setattr(st, "REOCR_ACTIVE_FILE", str(tmp_path / "active.json"))
+    # Ära ava päris SFTP-d — upload-thread ebaõnnestub vaikselt, mapping on juba kirjutatud
+    monkeypatch.setattr(r, "_sftp_open", lambda jid: (_ for _ in ()).throw(RuntimeError("no ssh")))
+    work_dir = tmp_path / "w1"; work_dir.mkdir()
+    (work_dir / "w1-a.jpg").write_bytes(b"x")
+    monkeypatch.setattr(r, "BASE_DIR", str(tmp_path))
+
+    job_id = r.start_reocr_batch("wid", "w1", str(work_dir),
+                                 [("w1-a.jpg", 7)], material_type="print", username="u")
+    mapping = st.load_batch_mapping(job_id)
+    assert mapping is not None
+    assert mapping["slug"] == "w1" and mapping["work_id"] == "wid"
+    # remote_txt_name → page_filename + page_number
+    names = list(mapping["pages"].values())
+    assert names[0]["page_filename"] == "w1-a.jpg"
+    assert names[0]["page_number"] == 7
+    assert "w1_pg_001.txt" in mapping["pages"]
+    with r._reocr_batch_jobs_lock:
+        r._reocr_batch_jobs.clear()

--- a/tests/test_reocr_state.py
+++ b/tests/test_reocr_state.py
@@ -42,3 +42,43 @@ def test_persist_is_atomic_valid_json(tmp_path, monkeypatch):
     st.persist_active_jobs({"a": {"status": "processing", "kind": "batch"}})
     assert json.loads(target.read_text(encoding="utf-8"))["a"]["kind"] == "batch"
     assert not (tmp_path / "reocr_active.json.tmp").exists()
+
+
+def test_batch_mapping_roundtrip(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "reocr_batch_maps"))
+    pages = {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-005.jpg", "page_number": 5},
+        "w1_pg_002.txt": {"page_filename": "w1-lk-006.jpg", "page_number": 6},
+    }
+    st.persist_batch_mapping("b1", "wid", "w1", pages)
+    loaded = st.load_batch_mapping("b1")
+    assert loaded["work_id"] == "wid"
+    assert loaded["slug"] == "w1"
+    assert loaded["pages"]["w1_pg_002.txt"]["page_filename"] == "w1-lk-006.jpg"
+    assert loaded["pages"]["w1_pg_002.txt"]["page_number"] == 6
+
+
+def test_batch_mapping_missing_returns_none(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "reocr_batch_maps"))
+    assert st.load_batch_mapping("puudub") is None
+
+
+def test_batch_mapping_corrupt_returns_none(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    d = tmp_path / "reocr_batch_maps"
+    d.mkdir()
+    (d / "b1.json").write_text("{ vigane", encoding="utf-8")
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(d))
+    assert st.load_batch_mapping("b1") is None
+
+
+def test_batch_mapping_remove(tmp_path, monkeypatch):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "reocr_batch_maps"))
+    st.persist_batch_mapping("b1", "wid", "w1", {})
+    assert st.load_batch_mapping("b1") is not None
+    st.remove_batch_mapping("b1")
+    assert st.load_batch_mapping("b1") is None
+    st.remove_batch_mapping("b1")  # teist korda — ei crash'i


### PR DESCRIPTION
Faas 1 kahefaasilisest OCR-tööde tööst (Faas 2 = ühtne vaade tuleb eraldi).

## Probleem
- **Batch-orbe ei taastatud:** batch re-OCR tööd polnud `reocr_log`-is; lehe-mapping (`_pg_NNN → page_filename`) elas ainult mälus → 5 batch-orvu jäi taastamata.
- **Taastatud kirjetel puudus link:** reaperi taastatud üksik-kirjed ei salvestanud `page_number`-i → Review-lehel polnud linki ega "lk N".

## Lahendus
- **Püsiv batch-mapping fail** (`state/reocr_batch_maps/{job_id}.json`), kirjutatud batch ALGUSES, kustutatud koristusel → restart/error/crash-kindel. (Batch-orb EI valmi kunagi VUTT-i poolel, seega valmimis-logimine ei sobiks — mapping peab olema püsiv algusest.)
- **Reaper taastab batch-orvud** mapping'ust; deterministlik eristaja (mapping-fail olemas → batch, muidu üksik). Aktiivsuse-check mõlemast dict'ist; claim per `(job_id, remote_txt_name)`; skip-müra dedupe.
- **`_resolve_job_meta` + `page_number`** → taastatud kirjed saavad `page_number`; frontend link `work_id` olemasolul (leht kui page_number, muidu teos).

## Testid
- Backend **799 läbivad** (4 uut batch-mapping, 1 slow_flag, 3 recovery). `npm run typecheck` puhas.

## Deploy järel
- Startup-recovery + reaper korjavad edaspidised batch-orvud. **Praegune 5 orvu vajab käsitsi koristust** (neil mapping puudub → reaper skip, üks hoiatus/protsess).

Disain: `docs/superpowers/specs/2026-07-01-ocr-jobs-unified-view-design.md`
Plaanid: `docs/superpowers/plans/2026-07-01-ocr-*.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)