### PR TITLE
Report /save Git commit failures

### DIFF
--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -92,7 +92,14 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
     }
     if page_tag_qcodes:
         background_tasks.add_task(enrich_entity_labels_async_qcodes, page_tag_qcodes)
-    return {"status": "success", "commit_hash": git_result.get("commit_hash", "")[:8]}
+
+    response = {"status": "success", "commit_hash": git_result.get("commit_hash", "")[:8], "git_committed": True}
+    if git_result.get("success") is False:
+        response["git_committed"] = False
+        response["warning"] = "Tekst salvestati kettale, aga Git versioonihalduse commit ebaõnnestus."
+        if git_result.get("error"):
+            response["git_error"] = git_result.get("error")
+    return response
 
 
 

--- a/tests/test_backend_smoke.py
+++ b/tests/test_backend_smoke.py
@@ -378,6 +378,32 @@ def test_save_triggers_page_person_mentions_update(client, login, monkeypatch, t
     assert "teos1" in calls[0][1]
 
 
+def test_save_reports_git_commit_failure(client, login, monkeypatch, tmp_path):
+    """POST /save peab nähtavalt teatama, kui save_with_git commit ebaõnnestus."""
+    from server.routers import editing as editing_router
+
+    monkeypatch.setattr(editing_router, "save_with_git", lambda *a, **kw: {"success": False, "error": "boom"})
+    monkeypatch.setattr(editing_router, "sync_work_to_meilisearch_async", lambda *a: None)
+    monkeypatch.setattr(editing_router, "update_page_person_mentions", lambda *a: None)
+    monkeypatch.setattr(editing_router, "BASE_DIR", str(tmp_path))
+
+    token = login("editor", "editorpass")
+    response = client.post("/save", headers={"Authorization": f"Bearer {token}"}, json={
+        "original_path": "teos1",
+        "file_name": "leht1.txt",
+        "text_content": "uus tekst",
+        "meta_content": {"page_tags": []},
+    })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["git_committed"] is False
+    assert data["commit_hash"] == ""
+    assert "warning" in data
+    assert data["git_error"] == "boom"
+
+
 # ============================================================
 # has_annotations regressioonitestid
 # ============================================================


### PR DESCRIPTION
## Kokkuvõte
- `/save` vastus sisaldab nüüd `git_committed` lippu
- Kui `save_with_git` tagastab `success: false`, jääb tekstisalvestus `status: success`, aga vastuses on nähtav hoiatus ja `git_committed: false`
- Lisa regressioonitest vaikse Git-commit failure vastu

Fixes #120

## Testid
- `.venv/bin/python -m pytest tests/test_backend_smoke.py::test_save_triggers_page_person_mentions_update tests/test_backend_smoke.py::test_save_reports_git_commit_failure -q`
- `.venv/bin/python -m pytest tests/test_backend_smoke.py -q`