### PR TITLE
Report import Git commit failures

### DIFF
--- a/server/git_ops.py
+++ b/server/git_ops.py
@@ -574,6 +574,7 @@ def commit_new_work_to_git(dir_name, username=None):
         return True
     except Exception as e:
         logger.error(f"GIT viga uue teose lisamisel ({dir_name}): {e}")
+        _record_git_failure(dir_name, username or "Automaatne", e)
         return False
 
 

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -1215,12 +1215,24 @@ def import_as_work(upload_id: str, username: str = None) -> dict:
     os.chmod(meta_path, 0o644)
 
     # Git commit
+    git_committed = False
+    git_warning = None
     try:
         from .git_ops import commit_new_work_to_git
-        commit_new_work_to_git(slug, username=username)
-        logger.info(f"import {upload_id}: git commit OK ({slug})")
+        git_committed = bool(commit_new_work_to_git(slug, username=username))
+        if git_committed:
+            logger.info(f"import {upload_id}: git commit OK ({slug})")
+        else:
+            git_warning = "Teos imporditi, aga Git versioonihalduse commit ebaõnnestus."
+            logger.warning(f"import {upload_id}: git commit ebaõnnestus ({slug})")
     except Exception as e:
+        git_warning = "Teos imporditi, aga Git versioonihalduse commit ebaõnnestus."
         logger.warning(f"import {upload_id}: git commit ebaõnnestus: {e}")
+        try:
+            from .git_ops import _record_git_failure
+            _record_git_failure(slug, username or "Automaatne", e)
+        except Exception:
+            pass
 
     # Person-to-works indeks (uus teos võib juba sisaldada creators/tags isikuid)
     try:
@@ -1266,7 +1278,10 @@ def import_as_work(upload_id: str, username: str = None) -> dict:
         logger.warning(f"import {upload_id}: OCR koristamine ebaõnnestus: {e}")
 
     logger.info(f"import {upload_id}: valmis → work_id={work_id}, slug={slug}, lehed={downloaded}")
-    return {"work_id": work_id, "slug": slug}
+    result = {"work_id": work_id, "slug": slug, "git_committed": git_committed}
+    if git_warning:
+        result["warning"] = git_warning
+    return result
 
 
 def replace_work_content(upload_id: str, target_work_id: str, metadata_updates: dict, username: str, background_tasks) -> dict:

--- a/tests/test_save_and_transfer.py
+++ b/tests/test_save_and_transfer.py
@@ -112,6 +112,64 @@ def _fake_sftp():
     return sftp
 
 
+class _ImportSftp:
+    """Minimaalne SFTP fake import_as_work testi jaoks."""
+
+    def listdir(self, _path):
+        return ["test-teos_pg_001.jpg", "test-teos_pg_001.txt"]
+
+    def get(self, remote, local):
+        if remote.endswith(".jpg"):
+            Path(local).write_bytes(b"jpg")
+        elif remote.endswith(".txt"):
+            Path(local).write_text("OCR tekst", encoding="utf-8")
+        else:
+            raise FileNotFoundError(remote)
+
+    def close(self):
+        pass
+
+
+# =========================================================
+# import_as_work
+# =========================================================
+
+
+def test_import_as_work_reports_git_commit_failure(make_state, tmp_path, monkeypatch):
+    """Import peab õnnestuma, aga vastuses nähtavalt märkima ebaõnnestunud Git-commiti."""
+    import server.git_ops as git_ops
+    import server.meilisearch_ops as meili_ops
+    import server.prosopography.indices as prosopo_indices
+    import server.prosopography.person_crud as person_crud
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(upload_ops, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(git_ops, "commit_new_work_to_git", lambda *a, **kw: False)
+    monkeypatch.setattr(upload_ops, "_sftp_open", lambda upload_id: _ImportSftp())
+    monkeypatch.setattr(upload_ops, "_ssh_rm_rf", lambda *a, **kw: None)
+    monkeypatch.setattr(upload_ops, "close_ssh", lambda *a, **kw: None)
+    monkeypatch.setattr(meili_ops, "sync_work_to_meilisearch", lambda slug: True)
+    monkeypatch.setattr(person_crud, "ensure_prosopo_stubs", lambda metadata, username=None: {})
+    monkeypatch.setattr(prosopo_indices, "update_person_to_works", lambda *a, **kw: None)
+    monkeypatch.setattr(prosopo_indices, "update_work_collections", lambda *a, **kw: None)
+
+    upload_id, _state = make_state(
+        upload_id="imp123",
+        slug="test-teos",
+        status="reviewing",
+        files=[{"page": 1, "has_ocr": True, "deleted": False}],
+        meta={"title": "Test teos", "year": "1700", "slug": "test-teos", "work_id": "wid123"},
+    )
+
+    result = upload_ops.import_as_work(upload_id, username="admin")
+
+    assert result["work_id"] == "wid123"
+    assert result["slug"] == "test-teos"
+    assert result["git_committed"] is False
+    assert "warning" in result
+
+
 # =========================================================
 # _count_pdf_pages (eraldatud pdfinfo loogika)
 # =========================================================


### PR DESCRIPTION
## Kokkuvõte
- `import_as_work` kontrollib nüüd `commit_new_work_to_git` tulemust
- Impordi vastuses on `git_committed: false` ja hoiatus, kui originaal-OCR commit ebaõnnestus
- `commit_new_work_to_git` salvestab erindi ka Git-failure logisse
- Lisa regressioonitest import-as-work Git failure nähtavuse jaoks

Fixes #117

## Testid
- `.venv/bin/python -m pytest tests/test_save_and_transfer.py::test_import_as_work_reports_git_commit_failure -q`
- `.venv/bin/python -m pytest tests/test_save_and_transfer.py tests/test_async_endpoint_offload.py -q`