### PR TITLE
feat: upload creatori username ühtses OCR-vaates

### DIFF
--- a/server/ocr_jobs_normalize.py
+++ b/server/ocr_jobs_normalize.py
@@ -58,7 +58,7 @@ def _normalize_upload(state: dict, title_of) -> dict:
         "progress": {"ready": ready, "total": total} if total else None,
         "link": _upload_link(state, status_key),
         "error": state.get("error_message"),
-        "username": state.get("username", ""),  # uploadid ei salvesta praegu → ""
+        "username": state.get("username") or "",  # None (vanad uploadid) → ""
     }
 
 

--- a/server/routers/upload.py
+++ b/server/routers/upload.py
@@ -40,7 +40,7 @@ async def admin_upload_create(request: Request, user=Depends(require_role("admin
     # sanitize_slug on idempotentne, seega juba korrektne slug ei muutu.
     slug = sanitize_slug(data.get("slug") or data.get("title", ""))
     data["slug"] = slug
-    return {"status": "success", "upload": create_upload(data)}
+    return {"status": "success", "upload": create_upload(data, username=user["username"])}
 
 
 @router.get("/admin/upload/{upload_id}/status")

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -280,13 +280,14 @@ def check_slug_conflict(year, slug: str) -> bool:
 # PÕHIFUNKTSIOONID
 # =========================================================
 
-def create_upload(meta: dict) -> dict:
+def create_upload(meta: dict, username: Optional[str] = None) -> dict:
     """
     Loob uue upload staging'u ja tagastab state.json sisu.
 
     meta peab sisaldama: title, year, slug
     Valikulised: type, genre, creators, location, publisher,
                  collections, languages, tags
+    username: kes uploadi lõi (ühtses OCR-vaates kuvamiseks)
     """
     upload_id = generate_nanoid()
     while os.path.isdir(_upload_dir(upload_id)):
@@ -309,6 +310,7 @@ def create_upload(meta: dict) -> dict:
     state = {
         "id": upload_id,
         "status": "pending",
+        "username": username,
         "meta": {
             "title": meta.get('title', ''),
             "year": year,

--- a/tests/test_backend_smoke.py
+++ b/tests/test_backend_smoke.py
@@ -667,3 +667,13 @@ def test_create_upload_appends_work_id(backend_env):
     assert len(work_id) == 6
     assert meta["slug"] == f"adam-koljo-kiri-{work_id}"
     assert meta["slug"].endswith(f"-{work_id}")
+
+
+def test_create_upload_stores_username(backend_env):
+    """create_upload salvestab creatori username'i (ühtses OCR-vaates kuvamiseks)."""
+    upload_ops = backend_env["upload_ops"]
+    state = upload_ops.create_upload({"title": "T", "year": "", "slug": "t"}, username="mari")
+    assert state["username"] == "mari"
+    # ilma username'ita → None (tagurpidiühilduv)
+    state2 = upload_ops.create_upload({"title": "T2", "year": "", "slug": "t2"})
+    assert state2["username"] is None


### PR DESCRIPTION
Väike järeltäiendus Faas 2-le: uploadid salvestavad nüüd creatori kasutajanime, nii et ühtses OCR-vaates (Review-leht) on ka upload-ridadel näha kes töö käivitas (varem ainult re-OCR/batch).

- `create_upload(meta, username=None)` salvestab `state["username"]`; endpoint annab `user["username"]`.
- `normalize_ocr_jobs` upload-username `None → ""` (vanad uploadid tagurpidiühilduvad).
- Frontend renderdab juba `job.username` (Faas 2) → **ainult backend-muudatus**, frontend rebuild pole vaja.

811 testi läbivad (1 uus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)