### PR TITLE
Fix re-OCR page filename path traversal

### DIFF
--- a/server/routers/reocr.py
+++ b/server/routers/reocr.py
@@ -35,6 +35,9 @@ async def admin_reocr_page(work_id: str, request: Request, user=Depends(require_
     page_filename = data.get("page_filename")
     if not page_filename:
         raise HTTPException(status_code=400, detail="page_filename puudub")
+    # Turvalisus: ainult bare failinimi — väldi path traversal'i (nt ../../state/users.json)
+    if not isinstance(page_filename, str) or page_filename != os.path.basename(page_filename):
+        raise HTTPException(status_code=400, detail="Vigane failinimi")
     img_path = os.path.join(path, page_filename)
     if not os.path.isfile(img_path):
         raise HTTPException(status_code=404, detail="Pilti ei leitud")

--- a/tests/test_reocr_router.py
+++ b/tests/test_reocr_router.py
@@ -1,0 +1,27 @@
+"""Re-OCR routeri turvaregressioonid."""
+
+
+def test_admin_reocr_page_rejects_path_traversal(client, login, tmp_path, monkeypatch):
+    """Üksik-lehe re-OCR peab aktsepteerima ainult bare failinime."""
+    import server.routers.reocr as reocr_router
+
+    work_dir = tmp_path / "data" / "work"
+    work_dir.mkdir(parents=True)
+    secret_dir = tmp_path / "secret"
+    secret_dir.mkdir()
+    (secret_dir / "users.json").write_text('{"secret": true}', encoding="utf-8")
+
+    monkeypatch.setattr(reocr_router, "find_directory_by_id", lambda work_id: str(work_dir) if work_id == "wid" else None)
+    monkeypatch.setattr(reocr_router, "get_active_reocr_count", lambda: 0)
+    monkeypatch.setattr(reocr_router.shutil, "copy2", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(reocr_router, "start_reocr_job", lambda *_args, **_kwargs: "job1")
+
+    token = login("admin", "adminpass")
+    response = client.post(
+        "/admin/work/wid/reocr-page",
+        json={"page_filename": "../../secret/users.json"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Vigane failinimi"


### PR DESCRIPTION
## Kokkuvõte
- Lisa `admin_reocr_page` endpointile bare-failinime kontroll
- Blokeeri `../`-ga path traversal enne `os.path.join` kasutamist
- Lisa regressioonitest

Fixes #113

## Testid
- `.venv/bin/python -m pytest tests/test_reocr_router.py -q`
- `.venv/bin/python -m pytest tests/test_reocr_router.py tests/test_reocr_batch.py tests/test_reocr_poll.py -q`