### PR TITLE
Surface import Git warnings in workspace (#117 follow-up)

### DIFF
--- a/src/locales/en/upload.json
+++ b/src/locales/en/upload.json
@@ -74,7 +74,8 @@
     "timeoutWarning": "OCR processing is taking a long time. You can import the available pages.",
     "forceImport": "Import available pages",
     "importSuccess": "Work imported!",
-    "importError": "Import failed"
+    "importError": "Import failed",
+    "gitCommitWarning": "Work was imported, but the Git version-control commit failed."
   },
   "notice": {
     "title": "Upload and processing takes {{time}}",

--- a/src/locales/et/upload.json
+++ b/src/locales/et/upload.json
@@ -74,7 +74,8 @@
     "timeoutWarning": "OCR töötlemine võtab kaua aega. Saad importida olemasolevad lehed.",
     "forceImport": "Impordi olemasolevad lehed",
     "importSuccess": "Teos imporditud!",
-    "importError": "Importimine ebaõnnestus"
+    "importError": "Importimine ebaõnnestus",
+    "gitCommitWarning": "Teos imporditi, aga Git versioonihalduse commit ebaõnnestus."
   },
   "notice": {
     "title": "Üleslaadimine ja töötlemine võtab {{time}}",

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import { isAtLeast } from '../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { MeiliSearch } from 'meilisearch';
 import { useUnsavedChangesGuard } from '../hooks/useUnsavedChangesGuard';
 import { getPage, savePage } from '../services/pageService';
@@ -40,6 +40,7 @@ const Workspace: React.FC = () => {
   }, [index, viewerToken]);
   const { workId, pageNum } = useParams<{ workId: string, pageNum: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [errorRequiresLogin, setErrorRequiresLogin] = useState(false);
@@ -65,6 +66,15 @@ const Workspace: React.FC = () => {
   useEffect(() => {
     setEditorChanges(false);
   }, [pageNum]);
+
+  // Upload-viisardilt tulnud hoiatused (nt import õnnestus, aga Git commit mitte)
+  // kuvatakse tööle jõudes ühekordselt ja eemaldatakse history state'ist.
+  useEffect(() => {
+    const uploadWarning = (location.state as { uploadWarning?: string } | null)?.uploadWarning;
+    if (!uploadWarning) return;
+    setSaveError(uploadWarning);
+    navigate(`${location.pathname}${location.search}`, { replace: true, state: null });
+  }, [location.pathname, location.search, location.state, navigate]);
 
   // Metaandmete muutmise modal
   const [isMetaModalOpen, setIsMetaModalOpen] = useState(false);

--- a/src/pages/upload/types.ts
+++ b/src/pages/upload/types.ts
@@ -63,4 +63,6 @@ export interface UploadListResponse {
 export interface UploadImportResponse {
   work_id: string;
   message?: string;
+  warning?: string;
+  git_committed?: boolean;
 }

--- a/src/pages/upload/useUploadWizard.ts
+++ b/src/pages/upload/useUploadWizard.ts
@@ -372,8 +372,9 @@ export function useUploadWizard() {
       const d = await importUpload(uploadId, authToken);
       stopPolling();
       setFileUploading(false);
-      // Suuna tööle
-      navigate(`/work/${d.work_id}`);
+      const uploadWarning = d.warning || (d.git_committed === false ? t('step3.gitCommitWarning') : undefined);
+      // Suuna tööle; Git-hoiatus kantakse kaasa, et admin seda sihtlehel näeks.
+      navigate(`/work/${d.work_id}`, uploadWarning ? { state: { uploadWarning } } : undefined);
     } catch (e) {
       setImportError(e instanceof Error ? e.message : t('step3.importError'));
     } finally {


### PR DESCRIPTION
## Kokkuvõte
PR #128 järelmeede: import-vastuse `git_committed: false` / `warning` nüüd ka kasutajale nähtav (mitte ainult API-vastuses).

- `UploadImportResponse` tüüpi lisatud `warning?` + `git_committed?`
- `useUploadWizard` kannab Git-hoiatuse router-state'iga sihtlehele
- `Workspace` kuvab upload-hoiatuse ühekordselt `ErrorBanner`-is ja puhastab history state'i
- i18n võti `step3.gitCommitWarning` (et/en)

Seotud: #117, järgneb #128-le (backend-pool juba main'is)

## Testid
- `npm run typecheck` — puhas