### PR TITLE
fix: Review OCR-link samas tabis + Workspace ootab auth-initi (restricted 403 võistlus)

### DIFF
--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -620,15 +620,28 @@ const Review: React.FC = () => {
                           )}
                         </div>
 
-                        {/* Staatus badge */}
-                        <a href={job.link} target={job.link.startsWith('/work') ? '_blank' : undefined} rel="noreferrer"
-                          className={`shrink-0 text-xs font-medium px-2 py-1 rounded ${
+                        {/* Staatus badge — avaneb SAMAS tabis (react-routeri klient-nav):
+                            säilitab auth-state, väldib värske tabi auth-re-initi ja
+                            "logi sisse" vilkumist restricted-teosel. ↗-ikoon (üleval) jääb
+                            uue-tabi valikuks. */}
+                        {job.link ? (
+                          <Link to={job.link}
+                            className={`shrink-0 text-xs font-medium px-2 py-1 rounded ${
+                              isSlow ? 'bg-amber-100 text-amber-800' :
+                              isActive ? 'bg-amber-100 text-amber-700' :
+                              isError ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
+                            }`}>
+                            {isSlow ? t('reocr.slow') : t(`ocr.statusKey.${job.status_key}`)}
+                          </Link>
+                        ) : (
+                          <span className={`shrink-0 text-xs font-medium px-2 py-1 rounded ${
                             isSlow ? 'bg-amber-100 text-amber-800' :
                             isActive ? 'bg-amber-100 text-amber-700' :
                             isError ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'
                           }`}>
-                          {isSlow ? t('reocr.slow') : t(`ocr.statusKey.${job.status_key}`)}
-                        </a>
+                            {isSlow ? t('reocr.slow') : t(`ocr.statusKey.${job.status_key}`)}
+                          </span>
+                        )}
                       </div>
                     );
                   })}

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -28,7 +28,7 @@ import { buildManageLink } from '../utils/manageDeeplink';
 
 const Workspace: React.FC = () => {
   const { t } = useTranslation(['workspace', 'common', 'auth']);
-  const { user, authToken, logout, sessionExpired, clearSessionExpired } = useUser();
+  const { user, authToken, logout, sessionExpired, clearSessionExpired, isLoading: authInitializing } = useUser();
   const isAdmin = isAtLeast(user?.role, 'admin');
   const { collections, selectedCollection, setSelectedCollection } = useCollection();
   const index = useMeiliIndex();
@@ -140,6 +140,12 @@ const Workspace: React.FC = () => {
 
   useEffect(() => {
     if (!effectiveIndex) return;
+    // Värske tab (nt Review-lingist, järjehoidjast, refreshist): auth initsialiseerub
+    // async (initAuth → /verify-token + Meili-tokeni värskendus). Kuni see käib, oota —
+    // muidu läheks restricted-teose päring anonüümse Meili-tokeniga → 403 → vale "logi
+    // sisse" vilkumine. `loading` jääb true (spinner). Effect jookseb uuesti kui
+    // authInitializing → false (dep-listis).
+    if (authInitializing) return;
     const loadData = async () => {
       if (!workId) {
         setError("Töö ID on puudu.");
@@ -223,7 +229,7 @@ const Workspace: React.FC = () => {
       }
     };
     loadData();
-  }, [effectiveIndex, workId, currentPageNum, navigate, viewerToken, authToken, sessionExpired, user, t]);
+  }, [effectiveIndex, workId, currentPageNum, navigate, viewerToken, authToken, sessionExpired, user, authInitializing, t]);
 
   // Metaandmete modaali avamine
   const openMetaModal = () => {


### PR DESCRIPTION
Kasutaja-raporteeritud UX-bug (Review ühtne OCR-vaade). Frontend-only.

## Probleem
"Valmis" badge avas `/work` lingi **uues tabis** (`target=_blank`). Värskes tabis initsialiseerub auth **async** (`initAuth` → `/verify-token` + Meili-tokeni värskendus, ~1–2s). Selle akna jooksul on `authToken` null → restricted-teose (nt Academia Gustaviana) päring läheb anonüümse Meili-tokeniga → 403 → Workspace näitab "logi sisse", kuigi kasutaja **on** sisse logitud (`localStorage` token on tabide vahel jagatud — mitte puudu).

## Lahendus
**(a)** Review "Valmis" badge → react-routeri `<Link>` (klient-navigatsioon, **samas tabis**): säilitab auth-state, väldib värske tabi re-initi täielikult. ↗-ExternalLink ikoon jääb eksplitsiitseks uue-tabi valikuks.

**(b)** Workspace andmelaadimine ootab auth-initi lõppu (`isLoading` kontekstist) enne restricted-teose päringut. Parandab võistluse **ka** järjehoidjatele, refreshile ja otselinkidele — mitte ainult Review-lingile. `loading` jääb `true` (spinner), effect jookseb uuesti kui `authInitializing`→false.

## Valideerimine
- `npm run typecheck` — puhas
- `npm test` — 540 passed
- Deploy: `npm run build` + `rsync -avz dist/ vutt:~/VUTT/dist/` (frontend-only, backend-buildi pole vaja)

🤖 Generated with [Claude Code](https://claude.com/claude-code)