### PR TITLE
fix: offload blokeeriv OCR/upload I/O async endpointides threadpooli

### DIFF
--- a/server/routers/ocr_jobs.py
+++ b/server/routers/ocr_jobs.py
@@ -3,6 +3,7 @@ import json
 import os
 
 from fastapi import APIRouter, Depends
+from starlette.concurrency import run_in_threadpool
 
 from ..deps import require_role
 from ..ocr_jobs_normalize import normalize_ocr_jobs
@@ -36,10 +37,15 @@ def _make_title_reader():
     return title_of
 
 
+def _build_admin_ocr_jobs() -> list:
+    """Blokeeriv failisüsteemi skänn + pealkirjade lugemine; jooksutatakse threadpoolis."""
+    return normalize_ocr_jobs(
+        list_uploads(), list_reocr_jobs(), list_reocr_batch_jobs(), _make_title_reader()
+    )
+
+
 @router.get("/admin/ocr/jobs")
 async def admin_ocr_jobs(user=Depends(require_role("admin"))):
     """Kõik OCR-serveri tööd (upload + üksik + batch) ühes normaliseeritud loendis."""
-    jobs = normalize_ocr_jobs(
-        list_uploads(), list_reocr_jobs(), list_reocr_batch_jobs(), _make_title_reader()
-    )
+    jobs = await run_in_threadpool(_build_admin_ocr_jobs)
     return {"status": "success", "jobs": jobs}

--- a/server/routers/reocr.py
+++ b/server/routers/reocr.py
@@ -3,6 +3,7 @@ import os
 import shutil
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from starlette.concurrency import run_in_threadpool
 
 from ..deps import get_json_data, require_role
 from ..reocr_ops import (
@@ -54,7 +55,9 @@ async def admin_reocr_page(work_id: str, request: Request, user=Depends(require_
 @router.get("/admin/reocr/{job_id}/status")
 async def admin_reocr_status(job_id: str, user=Depends(require_role("admin"))):
     """Küsib re-OCR töö staatust. Küsida korduvalt kuni done/error."""
-    return {"status": "success", **poll_reocr_job(job_id)}
+    # poll_reocr_job teeb SFTP stat/getfo päringuid; ära blokeeri uvicorni event-loopi.
+    result = await run_in_threadpool(poll_reocr_job, job_id)
+    return {"status": "success", **result}
 
 
 def _enrich_titles(items: list) -> list:

--- a/server/routers/upload.py
+++ b/server/routers/upload.py
@@ -3,6 +3,7 @@ import os
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import FileResponse
+from starlette.concurrency import run_in_threadpool
 
 from ..config import UPLOAD_ENABLED, UPLOADS_DIR, get_logger
 from ..deps import get_json_data, require_role
@@ -30,7 +31,8 @@ router = APIRouter()
 async def admin_uploads(user=Depends(require_role("admin"))):
     if not UPLOAD_ENABLED:
         raise HTTPException(status_code=503)
-    return {"status": "success", "uploads": list_uploads()}
+    uploads = await run_in_threadpool(list_uploads)
+    return {"status": "success", "uploads": uploads}
 
 
 @router.post("/admin/upload/create")
@@ -91,11 +93,17 @@ async def admin_upload_files(upload_id: str, request: Request, user=Depends(requ
         raise HTTPException(status_code=500, detail="Serveri viga faili töötlemisel")
 
 
+def _import_upload_sync(upload_id: str, username: str) -> dict:
+    """Blokeeriv import + cache rebuild; jooksutatakse ainult threadpoolis."""
+    res = import_as_work(upload_id, username=username)
+    build_work_id_cache()
+    return res
+
+
 @router.post("/admin/upload/{upload_id}/import")
 async def admin_upload_import(upload_id: str, user=Depends(require_role("admin"))):
     try:
-        res = import_as_work(upload_id, username=user["username"])
-        build_work_id_cache()
+        res = await run_in_threadpool(_import_upload_sync, upload_id, user["username"])
         return {"status": "success", **res}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -114,7 +122,8 @@ async def admin_upload_replace_work(
     except Exception:
         data = {}
     metadata_updates = (data.get("metadata_updates") or {}) if isinstance(data, dict) else {}
-    res = await replace_work_content(
+    res = await run_in_threadpool(
+        replace_work_content,
         upload_id,
         work_id,
         metadata_updates,
@@ -142,6 +151,6 @@ async def admin_upload_update_meta(upload_id: str, request: Request, user=Depend
 
 @router.delete("/admin/upload/{upload_id}")
 async def admin_upload_cancel(upload_id: str, user=Depends(require_role("admin"))):
-    if cancel_upload(upload_id):
+    if await run_in_threadpool(cancel_upload, upload_id):
         return {"status": "success"}
     raise HTTPException(status_code=500)

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -1269,7 +1269,7 @@ def import_as_work(upload_id: str, username: str = None) -> dict:
     return {"work_id": work_id, "slug": slug}
 
 
-async def replace_work_content(upload_id: str, target_work_id: str, metadata_updates: dict, username: str, background_tasks) -> dict:
+def replace_work_content(upload_id: str, target_work_id: str, metadata_updates: dict, username: str, background_tasks) -> dict:
     """
     Asendab olemasoleva teose sisu uue OCR-itud materjaliga.
 

--- a/tests/test_async_endpoint_offload.py
+++ b/tests/test_async_endpoint_offload.py
@@ -1,0 +1,119 @@
+"""Regressioon: async endpointid ei tohi blokeerivat OCR/upload I/O-d event-loopis jooksutada."""
+import asyncio
+import threading
+
+from fastapi import BackgroundTasks
+from starlette.requests import Request
+
+from server.routers import ocr_jobs, reocr, upload
+
+
+MAIN_THREAD = threading.current_thread().name
+
+
+def _worker_thread_name():
+    return threading.current_thread().name
+
+
+def test_reocr_status_poll_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_poll(job_id):
+        seen["job_id"] = job_id
+        seen["thread"] = _worker_thread_name()
+        return {"job_status": "done"}
+
+    monkeypatch.setattr(reocr, "poll_reocr_job", fake_poll)
+
+    result = asyncio.run(reocr.admin_reocr_status("job-1", user={"username": "admin"}))
+
+    assert result["status"] == "success"
+    assert seen == {"job_id": "job-1", "thread": seen["thread"]}
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_upload_import_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_import(upload_id, username):
+        seen["args"] = (upload_id, username)
+        seen["thread"] = _worker_thread_name()
+        return {"work_id": "w1", "slug": "slug"}
+
+    monkeypatch.setattr(upload, "_import_upload_sync", fake_import)
+
+    result = asyncio.run(upload.admin_upload_import("up-1", user={"username": "admin"}))
+
+    assert result == {"status": "success", "work_id": "w1", "slug": "slug"}
+    assert seen["args"] == ("up-1", "admin")
+    assert seen["thread"] != MAIN_THREAD
+
+
+def _json_request(body: bytes = b"{}"):
+    sent = False
+
+    async def receive():
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request({"type": "http", "method": "POST", "headers": []}, receive)
+
+
+def test_upload_replace_work_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_replace(upload_id, work_id, metadata_updates, username, background_tasks):
+        seen["args"] = (upload_id, work_id, metadata_updates, username)
+        seen["bg_type"] = type(background_tasks).__name__
+        seen["thread"] = _worker_thread_name()
+        return {"work_id": work_id, "slug": "slug"}
+
+    monkeypatch.setattr(upload, "replace_work_content", fake_replace)
+
+    result = asyncio.run(upload.admin_upload_replace_work(
+        "up-1",
+        "w1",
+        _json_request(b'{"metadata_updates":{"title":"T"}}'),
+        BackgroundTasks(),
+        user={"username": "admin"},
+    ))
+
+    assert result == {"status": "success", "work_id": "w1", "slug": "slug"}
+    assert seen["args"] == ("up-1", "w1", {"title": "T"}, "admin")
+    assert seen["bg_type"] == "BackgroundTasks"
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_upload_cancel_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_cancel(upload_id):
+        seen["upload_id"] = upload_id
+        seen["thread"] = _worker_thread_name()
+        return True
+
+    monkeypatch.setattr(upload, "cancel_upload", fake_cancel)
+
+    result = asyncio.run(upload.admin_upload_cancel("up-1", user={"username": "admin"}))
+
+    assert result == {"status": "success"}
+    assert seen["upload_id"] == "up-1"
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_admin_ocr_jobs_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_build():
+        seen["thread"] = _worker_thread_name()
+        return [{"id": "j1"}]
+
+    monkeypatch.setattr(ocr_jobs, "_build_admin_ocr_jobs", fake_build)
+
+    result = asyncio.run(ocr_jobs.admin_ocr_jobs(user={"username": "admin"}))
+
+    assert result == {"status": "success", "jobs": [{"id": "j1"}]}
+    assert seen["thread"] != MAIN_THREAD


### PR DESCRIPTION
Refs #111 (EI sulge automaatselt — sulgeme käsitsi pärast serveri-deploy + testi).

## Probleem
Mitu `async def` endpointi tegi blokeerivat SFTP/git/Meili I/O-d otse event-loopis → single-worker uvicorn külmus (sama klass mis 2026-06-13 OCR-SSH outage).

## Muudatused
`run_in_threadpool` offload:
- `admin_reocr_status` → `poll_reocr_job` (SFTP stat/getfo)
- `admin_upload_import` → `import_as_work` + `build_work_id_cache`
- `admin_upload_replace_work` → `replace_work_content`
- `admin_upload_cancel` → `cancel_upload` (SSH rm)
- `admin_ocr_jobs` → `list_uploads` + `_metadata.json` pealkirjad
- `admin_uploads` → `list_uploads`

`replace_work_content` teisendatud `async`→`sync` (ei sisalda `await`-i), et korrektselt threadpoolis joosta. `BackgroundTasks` edastus säilib.

## Testid
`tests/test_async_endpoint_offload.py` — kontrollivad, et blokeeriv töö jookseb mitte-main threadis.

## Valideerimine
- `.venv/bin/python -m pytest tests/` → 816 passed
- Uus testfail: 5 passed (iseseisvalt kontrollitud)

## Deploy (backend-only, --no-cache kohustuslik)
`git pull && docker compose build --no-cache backend && docker compose up -d backend`

## Väljas skoobist (eraldi jälgitud)
`admin_reocr_page` `shutil.copy2` blokeerimine — vt #113 kommentaar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)