### PR TITLE
feat: OCR-tööde ühtne vaade (Faas 2) — upload + re-OCR + batch ühes nimekirjas

### DIFF
--- a/docs/superpowers/plans/2026-07-01-ocr-jobs-unified-view-phase2.md
+++ b/docs/superpowers/plans/2026-07-01-ocr-jobs-unified-view-phase2.md
@@ -1,6 +1,6 @@
 # OCR-tööde ühtne vaade (Faas 2) — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Review-lehel üks ajajärjestatud nimekiri, mis näitab KÕIKI OCR-serveri töid (upload + üksik re-OCR + batch) tüübi-badge'i, ühtse staatuse ja järjekindla lingiga.
 
@@ -45,7 +45,7 @@
 **Interfaces:**
 - Produces: `list_reocr_batch_jobs() -> list` — iga batch-jobi kohta `{job_id, work_id, slug, username, status, slow, started_at, ready, total}`.
 
-- [ ] **Step 1: Write the failing test** (lisa `tests/test_reocr_batch.py` lõppu)
+- [x] **Step 1: Write the failing test** (lisa `tests/test_reocr_batch.py` lõppu)
 
 ```python
 def test_list_reocr_batch_jobs_summary():
@@ -67,12 +67,12 @@ def test_list_reocr_batch_jobs_summary():
         r._reocr_batch_jobs.clear()
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_batch.py::test_list_reocr_batch_jobs_summary -q`
 Expected: FAIL — `AttributeError: ... 'list_reocr_batch_jobs'`
 
-- [ ] **Step 3: Implement** (lisa `server/reocr_ops.py`-sse, `list_reocr_jobs` järele)
+- [x] **Step 3: Implement** (lisa `server/reocr_ops.py`-sse, `list_reocr_jobs` järele)
 
 ```python
 def list_reocr_batch_jobs() -> list:
@@ -96,12 +96,12 @@ def list_reocr_batch_jobs() -> list:
     return out
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `.venv/bin/python -m pytest tests/test_reocr_batch.py -q`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add server/reocr_ops.py tests/test_reocr_batch.py
@@ -123,7 +123,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Produces:
   - `normalize_ocr_jobs(uploads: List[dict], singles: List[dict], batches: List[dict], title_of: Callable[[Optional[str]], str]) -> List[dict]` — ühtne, ajajärjestatud (started_at DESC, None→0.0) kirjete loend kujuga: `{id, type, title, slug, work_id, page_number, status_key, slow, started_at, progress, link, error}`.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```python
 # tests/test_ocr_jobs_normalize.py
@@ -220,12 +220,12 @@ def test_normalize_sorted_desc():
     assert ids == ["b", "c", "a"]  # started_at DESC
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py -q`
 Expected: FAIL — `ModuleNotFoundError: No module named 'server.ocr_jobs_normalize'`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```python
 # server/ocr_jobs_normalize.py
@@ -354,12 +354,12 @@ def normalize_ocr_jobs(uploads: List[dict], singles: List[dict], batches: List[d
     return out
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py -q`
 Expected: PASS
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add server/ocr_jobs_normalize.py tests/test_ocr_jobs_normalize.py
@@ -380,7 +380,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Consumes: `normalize_ocr_jobs` (Task 2), `list_uploads`, `list_reocr_jobs`, `list_reocr_batch_jobs` (Task 1), `find_directory_by_id`.
 - Produces: `GET /admin/ocr/jobs` → `{status:"success", jobs:[...]}`.
 
-- [ ] **Step 1: Write the failing test** (lisa `tests/test_ocr_jobs_normalize.py` lõppu — endpoint-tasandi title-cache lugeja)
+- [x] **Step 1: Write the failing test** (lisa `tests/test_ocr_jobs_normalize.py` lõppu — endpoint-tasandi title-cache lugeja)
 
 ```python
 def test_title_reader_reads_metadata(tmp_path, monkeypatch):
@@ -397,12 +397,12 @@ def test_title_reader_reads_metadata(tmp_path, monkeypatch):
     assert reader("wid") == "Loetud Pealkiri"
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py::test_title_reader_reads_metadata -q`
 Expected: FAIL — `ModuleNotFoundError: No module named 'server.routers.ocr_jobs'`
 
-- [ ] **Step 3: Implement router**
+- [x] **Step 3: Implement router**
 
 ```python
 # server/routers/ocr_jobs.py
@@ -453,7 +453,7 @@ async def admin_ocr_jobs(user=Depends(require_role("admin"))):
     return {"status": "success", "jobs": jobs}
 ```
 
-- [ ] **Step 4: Register router in main.py**
+- [x] **Step 4: Register router in main.py**
 
 `server/main.py` — lisa import (`from .routers.reocr import router as reocr_router` juurde, rida ~19):
 
@@ -467,12 +467,12 @@ Ja registreerimise juurde (`app.include_router(reocr_router)` juurde, rida ~56):
 app.include_router(ocr_jobs_router)
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [x] **Step 5: Run tests to verify they pass**
 
 Run: `.venv/bin/python -m pytest tests/test_ocr_jobs_normalize.py -q && .venv/bin/python -c "import server.main; print('main imports OK')"`
 Expected: PASS + "main imports OK"
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add server/routers/ocr_jobs.py server/main.py tests/test_ocr_jobs_normalize.py
@@ -492,7 +492,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 - Consumes: `searchParams`, `pendingUploads`, `handleResume` (olemas).
 - Produces: `/upload?resumeUpload={id}` avab otse selle uploadi ülevaatusele; param eemaldatakse pärast.
 
-- [ ] **Step 1: Add deep-link resume effect**
+- [x] **Step 1: Add deep-link resume effect**
 
 `src/pages/upload/useUploadWizard.ts` — lisa `useRef` import kui puudub (`import { useRef } from 'react'`) ja `useNavigate` on juba imporditud. Lisa `handleResume` funktsiooni JÄREL (rida ~471) effect:
 
@@ -513,12 +513,12 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 
 **NB:** kontrolli, et `location` on saadaval (`useLocation`) või kasuta `window.location.pathname`. Kui `useLocation` pole imporditud, lisa `import { useLocation } from 'react-router-dom'` ja `const location = useLocation()`. `handleResume` on funktsioon samas hookis — effect'i deps ei vaja seda (stabiilne closure); kui lint nõuab, lisa `// eslint-disable-next-line react-hooks/exhaustive-deps`.
 
-- [ ] **Step 2: Typecheck**
+- [x] **Step 2: Typecheck**
 
 Run: `npm run typecheck`
 Expected: 0 errorit
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add src/pages/upload/useUploadWizard.ts
@@ -538,7 +538,7 @@ Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
 **Interfaces:**
 - Consumes: `GET /admin/ocr/jobs` (Task 3) → `{jobs:[{id,type,title,slug,work_id,page_number,status_key,slow,started_at,progress,link,error}]}`.
 
-- [ ] **Step 1: Replace ReocrJob type with unified OcrJob**
+- [x] **Step 1: Replace ReocrJob type with unified OcrJob**
 
 `src/pages/Review.tsx` — asenda `interface ReocrJob {...}` (aktiivsete tööde tüüp) järgnevaga (jäta `reocrLog` tüüp ReocrJob-iks eraldi — vt allpool):
 
@@ -561,7 +561,7 @@ interface OcrJob {
 
 Muuda `reocrJobs` olek: `const [reocrJobs, setReocrJobs] = useState<OcrJob[]>([]);` (ajaloo `reocrLog` jääb ReocrJob-iks, mille tüüp on juba failis — kui see kasutab slow/queue_ahead välju, jäta need alles).
 
-- [ ] **Step 2: Point fetch at unified endpoint**
+- [x] **Step 2: Point fetch at unified endpoint**
 
 `loadReocrJobs`-is asenda URL:
 
@@ -575,7 +575,7 @@ Ja pollimise `hasActive` kontroll (`j.status === ...`) → `status_key`:
     const hasActive = reocrJobs.some(j => j.status_key === 'uploading' || j.status_key === 'processing');
 ```
 
-- [ ] **Step 3: Replace active-jobs render with unified rows**
+- [x] **Step 3: Replace active-jobs render with unified rows**
 
 Asenda aktiivsete tööde `.map(job => {...})` plokk järgnevaga (kasutab `status_key`, `type`, `link`, `progress`; kulunud aeg + slow badge nagu enne):
 
@@ -637,7 +637,7 @@ Asenda aktiivsete tööde `.map(job => {...})` plokk järgnevaga (kasutab `statu
 
 **NB:** `formatElapsed` on juba failis (eelmisest featuurist). Kui `reocrJobs.filter(...)` loendurit kasutatakse mujal (nt aktiivsete arv, rida ~510), muuda `j.status === ...` → `j.status_key === ...`.
 
-- [ ] **Step 4: Add i18n keys**
+- [x] **Step 4: Add i18n keys**
 
 `src/locales/et/review.json` — `reocr` bloki KÕRVALE (juur-tasand) lisa `ocr` blokk:
 
@@ -671,12 +671,12 @@ Asenda aktiivsete tööde `.map(job => {...})` plokk järgnevaga (kasutab `statu
   },
 ```
 
-- [ ] **Step 5: Typecheck**
+- [x] **Step 5: Typecheck**
 
 Run: `npm run typecheck`
 Expected: 0 errorit
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add src/pages/Review.tsx src/locales/et/review.json src/locales/en/review.json

--- a/server/main.py
+++ b/server/main.py
@@ -26,6 +26,7 @@ from .routers.public_registries import router as public_registries_router
 from .routers.public import router as public_router
 from .routers.editing import router as editing_router
 from .routers.collections import router as collections_router
+from .routers.ocr_jobs import router as ocr_jobs_router
 from .prosopography.indices import rebuild_indices
 
 @asynccontextmanager
@@ -56,6 +57,7 @@ app.include_router(prosopography_router, prefix="/prosopography")
 app.include_router(notifications_router)
 app.include_router(upload_router)
 app.include_router(reocr_router)
+app.include_router(ocr_jobs_router)
 app.include_router(pages_router)
 app.include_router(auth_router)
 app.include_router(admin_router)

--- a/server/ocr_jobs_normalize.py
+++ b/server/ocr_jobs_normalize.py
@@ -58,6 +58,7 @@ def _normalize_upload(state: dict, title_of) -> dict:
         "progress": {"ready": ready, "total": total} if total else None,
         "link": _upload_link(state, status_key),
         "error": state.get("error_message"),
+        "username": state.get("username", ""),  # uploadid ei salvesta praegu → ""
     }
 
 
@@ -91,6 +92,7 @@ def _normalize_single(job: dict, title_of) -> dict:
         "progress": None,
         "link": _work_link(job.get("work_id"), job.get("page_number")),
         "error": job.get("error"),
+        "username": job.get("username", ""),
     }
 
 
@@ -109,6 +111,7 @@ def _normalize_batch(job: dict, title_of) -> dict:
         "progress": {"ready": job.get("ready", 0), "total": total} if total else None,
         "link": _work_link(job.get("work_id"), None),
         "error": job.get("error"),
+        "username": job.get("username", ""),
     }
 
 
@@ -119,5 +122,14 @@ def normalize_ocr_jobs(uploads: List[dict], singles: List[dict], batches: List[d
     out += [_normalize_upload(u, title_of) for u in uploads]
     out += [_normalize_single(s, title_of) for s in singles]
     out += [_normalize_batch(b, title_of) for b in batches]
+    # queue_ahead: ühtne lokaalne FIFO-lähend üle KÕIGI aktiivsete (upload+reocr+batch)
+    # started_at järgi. OCR-serveri päris järjekorda ei teata.
+    active = [e for e in out if e["status_key"] in ("uploading", "processing")]
+    for e in out:
+        if e["status_key"] in ("uploading", "processing"):
+            st = e.get("started_at") or 0.0
+            e["queue_ahead"] = sum(1 for o in active if (o.get("started_at") or 0.0) < st)
+        else:
+            e["queue_ahead"] = 0
     out.sort(key=lambda e: e.get("started_at") or 0.0, reverse=True)
     return out

--- a/server/ocr_jobs_normalize.py
+++ b/server/ocr_jobs_normalize.py
@@ -1,0 +1,123 @@
+"""Puhas normaliseerija: upload + üksik/batch re-OCR tööd ÜHE kujuni ühtse vaate jaoks.
+
+DOM-/IO-vaba. title_of süstitakse (endpoint annab cache'itud lugeja, test lambda).
+"""
+from datetime import datetime
+from typing import Callable, List, Optional
+
+
+def _parse_ts(value) -> float:
+    """ISO-string VÕI float → timestamp; parse-viga → 0.0 (sort-turvaline)."""
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return datetime.fromisoformat(str(value)).timestamp()
+    except Exception:
+        return 0.0
+
+
+def _upload_status_key(status: str) -> str:
+    if status in ("pending", "uploading", "collecting_images"):
+        return "uploading"
+    if status == "processing":
+        return "processing"
+    if status in ("reviewing", "done"):
+        return "review"
+    if status == "imported":
+        return "imported"
+    return "error"
+
+
+def _upload_link(state: dict, status_key: str) -> str:
+    if status_key == "imported":
+        wid = state.get("meta", {}).get("work_id")
+        return f"/work/{wid}" if wid else "/upload"
+    return f"/upload?resumeUpload={state.get('id')}"
+
+
+def _normalize_upload(state: dict, title_of) -> dict:
+    meta = state.get("meta", {}) or {}
+    status = state.get("status", "pending")
+    status_key = _upload_status_key(status)
+    files = state.get("files", []) or []
+    ready = sum(1 for f in files if f.get("has_ocr") and not f.get("deleted"))
+    total = state.get("expected_pages") or len(files)
+    title = meta.get("title") or meta.get("slug", "")
+    return {
+        "id": state.get("id"),
+        "type": "upload",
+        "title": title,
+        "slug": meta.get("slug", ""),
+        "work_id": meta.get("work_id"),
+        "page_number": None,
+        "status_key": status_key,
+        "slow": False,
+        "started_at": _parse_ts(state.get("created_at")),
+        "progress": {"ready": ready, "total": total} if total else None,
+        "link": _upload_link(state, status_key),
+        "error": state.get("error_message"),
+    }
+
+
+def _reocr_status_key(status: str) -> str:
+    if status in ("uploading",):
+        return "uploading"
+    if status == "processing":
+        return "processing"
+    if status == "done":
+        return "ready"
+    return "error"
+
+
+def _work_link(work_id: Optional[str], page_number) -> str:
+    if not work_id:
+        return ""
+    return f"/work/{work_id}/{page_number}" if page_number else f"/work/{work_id}"
+
+
+def _normalize_single(job: dict, title_of) -> dict:
+    return {
+        "id": job.get("job_id"),
+        "type": "reocr",
+        "title": title_of(job.get("work_id")) or job.get("slug", ""),
+        "slug": job.get("slug", ""),
+        "work_id": job.get("work_id"),
+        "page_number": job.get("page_number"),
+        "status_key": _reocr_status_key(job.get("status")),
+        "slow": bool(job.get("slow", False)),
+        "started_at": _parse_ts(job.get("started_at")),
+        "progress": None,
+        "link": _work_link(job.get("work_id"), job.get("page_number")),
+        "error": job.get("error"),
+    }
+
+
+def _normalize_batch(job: dict, title_of) -> dict:
+    total = job.get("total", 0)
+    return {
+        "id": job.get("job_id"),
+        "type": "batch",
+        "title": title_of(job.get("work_id")) or job.get("slug", ""),
+        "slug": job.get("slug", ""),
+        "work_id": job.get("work_id"),
+        "page_number": None,
+        "status_key": _reocr_status_key(job.get("status")),
+        "slow": bool(job.get("slow", False)),
+        "started_at": _parse_ts(job.get("started_at")),
+        "progress": {"ready": job.get("ready", 0), "total": total} if total else None,
+        "link": _work_link(job.get("work_id"), None),
+        "error": job.get("error"),
+    }
+
+
+def normalize_ocr_jobs(uploads: List[dict], singles: List[dict], batches: List[dict],
+                       title_of: Callable[[Optional[str]], str]) -> List[dict]:
+    """Ühtne, ajajärjestatud (started_at DESC, None→0.0) OCR-tööde loend."""
+    out: List[dict] = []
+    out += [_normalize_upload(u, title_of) for u in uploads]
+    out += [_normalize_single(s, title_of) for s in singles]
+    out += [_normalize_batch(b, title_of) for b in batches]
+    out.sort(key=lambda e: e.get("started_at") or 0.0, reverse=True)
+    return out

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -506,6 +506,27 @@ def list_reocr_jobs() -> list:
     ]
 
 
+def list_reocr_batch_jobs() -> list:
+    """Batch re-OCR tööde summaarid (ühtse OCR-vaate jaoks)."""
+    with _reocr_batch_jobs_lock:
+        items = list(_reocr_batch_jobs.items())
+    out = []
+    for jid, j in items:
+        pages = j.get("pages", [])
+        out.append({
+            "job_id": jid,
+            "work_id": j.get("work_id"),
+            "slug": j.get("slug", ""),
+            "username": j.get("username", ""),
+            "status": j.get("status"),
+            "slow": bool(j.get("slow", False)),
+            "started_at": j.get("started_at"),
+            "ready": sum(1 for e in pages if e.get("status") == "ready"),
+            "total": len(pages),
+        })
+    return out
+
+
 def start_reocr_job(work_id: str, slug: str, img_path: str, page_filename: str = "", page_number: int = None, username: str = "", material_type: str = "print") -> str:
     """
     Alustab lehekülje re-OCR tööd: laadib pildi OCR serverisse SFTP kaudu.

--- a/server/routers/ocr_jobs.py
+++ b/server/routers/ocr_jobs.py
@@ -1,0 +1,45 @@
+"""Ühtne OCR-tööde vaade: upload + üksik/batch re-OCR ühes normaliseeritud loendis."""
+import json
+import os
+
+from fastapi import APIRouter, Depends
+
+from ..deps import require_role
+from ..ocr_jobs_normalize import normalize_ocr_jobs
+from ..reocr_ops import list_reocr_batch_jobs, list_reocr_jobs
+from ..upload_ops import list_uploads
+from ..utils import find_directory_by_id
+
+router = APIRouter()
+
+
+def _make_title_reader():
+    """Tagastab title_of(work_id) -> str, mis loeb _metadata.json ja cache'ib per-päring."""
+    cache = {}
+
+    def title_of(work_id):
+        if not work_id:
+            return ""
+        if work_id in cache:
+            return cache[work_id]
+        title = ""
+        path = find_directory_by_id(work_id)
+        if path:
+            try:
+                with open(os.path.join(path, "_metadata.json"), "r", encoding="utf-8") as f:
+                    title = json.load(f).get("title") or ""
+            except Exception:
+                title = ""
+        cache[work_id] = title
+        return title
+
+    return title_of
+
+
+@router.get("/admin/ocr/jobs")
+async def admin_ocr_jobs(user=Depends(require_role("admin"))):
+    """Kõik OCR-serveri tööd (upload + üksik + batch) ühes normaliseeritud loendis."""
+    jobs = normalize_ocr_jobs(
+        list_uploads(), list_reocr_jobs(), list_reocr_batch_jobs(), _make_title_reader()
+    )
+    return {"status": "success", "jobs": jobs}

--- a/src/locales/en/review.json
+++ b/src/locales/en/review.json
@@ -21,6 +21,17 @@
     "elapsedLtMin": "running <1 min",
     "queueAhead": "~{{count}} earlier jobs"
   },
+  "ocr": {
+    "type": { "upload": "Upload", "reocr": "Re-OCR", "batch": "Batch" },
+    "statusKey": {
+      "uploading": "uploading",
+      "processing": "OCR running",
+      "review": "in review",
+      "ready": "ready",
+      "imported": "imported",
+      "error": "error"
+    }
+  },
   "subtitle": "Your recent work",
   "subtitleAdmin": "All users' changes",
   "empty": "No changes made yet",

--- a/src/locales/et/review.json
+++ b/src/locales/et/review.json
@@ -21,6 +21,17 @@
     "elapsedLtMin": "töötab <1 min",
     "queueAhead": "~{{count}} varasemat tööd"
   },
+  "ocr": {
+    "type": { "upload": "Üleslaadimine", "reocr": "Re-OCR", "batch": "Batch" },
+    "statusKey": {
+      "uploading": "üleslaadimine",
+      "processing": "OCR töötleb",
+      "review": "ülevaatusel",
+      "ready": "valmis",
+      "imported": "imporditud",
+      "error": "viga"
+    }
+  },
   "subtitle": "Sinu viimased töökohad",
   "subtitleAdmin": "Kõigi kasutajate muudatused",
   "empty": "Muudatusi pole veel tehtud",

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -72,6 +72,21 @@ interface ReocrJob {
   title?: string;
 }
 
+interface OcrJob {
+  id: string;
+  type: 'upload' | 'reocr' | 'batch';
+  title: string;
+  slug: string;
+  work_id: string | null;
+  page_number: number | null;
+  status_key: 'uploading' | 'processing' | 'review' | 'ready' | 'imported' | 'error';
+  slow: boolean;
+  started_at: number | null;
+  progress: { ready: number; total: number } | null;
+  link: string;
+  error: string | null;
+}
+
 interface DiffData {
   diff: string;
   additions: number;
@@ -98,7 +113,7 @@ const Review: React.FC = () => {
   const [offset, setOffset] = useState(0);
   const [allUsers, setAllUsers] = useState<string[]>([]);
   const [activeTab, setActiveTab] = useState<'history' | 'reocr'>('history');
-  const [reocrJobs, setReocrJobs] = useState<ReocrJob[]>([]);
+  const [reocrJobs, setReocrJobs] = useState<OcrJob[]>([]);
   const [reocrLoading, setReocrLoading] = useState(false);
   const reocrPollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [reocrLog, setReocrLog] = useState<ReocrJob[]>([]);
@@ -148,7 +163,7 @@ const Review: React.FC = () => {
     if (!token || !isAdmin) return;
     if (showLoader) setReocrLoading(true);
     try {
-      const res = await fetchWithTimeout(`${FILE_API_URL}/admin/reocr/jobs`, { headers: getAuthHeaders(token), timeout: 10000 });
+      const res = await fetchWithTimeout(`${FILE_API_URL}/admin/ocr/jobs`, { headers: getAuthHeaders(token), timeout: 10000 });
       const data = await res.json();
       if (data.status === 'success') setReocrJobs(data.jobs);
     } catch {
@@ -162,7 +177,7 @@ const Review: React.FC = () => {
   useEffect(() => {
     if (!isAdmin) return;
 
-    const hasActive = reocrJobs.some(j => j.status === 'uploading' || j.status === 'processing');
+    const hasActive = reocrJobs.some(j => j.status_key === 'uploading' || j.status_key === 'processing');
     if (activeTab !== 'reocr' && !hasActive) return;
 
     reocrPollRef.current = setTimeout(() => loadReocrJobs(), 4000);
@@ -518,9 +533,9 @@ const Review: React.FC = () => {
               >
                 <Wand2 size={15} />
                 {t('tabs.reocr')}
-                {reocrJobs.filter(j => j.status === 'uploading' || j.status === 'processing').length > 0 && (
+                {reocrJobs.filter(j => j.status_key === 'uploading' || j.status_key === 'processing').length > 0 && (
                   <span className="ml-1 bg-amber-100 text-amber-700 text-xs font-bold px-1.5 py-0.5 rounded-full">
-                    {reocrJobs.filter(j => j.status === 'uploading' || j.status === 'processing').length}
+                    {reocrJobs.filter(j => j.status_key === 'uploading' || j.status_key === 'processing').length}
                   </span>
                 )}
               </button>
@@ -545,84 +560,62 @@ const Review: React.FC = () => {
               ) : (
                 <div className="space-y-2">
                   {[...reocrJobs].sort((a, b) => (b.started_at ?? 0) - (a.started_at ?? 0)).map(job => {
-                    const isActive = job.status === 'uploading' || job.status === 'processing';
-                    const isSlow = isActive && !!job.slow;
+                    const isActive = job.status_key === 'uploading' || job.status_key === 'processing';
+                    const isSlow = isActive && job.slow;
+                    const isError = job.status_key === 'error';
                     return (
-                      <div
-                        key={job.job_id}
+                      <div key={job.id}
                         className={`flex items-center gap-4 px-4 py-3 rounded-lg border ${
                           isActive ? 'border-amber-200 bg-amber-50' :
-                          job.status === 'done' ? 'border-green-200 bg-green-50' :
-                          job.status === 'error' ? 'border-red-200 bg-red-50' :
-                          'border-gray-200'
-                        }`}
-                      >
+                          isError ? 'border-red-200 bg-red-50' : 'border-green-200 bg-green-50'
+                        }`}>
                         {/* Staatus ikoon */}
                         <div className="shrink-0">
-                          {isActive
-                            ? <Loader2 size={18} className="animate-spin text-amber-600" />
-                            : job.status === 'done'
-                              ? <CheckCircle size={18} className="text-green-600" />
-                              : <XCircle size={18} className="text-red-500" />
-                          }
+                          {isActive ? <Loader2 size={18} className="animate-spin text-amber-600" />
+                            : isError ? <XCircle size={18} className="text-red-500" />
+                            : <CheckCircle size={18} className="text-green-600" />}
                         </div>
 
                         {/* Info */}
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2 flex-wrap">
+                            <span className="text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded bg-gray-100 text-gray-500">
+                              {t(`ocr.type.${job.type}`)}
+                            </span>
                             <span className="font-medium text-gray-800 text-sm">{job.title || job.slug}</span>
-                            {job.title && (
-                              <span className="text-xs text-gray-400 font-mono" title={job.slug}>{job.slug}</span>
-                            )}
-                            {job.page_number && (
-                              <span className="text-xs text-gray-500">lk {job.page_number}</span>
-                            )}
+                            {job.title && <span className="text-xs text-gray-400 font-mono" title={job.slug}>{job.slug}</span>}
+                            {job.page_number && <span className="text-xs text-gray-500">lk {job.page_number}</span>}
+                            {job.progress && <span className="text-xs text-gray-500">{job.progress.ready}/{job.progress.total} lk</span>}
                             {job.work_id && (
-                              <a
-                                href={job.page_number ? `/work/${job.work_id}/${job.page_number}` : `/work/${job.work_id}`}
-                                className="text-xs text-primary-600 hover:underline flex items-center gap-0.5"
-                                target="_blank"
-                                rel="noreferrer"
-                              >
+                              <a href={job.link} target="_blank" rel="noreferrer"
+                                className="text-xs text-primary-600 hover:underline flex items-center gap-0.5">
                                 <ExternalLink size={11} />
                               </a>
                             )}
-                            {isActive && !!job.queue_ahead && job.queue_ahead > 0 && (
-                              <span className="text-xs text-gray-400">
-                                {t('reocr.queueAhead', { count: job.queue_ahead })}
-                              </span>
-                            )}
                           </div>
-                          {job.error && (
-                            <p className="text-xs text-red-600 mt-0.5">{job.error}</p>
-                          )}
+                          {job.error && <p className="text-xs text-red-600 mt-0.5">{job.error}</p>}
                         </div>
 
-                        {/* Kasutaja + aeg */}
+                        {/* Aeg */}
                         <div className="text-xs text-gray-500 text-right shrink-0">
-                          <div className="flex items-center gap-1 justify-end">
-                            <User size={11} />
-                            {job.username}
-                          </div>
                           {job.started_at && (
-                            <div className="flex items-center gap-1 mt-0.5 justify-end">
+                            <div className="flex items-center gap-1 justify-end">
                               <Clock size={11} />
-                              {isActive
-                                ? formatElapsed(job.started_at)
-                                : new Date(job.started_at * 1000).toLocaleTimeString('et-EE', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+                              {isActive ? formatElapsed(job.started_at)
+                                : new Date(job.started_at * 1000).toLocaleTimeString('et-EE', { hour: '2-digit', minute: '2-digit' })}
                             </div>
                           )}
                         </div>
 
                         {/* Staatus badge */}
-                        <div className={`shrink-0 text-xs font-medium px-2 py-1 rounded ${
-                          isSlow ? 'bg-amber-100 text-amber-800' :
-                          isActive ? 'bg-amber-100 text-amber-700' :
-                          job.status === 'done' ? 'bg-green-100 text-green-700' :
-                          'bg-red-100 text-red-700'
-                        }`}>
-                          {isSlow ? t('reocr.slow') : t(`reocr.status.${job.status}`)}
-                        </div>
+                        <a href={job.link} target={job.link.startsWith('/work') ? '_blank' : undefined} rel="noreferrer"
+                          className={`shrink-0 text-xs font-medium px-2 py-1 rounded ${
+                            isSlow ? 'bg-amber-100 text-amber-800' :
+                            isActive ? 'bg-amber-100 text-amber-700' :
+                            isError ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+                          }`}>
+                          {isSlow ? t('reocr.slow') : t(`ocr.statusKey.${job.status_key}`)}
+                        </a>
                       </div>
                     );
                   })}

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -85,6 +85,8 @@ interface OcrJob {
   progress: { ready: number; total: number } | null;
   link: string;
   error: string | null;
+  username?: string;
+  queue_ahead?: number;
 }
 
 interface DiffData {
@@ -592,14 +594,25 @@ const Review: React.FC = () => {
                                 <ExternalLink size={11} />
                               </a>
                             )}
+                            {isActive && !!job.queue_ahead && job.queue_ahead > 0 && (
+                              <span className="text-xs text-gray-400">
+                                {t('reocr.queueAhead', { count: job.queue_ahead })}
+                              </span>
+                            )}
                           </div>
                           {job.error && <p className="text-xs text-red-600 mt-0.5">{job.error}</p>}
                         </div>
 
-                        {/* Aeg */}
+                        {/* Kasutaja + aeg */}
                         <div className="text-xs text-gray-500 text-right shrink-0">
-                          {job.started_at && (
+                          {job.username && (
                             <div className="flex items-center gap-1 justify-end">
+                              <User size={11} />
+                              {job.username}
+                            </div>
+                          )}
+                          {job.started_at && (
+                            <div className="flex items-center gap-1 justify-end mt-0.5">
                               <Clock size={11} />
                               {isActive ? formatElapsed(job.started_at)
                                 : new Date(job.started_at * 1000).toLocaleTimeString('et-EE', { hour: '2-digit', minute: '2-digit' })}

--- a/src/pages/upload/useUploadWizard.ts
+++ b/src/pages/upload/useUploadWizard.ts
@@ -470,6 +470,22 @@ export function useUploadWizard() {
     }
   }
 
+  // Deep-link: /upload?resumeUpload={id} avab otse selle uploadi ülevaatusele,
+  // kui pendingUploads on laaditud. Param eemaldatakse pärast, et back/forward
+  // remount ei käivitaks resume't uuesti.
+  const resumeHandledRef = useRef(false);
+  useEffect(() => {
+    if (resumeHandledRef.current) return;
+    const targetId = searchParams.get('resumeUpload');
+    if (!targetId || pendingUploads.length === 0) return;
+    const match = pendingUploads.find((u) => u.id === targetId);
+    if (!match) return;
+    resumeHandledRef.current = true;
+    handleResume(match);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    navigate(window.location.pathname, { replace: true });
+  }, [pendingUploads, searchParams, navigate]);
+
   // ---------------------------------------------------------------------------
   // Arvutused (puhas tuletus utils-ist)
   // ---------------------------------------------------------------------------

--- a/tests/test_ocr_jobs_normalize.py
+++ b/tests/test_ocr_jobs_normalize.py
@@ -103,3 +103,34 @@ def test_title_reader_reads_metadata(tmp_path, monkeypatch):
     assert reader("puudub") == ""     # ei leidu → tühi (normaliseerija fallback slug'ile)
     # cache: teine kutse ei ava faili uuesti (sama tulemus)
     assert reader("wid") == "Loetud Pealkiri"
+
+
+def test_normalize_includes_username():
+    singles = [{"job_id": "s1", "work_id": "wid", "slug": "w1", "page_number": 1,
+                "status": "processing", "slow": False, "started_at": 100.0,
+                "error": None, "username": "mari"}]
+    batches = [{"job_id": "b1", "work_id": "wid", "slug": "w1", "status": "processing",
+                "slow": False, "started_at": 90.0, "ready": 0, "total": 2, "username": "jaan"}]
+    uploads = [{"id": "u1", "status": "processing",
+                "meta": {"title": "T", "slug": "t", "work_id": "wx"},
+                "expected_pages": 3, "created_at": "2026-07-01T10:00:00", "files": []}]
+    by_id = {e["id"]: e for e in normalize_ocr_jobs(uploads, singles, batches, _title_of)}
+    assert by_id["s1"]["username"] == "mari"
+    assert by_id["b1"]["username"] == "jaan"
+    assert by_id["u1"]["username"] == ""   # upload ei salvesta kasutajanime
+
+
+def test_normalize_queue_ahead_across_all_active():
+    # Aktiivsed single+batch erineva started_at-iga → ühtne järjekord üle tüüpide.
+    # (float started_at, et vältida ISO/TZ-sõltuvust; done pole aktiivne → 0)
+    singles = [{"job_id": "s1", "work_id": "wid", "slug": "w", "page_number": 1,
+                "status": "processing", "slow": False, "started_at": 30.0, "error": None},
+               {"job_id": "s2", "work_id": "wid", "slug": "w", "page_number": 2,
+                "status": "done", "slow": False, "started_at": 10.0, "error": None}]  # done → mitte-aktiivne
+    batches = [{"job_id": "b1", "work_id": "wid", "slug": "w", "status": "processing",
+                "slow": False, "started_at": 25.0, "ready": 0, "total": 1}]
+    by_id = {e["id"]: e for e in normalize_ocr_jobs([], singles, batches, _title_of)}
+    # Aktiivsed started_at järgi: b1(25) < s1(30); done s2 pole aktiivne
+    assert by_id["b1"]["queue_ahead"] == 0
+    assert by_id["s1"]["queue_ahead"] == 1
+    assert by_id["s2"]["queue_ahead"] == 0   # mitte-aktiivne → 0

--- a/tests/test_ocr_jobs_normalize.py
+++ b/tests/test_ocr_jobs_normalize.py
@@ -1,0 +1,91 @@
+"""normalize_ocr_jobs — puhas OCR-tööde normaliseerija."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from server.ocr_jobs_normalize import normalize_ocr_jobs
+
+
+def _title_of(work_id):
+    return {"wid": "Teose Pealkiri"}.get(work_id, work_id or "")
+
+
+def test_normalize_upload_reviewing():
+    uploads = [{
+        "id": "u1", "status": "reviewing",
+        "meta": {"title": "Uus teos", "slug": "uus-teos-x", "work_id": "wx"},
+        "expected_pages": 12, "created_at": "2026-07-01T10:00:00",
+        "files": [{"has_ocr": True, "deleted": False}, {"has_ocr": False, "deleted": False}],
+    }]
+    out = normalize_ocr_jobs(uploads, [], [], _title_of)
+    e = out[0]
+    assert e["type"] == "upload"
+    assert e["title"] == "Uus teos"
+    assert e["status_key"] == "review"
+    assert e["progress"] == {"ready": 1, "total": 12}
+    assert e["link"] == "/upload?resumeUpload=u1"
+    assert e["started_at"] > 0
+
+
+def test_normalize_upload_import_error():
+    uploads = [{"id": "u2", "status": "error", "error_message": "import ebaõnnestus",
+                "meta": {"title": "X", "slug": "x", "work_id": "wx"},
+                "expected_pages": None, "created_at": "2026-07-01T10:00:00", "files": []}]
+    e = normalize_ocr_jobs(uploads, [], [], _title_of)[0]
+    assert e["status_key"] == "error"
+    assert e["error"] == "import ebaõnnestus"
+    assert e["link"] == "/upload?resumeUpload=u2"
+
+
+def test_normalize_reocr_single_done_links_page():
+    singles = [{"job_id": "s1", "work_id": "wid", "slug": "w1", "page_number": 42,
+                "status": "done", "slow": False, "started_at": 100.0, "error": None}]
+    e = normalize_ocr_jobs([], singles, [], _title_of)[0]
+    assert e["type"] == "reocr"
+    assert e["title"] == "Teose Pealkiri"
+    assert e["status_key"] == "ready"
+    assert e["link"] == "/work/wid/42"
+    assert e["page_number"] == 42
+
+
+def test_normalize_reocr_single_no_page_links_work():
+    singles = [{"job_id": "s2", "work_id": "wid", "slug": "w1", "page_number": None,
+                "status": "done", "slow": False, "started_at": 100.0, "error": None}]
+    e = normalize_ocr_jobs([], singles, [], _title_of)[0]
+    assert e["link"] == "/work/wid"
+
+
+def test_normalize_reocr_batch():
+    batches = [{"job_id": "b1", "work_id": "wid", "slug": "w1", "status": "processing",
+                "slow": True, "started_at": 50.0, "ready": 3, "total": 8}]
+    e = normalize_ocr_jobs([], [], batches, _title_of)[0]
+    assert e["type"] == "batch"
+    assert e["status_key"] == "processing"
+    assert e["slow"] is True
+    assert e["progress"] == {"ready": 3, "total": 8}
+    assert e["link"] == "/work/wid"
+
+
+def test_normalize_missing_fields_and_sort():
+    # started_at=None ei tohi sort'i crash'ida; title puudub → slug
+    uploads = [{"id": "u3", "status": "processing",
+                "meta": {"title": "", "slug": "slug-only", "work_id": None},
+                "expected_pages": None, "created_at": "vigane-kuupäev", "files": []}]
+    singles = [{"job_id": "s3", "work_id": "wid", "slug": "w1", "page_number": 1,
+                "status": "processing", "slow": False, "started_at": None, "error": None}]
+    out = normalize_ocr_jobs(uploads, singles, [], _title_of)
+    assert len(out) == 2
+    u = next(x for x in out if x["id"] == "u3")
+    assert u["title"] == "slug-only"          # tühi title → slug
+    assert u["started_at"] == 0.0             # vigane created_at → 0.0
+    assert u["link"] == "/upload?resumeUpload=u3"
+
+
+def test_normalize_sorted_desc():
+    singles = [
+        {"job_id": "a", "work_id": "wid", "slug": "w", "page_number": 1, "status": "done", "slow": False, "started_at": 10.0, "error": None},
+        {"job_id": "b", "work_id": "wid", "slug": "w", "page_number": 2, "status": "done", "slow": False, "started_at": 30.0, "error": None},
+        {"job_id": "c", "work_id": "wid", "slug": "w", "page_number": 3, "status": "done", "slow": False, "started_at": 20.0, "error": None},
+    ]
+    ids = [e["id"] for e in normalize_ocr_jobs([], singles, [], _title_of)]
+    assert ids == ["b", "c", "a"]  # started_at DESC

--- a/tests/test_ocr_jobs_normalize.py
+++ b/tests/test_ocr_jobs_normalize.py
@@ -89,3 +89,17 @@ def test_normalize_sorted_desc():
     ]
     ids = [e["id"] for e in normalize_ocr_jobs([], singles, [], _title_of)]
     assert ids == ["b", "c", "a"]  # started_at DESC
+
+
+def test_title_reader_reads_metadata(tmp_path, monkeypatch):
+    import json
+    import server.routers.ocr_jobs as oj
+    work = tmp_path / "w1"
+    work.mkdir()
+    (work / "_metadata.json").write_text(json.dumps({"title": "Loetud Pealkiri"}), encoding="utf-8")
+    monkeypatch.setattr(oj, "find_directory_by_id", lambda wid: str(work) if wid == "wid" else None)
+    reader = oj._make_title_reader()
+    assert reader("wid") == "Loetud Pealkiri"
+    assert reader("puudub") == ""     # ei leidu → tühi (normaliseerija fallback slug'ile)
+    # cache: teine kutse ei ava faili uuesti (sama tulemus)
+    assert reader("wid") == "Loetud Pealkiri"

--- a/tests/test_reocr_batch.py
+++ b/tests/test_reocr_batch.py
@@ -320,3 +320,22 @@ def test_poll_batch_write_vea_korral_remote_txt_ei_kustutata(tmp_path, monkeypat
         f"remote .txt kustutati write-vea korral — andmekadu! removed={fake_sftp.removed}")
 
     del reocr_ops._reocr_batch_jobs[job_id]
+
+
+def test_list_reocr_batch_jobs_summary():
+    import server.reocr_ops as r
+    with r._reocr_batch_jobs_lock:
+        r._reocr_batch_jobs.clear()
+        r._reocr_batch_jobs["b1"] = {
+            "kind": "batch", "work_id": "wid", "slug": "w1", "username": "u",
+            "status": "processing", "slow": True, "started_at": 123.0,
+            "pages": [{"status": "ready"}, {"status": "processing"}, {"status": "error"}],
+        }
+    out = {j["job_id"]: j for j in r.list_reocr_batch_jobs()}
+    assert out["b1"]["work_id"] == "wid"
+    assert out["b1"]["ready"] == 1        # ainult "ready"
+    assert out["b1"]["total"] == 3
+    assert out["b1"]["slow"] is True
+    assert out["b1"]["started_at"] == 123.0
+    with r._reocr_batch_jobs_lock:
+        r._reocr_batch_jobs.clear()


### PR DESCRIPTION
Faas 2 kahefaasilisest tööst (Faas 1 = recovery hardening, juba merged #108).

## Mida teeb
Review-lehe OCR-nimekiri näitab nüüd KÕIKI OCR-serveri töid ühes ajajärjestatud nimekirjas — upload, üksik re-OCR ja batch — tüübi-badge'i, ühtse staatuse ja järjekindla lingiga. Varem nägi ainult üksik-lehe re-OCR töid; uploade pidi vaatama eraldi lehel.

## Komponendid
- `list_reocr_batch_jobs()` — batch-summaarid globaalselt (polnud `list_reocr_jobs`-is).
- `server/ocr_jobs_normalize.py` — **puhas** `normalize_ocr_jobs(uploads, singles, batches, title_of)`; backend arvutab `status_key`, `link`, `queue_ahead` (üks tõeallikas). Sort `started_at` DESC (None→0.0).
- `GET /admin/ocr/jobs` (`routers/ocr_jobs.py`) + per-päring title-cache.
- Upload deep-link `/upload?resumeUpload={id}` → progress kohe näha (param strippitakse pärast).
- `Review.tsx` — ühtne nimekiri, tüübi-badge, kulunud aeg, slow-märk, **username + '~N ees'**, järjekindel link (leht/teos/upload-viisard).

## Staatus-sõnavara
uploading / OCR töötleb (+aeglane) / ülevaatusel / valmis / imporditud / viga.

## Testid
Backend **810 läbivad** (11 uut: normaliseerija, batch-summaarid, title-cache, username, queue_ahead). `npm run typecheck` + `npm run build` 0 viga.

## Märkus
Uploadid ei salvesta praegu kasutajanime → username tühi upload-ridadel (re-OCR/batch näitavad). Upload-creatori jälgimine = eraldi väike TODO kui vaja.

Plaan: `docs/superpowers/plans/2026-07-01-ocr-jobs-unified-view-phase2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)