### PR TITLE
Fix re-OCR batch recovery mapping cleanup

### DIFF
--- a/server/reocr_recovery.py
+++ b/server/reocr_recovery.py
@@ -110,6 +110,15 @@ def _recover_one(sftp, base: str, job_id: str, recovered: List[str], skipped: Li
         _recover_single(sftp, base, job_id, recovered, skipped)
 
 
+def _remote_img_name(txt_name: str, info: Optional[dict]) -> str:
+    """Remote-pildi nimi .txt-nime järgi. Laiend tuletatakse mapping'u page_filename-st
+    (nagu _build_batch_pages selle algselt tegi: remote_img jagab txt-ga stem'i, ext on
+    originaalfaili oma), et .png/.jpeg lehed ei jääks lõpetamise-kontrollist vahele."""
+    stem = txt_name[:-4] if txt_name.endswith(".txt") else txt_name
+    ext = os.path.splitext((info or {}).get("page_filename", ""))[1] or ".jpg"
+    return stem + ext
+
+
 def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[str], skipped: List[str]) -> None:
     slug = mapping.get("slug")
     work_id = mapping.get("work_id")
@@ -147,12 +156,13 @@ def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[
                 sftp.remove(f"{work_dir}/{fname}")
             except Exception:
                 pass
-            # Sama lehe JPG ei ole pärast .txt taastamist enam vajalik. Selle eemaldamine
-            # laseb alloleval lõpetamise kontrollil eristada "veel töötleb" (JPG alles,
-            # .txt puudub) seisust "kõik mapping'u lehed on lahendatud".
-            jpg_name = fname[:-4] + ".jpg"
+            # Sama lehe pilt ei ole pärast .txt taastamist enam vajalik. Selle eemaldamine
+            # laseb alloleval lõpetamise kontrollil eristada "veel töötleb" (pilt alles,
+            # .txt puudub) seisust "kõik mapping'u lehed on lahendatud". Laiend page_filename-st
+            # (võib olla .png/.jpeg, mitte ainult .jpg).
+            img_name = _remote_img_name(fname, info)
             try:
-                sftp.remove(f"{work_dir}/{jpg_name}")
+                sftp.remove(f"{work_dir}/{img_name}")
             except Exception:
                 pass
             recovered.append(job_id)
@@ -161,7 +171,7 @@ def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[
             _release(key)
     # Mappingut tohib kustutada ainult siis, kui staging on kadunud või kõik mapping'u
     # lehed on lahendatud. "0 .txt" ei tähenda valmis: OCR-server võib alles töödelda
-    # allesolevaid .jpg faile ja kirjutada .txt-id hiljem.
+    # allesolevaid pildifaile ja kirjutada .txt-id hiljem.
     try:
         remaining_files = set(sftp.listdir(work_dir))
     except FileNotFoundError:
@@ -169,9 +179,9 @@ def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[
         return
 
     unresolved = []
-    for txt_name in pages.keys():
-        jpg_name = txt_name[:-4] + ".jpg" if txt_name.endswith(".txt") else txt_name + ".jpg"
-        if txt_name in remaining_files or jpg_name in remaining_files:
+    for txt_name, info in pages.items():
+        img_name = _remote_img_name(txt_name, info)
+        if txt_name in remaining_files or img_name in remaining_files:
             unresolved.append(txt_name)
 
     if not unresolved:

--- a/server/reocr_recovery.py
+++ b/server/reocr_recovery.py
@@ -147,16 +147,34 @@ def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[
                 sftp.remove(f"{work_dir}/{fname}")
             except Exception:
                 pass
+            # Sama lehe JPG ei ole pärast .txt taastamist enam vajalik. Selle eemaldamine
+            # laseb alloleval lõpetamise kontrollil eristada "veel töötleb" (JPG alles,
+            # .txt puudub) seisust "kõik mapping'u lehed on lahendatud".
+            jpg_name = fname[:-4] + ".jpg"
+            try:
+                sftp.remove(f"{work_dir}/{jpg_name}")
+            except Exception:
+                pass
             recovered.append(job_id)
             logger.info(f"Reaper taastas batch {job_id}/{fname} ({slug}/{info['page_filename']})")
         finally:
             _release(key)
-    # Kui rohkem .txt pole, koorista kaust + mapping
+    # Mappingut tohib kustutada ainult siis, kui staging on kadunud või kõik mapping'u
+    # lehed on lahendatud. "0 .txt" ei tähenda valmis: OCR-server võib alles töödelda
+    # allesolevaid .jpg faile ja kirjutada .txt-id hiljem.
     try:
-        remaining = [f for f in sftp.listdir(work_dir) if f.endswith(".txt")]
+        remaining_files = set(sftp.listdir(work_dir))
     except FileNotFoundError:
-        remaining = []
-    if not remaining:
+        reocr_state.remove_batch_mapping(job_id)  # staging kadunud → mapping aegunud
+        return
+
+    unresolved = []
+    for txt_name in pages.keys():
+        jpg_name = txt_name[:-4] + ".jpg" if txt_name.endswith(".txt") else txt_name + ".jpg"
+        if txt_name in remaining_files or jpg_name in remaining_files:
+            unresolved.append(txt_name)
+
+    if not unresolved:
         for d in (work_dir, job_dir):
             try:
                 sftp.rmdir(d)

--- a/tests/test_reocr_recovery.py
+++ b/tests/test_reocr_recovery.py
@@ -214,10 +214,13 @@ def test_batch_orphan_recovered_via_mapping(monkeypatch, tmp_path):
     })
     tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
             "/OCR/AUTO-OCR/print/borb": ["w1"],
-            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.txt", "w1_pg_002.txt"]}
+            "/OCR/AUTO-OCR/print/borb/w1": [
+                "w1_pg_001.jpg", "w1_pg_001.txt", "w1_pg_002.jpg", "w1_pg_002.txt"
+            ]}
     files = {"/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt": b"tekst1",
              "/OCR/AUTO-OCR/print/borb/w1/w1_pg_002.txt": b"tekst2"}
-    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: _FakeSftp(tree, files))
+    sftp = _FakeSftp(tree, files)
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: sftp)
     monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
     with reocr_ops._reocr_jobs_lock:
         reocr_ops._reocr_jobs.clear()
@@ -232,8 +235,60 @@ def test_batch_orphan_recovered_via_mapping(monkeypatch, tmp_path):
     entries = reocr_ops.get_reocr_log(0, 100)["entries"]
     recs = [e for e in entries if e.get("recovered")]
     assert {e["page_number"] for e in recs} == {1, 2}
-    # Mapping kustutatud pärast taastet
+    # Mapping kustutatud pärast taastet; taastatud lehtede JPG-d koristati ka ära.
     assert st.load_batch_mapping("borb") is None
+    assert "/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.jpg" in sftp.removed
+    assert "/OCR/AUTO-OCR/print/borb/w1/w1_pg_002.jpg" in sftp.removed
+
+
+def test_batch_mapping_sailib_kui_ainult_jpgd_ootavad_txti(monkeypatch, tmp_path):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    st.persist_batch_mapping("borb", "wid", "w1", {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-1.jpg", "page_number": 1},
+        "w1_pg_002.txt": {"page_filename": "w1-lk-2.jpg", "page_number": 2},
+    })
+    tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
+            "/OCR/AUTO-OCR/print/borb": ["w1"],
+            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.jpg", "w1_pg_002.jpg"]}
+    sftp = _FakeSftp(tree, {})
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: sftp)
+    monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
+    rec._recovering.clear()
+
+    result = rec.scan_and_recover()
+
+    assert result == {"recovered": [], "skipped": []}
+    assert st.load_batch_mapping("borb") is not None
+    assert sftp.removed == []
+    assert sftp.rmdired == []
+
+
+def test_batch_mapping_sailib_kui_osa_lehti_veel_jpgna_ootab(monkeypatch, tmp_path):
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    st.persist_batch_mapping("borb", "wid", "w1", {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-1.jpg", "page_number": 1},
+        "w1_pg_002.txt": {"page_filename": "w1-lk-2.jpg", "page_number": 2},
+    })
+    tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
+            "/OCR/AUTO-OCR/print/borb": ["w1"],
+            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.jpg", "w1_pg_001.txt", "w1_pg_002.jpg"]}
+    files = {"/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt": b"tekst1"}
+    sftp = _FakeSftp(tree, files)
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: sftp)
+    monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
+    rec._recovering.clear()
+
+    result = rec.scan_and_recover()
+
+    assert result["recovered"] == ["borb"]
+    assert (tmp_path / "w1" / "w1-lk-1.ocr").read_text(encoding="utf-8") == "tekst1"
+    assert st.load_batch_mapping("borb") is not None
+    assert "/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt" in sftp.removed
+    assert "/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.jpg" in sftp.removed
+    assert "/OCR/AUTO-OCR/print/borb/w1/w1_pg_002.jpg" not in sftp.removed
+    assert sftp.rmdired == []
 
 
 def test_reaper_skips_live_batch_job(monkeypatch, tmp_path):

--- a/tests/test_reocr_recovery.py
+++ b/tests/test_reocr_recovery.py
@@ -291,6 +291,38 @@ def test_batch_mapping_sailib_kui_osa_lehti_veel_jpgna_ootab(monkeypatch, tmp_pa
     assert sftp.rmdired == []
 
 
+def test_batch_mapping_arvestab_png_jpeg_laiendit(monkeypatch, tmp_path):
+    """Remote-pilt jagab .txt-ga stem'i, aga laiend on originaalfaili oma (.png/.jpeg).
+    Kui lõpetamise-kontroll eeldaks kõvasti .jpg-d, jääks veel-töötlev .png leht vahele
+    ja mapping kustutataks enne .txt saabumist (sama andmekadu, mille #112 pidi vältima)."""
+    import server.reocr_state as st
+    monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))
+    st.persist_batch_mapping("borb", "wid", "w1", {
+        "w1_pg_001.txt": {"page_filename": "w1-lk-1.png", "page_number": 1},
+        "w1_pg_002.txt": {"page_filename": "w1-lk-2.png", "page_number": 2},
+    })
+    # Lk 1: .txt valmis (taastatav). Lk 2: ainult .png (OCR töötleb veel).
+    tree = {"/OCR/AUTO-OCR/print": ["borb"], "/OCR/AUTO-OCR/hand": [],
+            "/OCR/AUTO-OCR/print/borb": ["w1"],
+            "/OCR/AUTO-OCR/print/borb/w1": ["w1_pg_001.png", "w1_pg_001.txt", "w1_pg_002.png"]}
+    files = {"/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.txt": b"tekst1"}
+    sftp = _FakeSftp(tree, files)
+    monkeypatch.setattr(rec.reocr_ops, "_sftp_open", lambda cid: sftp)
+    monkeypatch.setattr(rec.reocr_ops, "close_ssh", lambda cid: None)
+    rec._recovering.clear()
+
+    result = rec.scan_and_recover()
+
+    assert result["recovered"] == ["borb"]
+    assert (tmp_path / "w1" / "w1-lk-1.ocr").read_text(encoding="utf-8") == "tekst1"
+    # Mapping säilib — lk 2 .png ootab veel .txt-d
+    assert st.load_batch_mapping("borb") is not None
+    # Taastatud lehe .png koristati õige laiendiga (mitte .jpg)
+    assert "/OCR/AUTO-OCR/print/borb/w1/w1_pg_001.png" in sftp.removed
+    assert "/OCR/AUTO-OCR/print/borb/w1/w1_pg_002.png" not in sftp.removed
+    assert sftp.rmdired == []
+
+
 def test_reaper_skips_live_batch_job(monkeypatch, tmp_path):
     import server.reocr_state as st
     monkeypatch.setattr(st, "BATCH_MAPS_DIR", str(tmp_path / "maps"))


### PR DESCRIPTION
## Kokkuvõte
- Hoia batch re-OCR mapping alles, kui staging'us on veel mapping'u lehtede JPG-d ilma TXT tulemuseta
- Korista taastatud lehe JPG koos TXT-ga, et kõik-lahendatud seisu saaks tuvastada
- Lisa regressioonitestid mappingu säilimise ja lõpliku koristuse kohta

Fixes #112

## Testid
- .venv/bin/python -m pytest tests/test_reocr_recovery.py