### PR TITLE
Prerender full-text SEO and bot policy

### DIFF
--- a/docs/monitoring-bot-traffic.md
+++ b/docs/monitoring-bot-traffic.md
@@ -1,0 +1,77 @@
+# Bot/scraper liikluse jälgimine (Part D)
+
+Eesmärk: teha "luba esialgu, jälgi, klassifitseeri ümber" poliitika reaalseks.
+Praegu logib nginx HTML-lehed UA-ga (`vutt_access.log`), AGA `/api/images/` on
+`access_log off` → pildikraapimine on nähtamatu. Umami näeb ainult brausereid.
+Zabbix teeb uptime-kontrolli ja on tuleviku push-alertingu koht (D4, sügis 2026).
+
+## D1 — Logi pildipäringud (eraldi fail)
+
+`/etc/nginx/sites-available/vutt`, `location /api/images/` blokis ASENDA
+`access_log off;` reaga:
+
+    access_log /var/log/nginx/vutt_images.log;
+
+Rakenda:
+
+    sudo nginx -t && sudo systemctl reload nginx
+
+## D2 — Piira logi kasvu (KOHUSTUSLIK)
+
+Pildipäringuid on palju → ilma rotatsioonita täidab ketta.
+Loo `/etc/logrotate.d/vutt-images`:
+
+    /var/log/nginx/vutt_images.log {
+        daily
+        rotate 7
+        size 100M
+        compress
+        missingok
+        notifempty
+        create 0640 www-data adm
+        sharedscripts
+        postrotate
+            [ -f /var/run/nginx.pid ] && kill -USR1 `cat /var/run/nginx.pid`
+        endscript
+    }
+
+Testi: `sudo logrotate -d /etc/logrotate.d/vutt-images` (dry-run).
+
+## Privaatsus / säilitus
+
+Pildi- ja lehelogid sisaldavad IP + User-Agent. Hoia säilitus LÜHIKE (7 rotatsiooni
+ülal), ligipääs ADMIN-only, kasutus PIIRATUD väärkasutuse/koormuse jälgimisega —
+mitte analüütika ega profileerimine.
+
+## D3 — GoAccess raport + ülevaatuse rütm
+
+Paigalda: `sudo apt-get install goaccess`
+
+Genereeri staatiline HTML-raport (cron, nt iga öö):
+
+    goaccess /var/log/nginx/vutt_access.log /var/log/nginx/vutt_images.log \
+      --log-format=COMBINED -o /root/vutt-goaccess/report.html
+
+RAPORT EI TOHI LEKKIDA (sisaldab IP/UA): hoia väljaspool web-rooti, `chmod 600`,
+vaata AINULT SSH-tunneli või nginx basic-auth kaudu — MITTE avalik URL.
+
+Cron (`sudo crontab -e`):
+
+    15 3 * * * goaccess /var/log/nginx/vutt_access.log /var/log/nginx/vutt_images.log --log-format=COMBINED -o /root/vutt-goaccess/report.html 2>/dev/null
+
+Ülevaatuse rütm: kord nädalas vaata top UA-d/IP-d. Tegutse, kui üks UA/IP domineerib
+pildimahtu või kogub palju 429-sid → see on trigger Firecrawl / PerplexityBot /
+OAI-SearchBot ümberklassifitseerimiseks (vt robots.txt Task 7).
+
+## D4 — Zabbix alerting (EDASI LÜKATUD → sügis 2026)
+
+Ülikooli Zabbix juba pingib saiti. Ideaal: push-alertid request-rate / bandwidth /
+429 piikidele. Ootab IT-d (suvepuhkused). Vahepeal katab GoAccess + logid.
+
+## Verifitseerimine (pärast D1)
+
+    # Botina päring lehele (peab endiselt töötama)
+    curl -s -A "Googlebot" https://vutt.utlib.ut.ee/work/<id> | grep -c data-page
+    # Pildipäring peab nüüd logisse ilmuma
+    curl -s -A "TestBot" https://vutt.utlib.ut.ee/api/images/<id>/_thumb -o /dev/null
+    sudo tail -n 5 /var/log/nginx/vutt_images.log

--- a/docs/superpowers/plans/2026-07-03-prerender-fulltext-seo.md
+++ b/docs/superpowers/plans/2026-07-03-prerender-fulltext-seo.md
@@ -1,0 +1,880 @@
+# Prerender Full-Text SEO + AI-Bot Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose each work's full cleaned transcription in the bot-facing prerender so search engines index the corpus by its actual words, add a sitemap freshness signal for edits, and set an AI-bot robots.txt policy + traffic-monitoring plan.
+
+**Architecture:** A new neutral module `server/text_reading.py` reads page text (reusing the indexer's enumeration, extracted from `meili_doc.py`) and computes a max-mtime key. `build_meta_html` injects per-page cleaned text (main + marginalia) with a size guardrail; `build_sitemap_xml` uses the max-mtime for `lastmod`; the `/meta/work/{id}` endpoint caches HTML keyed on that mtime. `public/robots.txt` gains AI-training-bot blocks. Part D is host-config + docs (nginx image logging, logrotate, GoAccess).
+
+**Tech Stack:** Python 3.9 (FastAPI backend, in Docker), pytest, nginx (host), robots.txt.
+
+## Global Constraints
+
+- **Python 3.9 compatibility:** use `Optional[X]` / `Tuple[...]` from `typing`, never `X | None`.
+- **Code comments in Estonian** (project convention); UI strings Estonian + English.
+- **Run tests with** `.venv/bin/python -m pytest <path> -v` from repo root.
+- **`metadata_handler.py` must NOT import `meilisearch_ops.py`** (heavy: ThreadPoolExecutor, git_ops). It may import `meili_doc.py` and `text_reading.py` — both pure (stdlib + `server.utils` + `server.marginalia_normalize`).
+- **Do NOT rename Meilisearch field names** (legacy `y`-orthography); this plan does not touch the index schema.
+- **Reuse existing helpers**, do not duplicate: `clean_text_for_search`, `split_marginalia`, `_clean_search_text` (`server/meili_doc.py`); `_escape`, `SITE_URL`, `find_directory_by_id`, `_sitemap_lastmod` (`server/metadata_handler.py`).
+- **Escape all injected text** with the existing `_escape`.
+
+---
+
+## File Structure
+
+- **Create** `server/text_reading.py` — page-text reader + max-mtime helper; re-exports cleaners. Neutral import surface for `metadata_handler.py`.
+- **Modify** `server/meili_doc.py` — extract inline page-image enumeration into `enumerate_page_images(doc_path)`; `build_document` calls it (behaviour unchanged, guarded by snapshot tests).
+- **Modify** `server/metadata_handler.py` — `build_meta_html`: inject per-page text + size guardrail; add `cached_work_meta_html`; `build_sitemap_xml`: `lastmod` from max-mtime; add module `logger`.
+- **Modify** `server/cache_invalidation.py` — add `_work_meta_cache` + clear it in `invalidate_all_caches`.
+- **Modify** `server/routers/public.py` — `/meta/work/{id}` uses `cached_work_meta_html` on the public branch.
+- **Modify** `public/robots.txt` — AI-training-bot blocks; keep search/referral bots allowed.
+- **Create** `docs/monitoring-bot-traffic.md` — Part D host-config (image logging, logrotate, GoAccess, privacy, review cadence).
+- **Tests:** create `tests/test_text_reading.py`, `tests/test_robots_txt.py`; extend `tests/test_metadata_handler.py`.
+
+---
+
+### Task 1: Extract `enumerate_page_images` in meili_doc.py
+
+Extract the inline page-image enumeration (currently inside `build_document`, `server/meili_doc.py:567-582`) into a reusable module-level function, so the prerender reader and the indexer share one ordering and cannot drift.
+
+**Files:**
+- Modify: `server/meili_doc.py` (add function near other text helpers; replace lines 567-582 usage)
+- Test: `tests/test_text_reading.py` (new — also used by Task 2)
+
+**Interfaces:**
+- Produces: `enumerate_page_images(doc_path: str) -> list[str]` — image filenames ordered by `(sequence, filename)`, excluding `_thumb_*`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_text_reading.py`:
+
+```python
+# tests/test_text_reading.py
+import json
+import os
+
+
+def _make_work(tmp_path):
+    d = tmp_path / "w"
+    d.mkdir()
+    return d
+
+
+def test_enumerate_orders_by_sequence(tmp_path):
+    from server.meili_doc import enumerate_page_images
+    d = _make_work(tmp_path)
+    # Kaks pilti, sequence tagurpidi failinime suhtes
+    (d / "b.jpg").write_bytes(b"x")
+    (d / "b.json").write_text(json.dumps({"sequence": 1}), encoding="utf-8")
+    (d / "a.jpg").write_bytes(b"x")
+    (d / "a.json").write_text(json.dumps({"sequence": 2}), encoding="utf-8")
+    (d / "_thumb_a.jpg").write_bytes(b"x")  # peab välja jääma
+    result = enumerate_page_images(str(d))
+    assert result == ["b.jpg", "a.jpg"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_text_reading.py::test_enumerate_orders_by_sequence -v`
+Expected: FAIL with `ImportError: cannot import name 'enumerate_page_images'`.
+
+- [ ] **Step 3: Add the function to `server/meili_doc.py`**
+
+Add near the other pure helpers (e.g. after `_clean_search_text`):
+
+```python
+def enumerate_page_images(doc_path):
+    """Loeb teose pildifailid järjekorras (sequence, siis failinimi).
+
+    Jätab välja `_thumb_` failid. ÜHINE loogika indekseerijale (build_document)
+    ja bot-prerenderi teksti-lugejale (text_reading.read_work_page_texts) —
+    nii ei saa lehe-järjekord kahe tee vahel lahku minna.
+    """
+    def _seq(img_name):
+        jp = os.path.join(doc_path, os.path.splitext(img_name)[0] + '.json')
+        if os.path.exists(jp):
+            try:
+                with open(jp, 'r', encoding='utf-8') as fj:
+                    d = json.load(fj)
+                    s = d.get('sequence') or d.get('meta_content', {}).get('sequence')
+                    if s is not None:
+                        return int(s)
+            except Exception:
+                pass
+        return float('inf')
+
+    all_imgs = [f for f in os.listdir(doc_path)
+                if f.lower().endswith(('.jpg', '.jpeg', '.png')) and not f.startswith('_thumb_')]
+    return sorted(all_imgs, key=lambda f: (_seq(f), f))
+```
+
+Then replace the inline block in `build_document` (lines 567-582, the local `def _seq`, `all_imgs`, `jpg_files = sorted(...)`) with:
+
+```python
+    jpg_files = enumerate_page_images(doc_path)
+    if not jpg_files:
+        return teose_id, []
+```
+
+- [ ] **Step 4: Run tests to verify they pass (incl. indexer snapshot guards)**
+
+Run: `.venv/bin/python -m pytest tests/test_text_reading.py tests/test_meilisearch_sync_snapshot.py tests/test_meili_seed_live_parity.py -v`
+Expected: PASS (snapshot/parity tests confirm the indexer behaviour is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/meili_doc.py tests/test_text_reading.py
+git commit -m "refactor: extract enumerate_page_images for shared page ordering"
+```
+
+---
+
+### Task 2: `text_reading.py` — page reader + mtime helper
+
+**Files:**
+- Create: `server/text_reading.py`
+- Test: `tests/test_text_reading.py` (extend)
+
+**Interfaces:**
+- Consumes: `enumerate_page_images` (Task 1), `clean_text_for_search`, `_clean_search_text` (`meili_doc.py`).
+- Produces:
+  - `read_work_page_texts(work_path: str) -> list` of `(page_num: int, raw_text: str)`, in page order; `.txt` authoritative, page `.json` `text_content` fallback.
+  - `work_latest_mtime(work_path: str) -> float` — max mtime over `_metadata.json` + page `.txt`/`.json` files (0.0 if none).
+  - Re-exports `clean_text_for_search`, `_clean_search_text` for a neutral import surface.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_text_reading.py`:
+
+```python
+def test_read_work_page_texts_txt_authoritative(tmp_path):
+    from server.text_reading import read_work_page_texts
+    d = _make_work(tmp_path)
+    (d / "a.jpg").write_bytes(b"x")
+    (d / "a.json").write_text(json.dumps({"sequence": 1, "text_content": "JSON"}), encoding="utf-8")
+    (d / "a.txt").write_text("TXT tekst", encoding="utf-8")
+    (d / "b.jpg").write_bytes(b"x")
+    (d / "b.json").write_text(json.dumps({"sequence": 2, "text_content": "ainult JSON"}), encoding="utf-8")
+    pages = read_work_page_texts(str(d))
+    assert pages == [(1, "TXT tekst"), (2, "ainult JSON")]
+
+
+def test_work_latest_mtime_tracks_page_edit(tmp_path):
+    from server.text_reading import work_latest_mtime
+    d = _make_work(tmp_path)
+    (d / "_metadata.json").write_text("{}", encoding="utf-8")
+    (d / "a.jpg").write_bytes(b"x")
+    txt = d / "a.txt"
+    txt.write_text("v1", encoding="utf-8")
+    k1 = work_latest_mtime(str(d))
+    os.utime(str(txt), (k1 + 10, k1 + 10))  # simuleeri hilisemat muudatust
+    k2 = work_latest_mtime(str(d))
+    assert k2 > k1
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/test_text_reading.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'server.text_reading'`.
+
+- [ ] **Step 3: Create `server/text_reading.py`**
+
+```python
+"""Neutraalne teksti-lugemise moodul bot-prerenderi ja sitemapi jaoks.
+
+Sõltub AINULT stdlibist + server.meili_doc puhtast osast (enumerate_page_images,
+clean_text_for_search, _clean_search_text). metadata_handler impordib SIIT, MITTE
+meilisearch_ops-ist (raske: ThreadPoolExecutor, git_ops).
+"""
+import os
+import json
+
+from .meili_doc import (
+    enumerate_page_images,
+    clean_text_for_search,   # re-export
+    _clean_search_text,      # re-export
+)
+
+__all__ = [
+    "read_work_page_texts",
+    "work_latest_mtime",
+    "clean_text_for_search",
+    "_clean_search_text",
+]
+
+
+def read_work_page_texts(work_path):
+    """Loeb teose lehtede toore teksti järjekorras.
+
+    Tagastab [(page_num, raw_text)]. `.txt` on autoriteet, lehe `.json`
+    `text_content` on fallback (sama reegel nagu indekseerijal, meili_doc.py:646-678).
+    """
+    pages = []
+    for idx, img_name in enumerate(enumerate_page_images(work_path)):
+        page_num = idx + 1
+        base = os.path.splitext(img_name)[0]
+        raw = ""
+        txt_path = os.path.join(work_path, base + '.txt')
+        if os.path.exists(txt_path):
+            try:
+                with open(txt_path, 'r', encoding='utf-8') as f:
+                    raw = f.read()
+            except Exception:
+                pass
+        if not raw:
+            jp = os.path.join(work_path, base + '.json')
+            if os.path.exists(jp):
+                try:
+                    with open(jp, 'r', encoding='utf-8') as jf:
+                        d = json.load(jf)
+                        raw = d.get('text_content', '') or ''
+                except Exception:
+                    pass
+        pages.append((page_num, raw))
+    return pages
+
+
+def work_latest_mtime(work_path):
+    """max mtime üle `_metadata.json` + lehtede `.txt`/`.json` failide.
+
+    Kasutatakse NII sitemap `lastmod` (Part B) KUI bot-HTML cache-võtme (Part A)
+    jaoks — nii et teksti- VÕI bibliograafiamuudatus värskendab mõlemat.
+    """
+    latest = 0.0
+    meta = os.path.join(work_path, '_metadata.json')
+    if os.path.exists(meta):
+        try:
+            latest = os.path.getmtime(meta)
+        except OSError:
+            pass
+    try:
+        for name in os.listdir(work_path):
+            if name.startswith('_'):
+                continue
+            if name.endswith('.txt') or name.endswith('.json'):
+                try:
+                    latest = max(latest, os.path.getmtime(os.path.join(work_path, name)))
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return latest
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_text_reading.py -v`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/text_reading.py tests/test_text_reading.py
+git commit -m "feat: text_reading module (page reader + max-mtime helper)"
+```
+
+---
+
+### Task 3: Inject per-page text into `build_meta_html`
+
+**Files:**
+- Modify: `server/metadata_handler.py` (`build_meta_html`; add `logger`)
+- Test: `tests/test_metadata_handler.py` (extend)
+
+**Interfaces:**
+- Consumes: `read_work_page_texts`, `_clean_search_text` (Task 2); `_escape`, `work_url` (existing).
+- Produces: `build_meta_html` body now contains `<section data-page="N">` blocks with cleaned main text and (when present) a marginalia `<p class="marginalia">`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_metadata_handler.py` a helper that also writes page files, and tests. Put near the top (after `_write_meta`):
+
+```python
+def _write_page(work_dir_path, base, seq, txt):
+    """Lisab teosele lehe: {base}.jpg + {base}.json (sequence) + {base}.txt."""
+    import json as _json
+    from pathlib import Path
+    p = Path(work_dir_path)
+    (p / f"{base}.jpg").write_bytes(b"x")
+    (p / f"{base}.json").write_text(_json.dumps({"sequence": seq}), encoding="utf-8")
+    (p / f"{base}.txt").write_text(txt, encoding="utf-8")
+```
+
+```python
+def test_body_includes_page_text(patch_find):
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    path = _write_meta(tmp_path, FULL_META)
+    registry["work001"] = path
+    _write_page(path, "p1", 1, "Suecorum gloria in aeternum")
+    _write_page(path, "p2", 2, "Pars altera <m>nota marginalis</m> textus")
+    html = build_meta_html("work001")
+    assert 'data-page="1"' in html
+    assert "Suecorum gloria in aeternum" in html
+    assert 'data-page="2"' in html
+    # Marginaalia eraldi lõiguna
+    assert 'class="marginalia"' in html
+    assert "nota marginalis" in html
+    # Põhitekstist on marginaalia välja lõigatud
+    assert "Pars altera textus" in html
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py::test_body_includes_page_text -v`
+Expected: FAIL (no `data-page` in output).
+
+- [ ] **Step 3: Add a module logger (if absent) and the text block**
+
+At the top of `server/metadata_handler.py`, ensure a logger exists (add if not present):
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+```
+
+Add the import near the other imports:
+
+```python
+from .text_reading import read_work_page_texts, _clean_search_text, work_latest_mtime
+```
+
+In `build_meta_html`, after the bibliographic `body_lines` are built and **before** the permalink line (`body_lines.append(f'<p><a href="{work_url}">...')`), insert:
+
+```python
+    # Täistekst botidele (sama avalik transkriptsioon, mida kasutaja SPA-s näeb —
+    # EI ole SEO-only peidetud teksti → ei ole cloaking). Lehekülgede kaupa.
+    if found_path:
+        _append_work_text(body_lines, found_path, work_url, work_id)
+```
+
+Add the helper function (module level, above `build_meta_html`):
+
+```python
+# Googlebot indekseerib esimesed ~2MB HTML-i (Search Central, veebr 2026).
+# Hoiame teksti alla selle; sum ületamisel lõikame ja lisame "täistekst rakenduses".
+PRERENDER_TEXT_MAX_BYTES = 1_600_000
+PRERENDER_TEXT_WARN_BYTES = 1_500_000
+
+
+def _append_work_text(body_lines, found_path, work_url, work_id):
+    """Lisab lehekülgede kaupa puhastatud põhiteksti + marginaalia body_lines-i.
+
+    Suuruse-kaitse: lõpetab lehtede lisamise, kui HTML ületaks piiri (Task 4 katab).
+    """
+    parts = []
+    total = 0
+    truncated = False
+    for page_num, raw in read_work_page_texts(found_path):
+        main_clean, marg_clean = _clean_search_text(raw)
+        if not main_clean and not marg_clean:
+            continue
+        seg = f'<section data-page="{page_num}">'
+        if main_clean:
+            seg += f'<p>{_escape(main_clean)}</p>'
+        if marg_clean:
+            seg += f'<p class="marginalia"><em>Ääremärkused:</em> {_escape(marg_clean)}</p>'
+        seg += '</section>'
+        seg_bytes = len(seg.encode('utf-8'))
+        if total + seg_bytes > PRERENDER_TEXT_MAX_BYTES:
+            truncated = True
+            break
+        parts.append(seg)
+        total += seg_bytes
+    if parts:
+        body_lines.append('<div class="work-text">')
+        body_lines.extend(parts)
+        if truncated:
+            body_lines.append(f'<p><a href="{work_url}">Täistekst rakenduses</a></p>')
+        body_lines.append('</div>')
+    if total >= PRERENDER_TEXT_WARN_BYTES:
+        logger.warning(
+            "Prerender HTML suur: work_id=%s text_bytes=%s truncated=%s",
+            work_id, total, truncated,
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py -v`
+Expected: PASS (new test + all existing metadata_handler tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/metadata_handler.py tests/test_metadata_handler.py
+git commit -m "feat: inject per-page transcription text into work prerender"
+```
+
+---
+
+### Task 4: Size guardrail — truncate oversized works
+
+Verify the truncation path added in Task 3 behaves: oversized works are capped and get a visible "full text in app" note; the head tags (canonical/OG) stay intact.
+
+**Files:**
+- Modify: `server/metadata_handler.py` (only if a fix is needed — logic added in Task 3)
+- Test: `tests/test_metadata_handler.py` (extend)
+
+**Interfaces:**
+- Consumes: `PRERENDER_TEXT_MAX_BYTES`, `_append_work_text` (Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_metadata_handler.py`:
+
+```python
+def test_oversized_work_truncated_with_note(patch_find, monkeypatch):
+    import server.metadata_handler as mh
+    registry, tmp_path = patch_find
+    path = _write_meta(tmp_path, FULL_META)
+    registry["work001"] = path
+    # Väike piir, et test ei vaja megabaite
+    monkeypatch.setattr(mh, "PRERENDER_TEXT_MAX_BYTES", 200)
+    _write_page(path, "p1", 1, "A" * 300)
+    _write_page(path, "p2", 2, "B" * 300)
+    html = mh.build_meta_html("work001")
+    assert "Täistekst rakenduses" in html          # kärbe-märge olemas
+    assert "BBB" not in html                        # teine leht jäi välja
+    assert 'rel="canonical"' in html                # head-tagid alles (2MB sees)
+```
+
+- [ ] **Step 2: Run to verify it passes or fails**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py::test_oversized_work_truncated_with_note -v`
+Expected: PASS if Task 3 logic is correct. If FAIL, fix `_append_work_text` truncation logic until green (the truncation branch must `break` before appending the oversized segment and set `truncated = True`).
+
+- [ ] **Step 3: (Only if needed) fix `_append_work_text`**
+
+No change expected; if the test failed, correct the byte-accounting so the first over-limit segment is excluded and the note is appended.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_metadata_handler.py server/metadata_handler.py
+git commit -m "test: verify oversized-work prerender truncation guardrail"
+```
+
+---
+
+### Task 5: Sitemap `lastmod` reflects text edits
+
+**Files:**
+- Modify: `server/metadata_handler.py` (`build_sitemap_xml`)
+- Test: `tests/test_metadata_handler.py` (extend)
+
+**Interfaces:**
+- Consumes: `work_latest_mtime` (Task 2), `_sitemap_lastmod` (existing).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_metadata_handler.py`:
+
+```python
+def test_sitemap_lastmod_uses_page_mtime(tmp_path):
+    import os, json as _json, datetime
+    from server.metadata_handler import build_sitemap_xml
+    # Loo päris kaust, kus lehe .txt on UUEM kui _metadata.json mtime
+    d = tmp_path / "slug"
+    d.mkdir()
+    (d / "_metadata.json").write_text(_json.dumps({"id": "w1", "collections": []}), encoding="utf-8")
+    txt = d / "a.txt"
+    txt.write_text("tekst", encoding="utf-8")
+    new_ts = 1_800_000_000.0  # kaugel tulevikus, kindlasti > _metadata mtime
+    os.utime(str(txt), (new_ts, new_ts))
+
+    cache = {"w1": (str(d), os.path.getmtime(str(d / "_metadata.json")))}
+    xml = build_sitemap_xml(cache, lambda m: True, lambda wid: {"id": "w1", "collections": []})
+    expected = datetime.datetime.fromtimestamp(new_ts, datetime.timezone.utc).strftime("%Y-%m-%d")
+    assert expected in xml
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py::test_sitemap_lastmod_uses_page_mtime -v`
+Expected: FAIL (lastmod still from `_metadata.json` mtime, not the future page mtime).
+
+- [ ] **Step 3: Update `build_sitemap_xml`**
+
+Import at top of `metadata_handler.py` is already added (Task 3: `work_latest_mtime`). In `build_sitemap_xml`, replace:
+
+```python
+        lastmod = _sitemap_lastmod(mtime)
+```
+
+with:
+
+```python
+        # lastmod = max(_metadata.json, lehtede .txt/.json) → tekstimuudatus värskendab
+        latest = work_latest_mtime(path) or mtime
+        lastmod = _sitemap_lastmod(latest)
+```
+
+(`path` is already in scope in that loop.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py -v`
+Expected: PASS (new test + existing sitemap tests, which pass real `_metadata.json`-less tuple paths — note those use `/data/...` strings that don't exist on disk, so `work_latest_mtime` returns 0.0 and falls back to `mtime`, keeping them green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/metadata_handler.py tests/test_metadata_handler.py
+git commit -m "feat: sitemap lastmod reflects page-text edits"
+```
+
+---
+
+### Task 6: Cache work prerender HTML keyed on max-mtime
+
+**Files:**
+- Modify: `server/cache_invalidation.py` (add `_work_meta_cache`)
+- Modify: `server/metadata_handler.py` (add `cached_work_meta_html`)
+- Modify: `server/routers/public.py` (`work_meta` uses it on the public branch)
+- Test: `tests/test_metadata_handler.py` (extend)
+
+**Interfaces:**
+- Produces: `cached_work_meta_html(work_id: str, work_path: str, build_fn) -> str` — returns cached HTML when `work_latest_mtime(work_path)` is unchanged, else calls `build_fn()` and caches.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_metadata_handler.py`:
+
+```python
+def test_cached_work_meta_html_rebuilds_on_mtime_change(tmp_path):
+    import os
+    from server.metadata_handler import cached_work_meta_html
+    from server.cache_invalidation import _work_meta_cache
+    _work_meta_cache.clear()
+    d = tmp_path / "slug"
+    d.mkdir()
+    (d / "_metadata.json").write_text("{}", encoding="utf-8")
+    txt = d / "a.txt"
+    txt.write_text("v1", encoding="utf-8")
+
+    calls = {"n": 0}
+    def build():
+        calls["n"] += 1
+        return f"<html>{calls['n']}</html>"
+
+    h1 = cached_work_meta_html("w1", str(d), build)
+    h2 = cached_work_meta_html("w1", str(d), build)  # cache hit
+    assert h1 == h2
+    assert calls["n"] == 1
+
+    os.utime(str(txt), (2_000_000_000.0, 2_000_000_000.0))  # muudatus
+    h3 = cached_work_meta_html("w1", str(d), build)         # rebuild
+    assert calls["n"] == 2
+    assert h3 != h1
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py::test_cached_work_meta_html_rebuilds_on_mtime_change -v`
+Expected: FAIL (`_work_meta_cache` / `cached_work_meta_html` do not exist).
+
+- [ ] **Step 3: Add cache dict + helper**
+
+In `server/cache_invalidation.py`, add the dict and clear it:
+
+```python
+_sitemap_cache: dict = {"xml": None, "expires": 0.0}
+_home_cache: dict = {"html": None, "expires": 0.0}
+_work_meta_cache: dict = {}   # work_id -> (mtime_key: float, html: str)
+```
+
+In `invalidate_all_caches`, add:
+
+```python
+    _work_meta_cache.clear()
+```
+
+In `server/metadata_handler.py`, add:
+
+```python
+def cached_work_meta_html(work_id, work_path, build_fn):
+    """Tagastab bot-HTML-i cache'ist, kui teose max-mtime pole muutunud;
+    muidu kutsub build_fn() ja cache'ib. Võti = work_latest_mtime (Task 2):
+    max(_metadata.json, lehtede .txt/.json) → nii tekst- kui bibliograafiamuudatus
+    värskendab. Vt [[project_seo_bot_prerender]]."""
+    from .cache_invalidation import _work_meta_cache
+    key = work_latest_mtime(work_path)
+    cached = _work_meta_cache.get(work_id)
+    if cached is not None and cached[0] == key:
+        return cached[1]
+    html = build_fn()
+    _work_meta_cache[work_id] = (key, html)
+    return html
+```
+
+- [ ] **Step 4: Wire into the endpoint**
+
+In `server/routers/public.py`, add imports near the top:
+
+```python
+from ..metadata_handler import find_directory_by_id, cached_work_meta_html
+```
+
+In `work_meta` (currently `server/routers/public.py:270-283`), replace the final build lines:
+
+```python
+    # Loojate isikukaardid ristviidete jaoks (linkgraaf teos↔isik)
+    creator_persons = get_persons_for_work(work_id)
+    return HTMLResponse(content=build_meta_html(work_id, creator_persons=creator_persons))
+```
+
+with:
+
+```python
+    found_path = find_directory_by_id(work_id)
+    if found_path and meta is not None:
+        # Avalik/lubatud teos → cache mtime-võtmega
+        html = cached_work_meta_html(
+            work_id,
+            found_path,
+            lambda: build_meta_html(work_id, creator_persons=get_persons_for_work(work_id)),
+        )
+        return HTMLResponse(content=html)
+    # Tundmatu teos → fallback HTML (odav, ei cache'i)
+    return HTMLResponse(content=build_meta_html(work_id, creator_persons=get_persons_for_work(work_id)))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_metadata_handler.py tests/test_bot_link_graph.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/cache_invalidation.py server/metadata_handler.py server/routers/public.py tests/test_metadata_handler.py
+git commit -m "feat: cache work prerender HTML keyed on max page/metadata mtime"
+```
+
+---
+
+### Task 7: robots.txt AI-bot policy
+
+**Files:**
+- Modify: `public/robots.txt`
+- Test: `tests/test_robots_txt.py` (new)
+
+**Interfaces:** none (static file + content assertions).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_robots_txt.py`:
+
+```python
+# tests/test_robots_txt.py
+import os
+
+ROBOTS = os.path.join(os.path.dirname(__file__), "..", "public", "robots.txt")
+
+
+def _read():
+    with open(ROBOTS, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_blocks_training_bots():
+    txt = _read()
+    for ua in ["GPTBot", "Google-Extended", "CCBot", "ClaudeBot", "anthropic-ai", "Bytespider"]:
+        assert f"User-agent: {ua}" in txt, ua
+
+
+def test_does_not_block_search_referral_bots():
+    txt = _read()
+    # Need EI TOHI olla eraldi Disallow-grupis
+    for ua in ["OAI-SearchBot", "PerplexityBot", "Perplexity-User", "FirecrawlAgent"]:
+        assert f"User-agent: {ua}" not in txt, ua
+
+
+def test_keeps_sitemap_and_wildcard_group():
+    txt = _read()
+    assert "Sitemap: https://vutt.utlib.ut.ee/sitemap.xml" in txt
+    assert "User-agent: *" in txt
+    # Googlebot/Bingbot ei tohi olla üheski Disallow: / grupis
+    assert "\nUser-agent: Googlebot\nDisallow: /" not in txt
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/python -m pytest tests/test_robots_txt.py -v`
+Expected: FAIL (`test_blocks_training_bots` — no GPTBot group yet).
+
+- [ ] **Step 3: Edit `public/robots.txt`**
+
+Insert the AI-training block **before** the `Sitemap:` line, keeping the existing `User-agent: *` group intact. Comments on their own lines:
+
+```
+# --- AI training / ingestion opt-out (review quarterly) ---
+
+# OpenAI model-training crawler
+User-agent: GPTBot
+Disallow: /
+
+# Google product token for Gemini training/grounding opt-out.
+# Does not affect Google Search crawling or ranking.
+User-agent: Google-Extended
+Disallow: /
+
+# Common Crawl
+User-agent: CCBot
+Disallow: /
+
+# Anthropic
+User-agent: ClaudeBot
+Disallow: /
+User-agent: anthropic-ai
+Disallow: /
+
+# ByteDance
+User-agent: Bytespider
+Disallow: /
+
+# AI search / referral / agent-fetch bots are intentionally NOT blocked (allowed):
+# OAI-SearchBot, PerplexityBot, Perplexity-User, FirecrawlAgent.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/test_robots_txt.py -v`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add public/robots.txt tests/test_robots_txt.py
+git commit -m "feat: robots.txt blocks AI training bots, allows search/referral"
+```
+
+---
+
+### Task 8: Part D — monitoring docs + host-config snippets
+
+Host config (nginx, logrotate, GoAccess) lives on the server, not in git. This task produces a documented, repeatable setup and the exact server commands. No unit tests; verification is manual on the server.
+
+**Files:**
+- Create: `docs/monitoring-bot-traffic.md`
+
+- [ ] **Step 1: Write `docs/monitoring-bot-traffic.md`**
+
+```markdown
+# Bot/scraper liikluse jälgimine (Part D)
+
+Eesmärk: teha "luba esialgu, jälgi, klassifitseeri ümber" poliitika reaalseks.
+Praegu logib nginx HTML-lehed UA-ga (`vutt_access.log`), AGA `/api/images/` on
+`access_log off` → pildikraapimine on nähtamatu. Umami näeb ainult brausereid.
+Zabbix teeb uptime-kontrolli ja on tuleviku push-alertingu koht (D4, sügis 2026).
+
+## D1 — Logi pildipäringud (eraldi fail)
+
+`/etc/nginx/sites-available/vutt`, `location /api/images/` blokis ASENDA
+`access_log off;` reaga:
+
+    access_log /var/log/nginx/vutt_images.log;
+
+Rakenda:
+
+    sudo nginx -t && sudo systemctl reload nginx
+
+## D2 — Piira logi kasvu (KOHUSTUSLIK)
+
+Pildipäringuid on palju → ilma rotatsioonita täidab ketta.
+Loo `/etc/logrotate.d/vutt-images`:
+
+    /var/log/nginx/vutt_images.log {
+        daily
+        rotate 7
+        size 100M
+        compress
+        missingok
+        notifempty
+        create 0640 www-data adm
+        sharedscripts
+        postrotate
+            [ -f /var/run/nginx.pid ] && kill -USR1 `cat /var/run/nginx.pid`
+        endscript
+    }
+
+Testi: `sudo logrotate -d /etc/logrotate.d/vutt-images` (dry-run).
+
+## Privaatsus / säilitus
+
+Pildi- ja lehelogid sisaldavad IP + User-Agent. Hoia säilitus LÜHIKE (7 rotatsiooni
+ülal), ligipääs ADMIN-only, kasutus PIIRATUD väärkasutuse/koormuse jälgimisega —
+mitte analüütika ega profileerimine.
+
+## D3 — GoAccess raport + ülevaatuse rütm
+
+Paigalda: `sudo apt-get install goaccess`
+
+Genereeri staatiline HTML-raport (cron, nt iga öö):
+
+    goaccess /var/log/nginx/vutt_access.log /var/log/nginx/vutt_images.log \
+      --log-format=COMBINED -o /root/vutt-goaccess/report.html
+
+RAPORT EI TOHI LEKKIDA (sisaldab IP/UA): hoia väljaspool web-rooti, `chmod 600`,
+vaata AINULT SSH-tunneli või nginx basic-auth kaudu — MITTE avalik URL.
+
+Cron (`sudo crontab -e`):
+
+    15 3 * * * goaccess /var/log/nginx/vutt_access.log /var/log/nginx/vutt_images.log --log-format=COMBINED -o /root/vutt-goaccess/report.html 2>/dev/null
+
+Ülevaatuse rütm: kord nädalas vaata top UA-d/IP-d. Tegutse, kui üks UA/IP domineerib
+pildimahtu või kogub palju 429-sid → see on trigger Firecrawl / PerplexityBot /
+OAI-SearchBot ümberklassifitseerimiseks (vt robots.txt Task 7).
+
+## D4 — Zabbix alerting (EDASI LÜKATUD → sügis 2026)
+
+Ülikooli Zabbix juba pingib saiti. Ideaal: push-alertid request-rate / bandwidth /
+429 piikidele. Ootab IT-d (suvepuhkused). Vahepeal katab GoAccess + logid.
+
+## Verifitseerimine (pärast D1)
+
+    # Botina päring lehele (peab endiselt töötama)
+    curl -s -A "Googlebot" https://vutt.utlib.ut.ee/work/<id> | grep -c data-page
+    # Pildipäring peab nüüd logisse ilmuma
+    curl -s -A "TestBot" https://vutt.utlib.ut.ee/api/images/<id>/_thumb -o /dev/null
+    sudo tail -n 5 /var/log/nginx/vutt_images.log
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/monitoring-bot-traffic.md
+git commit -m "docs: Part D bot-traffic monitoring (image log, logrotate, GoAccess)"
+```
+
+- [ ] **Step 3 (server, manual — during rollout, not in this session):**
+
+Apply D1 + D2 on the server per the doc, `sudo nginx -t && sudo systemctl reload nginx`, then run the verification block. Install GoAccess + cron (D3). Zabbix (D4) deferred.
+
+---
+
+## Rollout (after all tasks pass locally)
+
+1. **Full test sweep:** `.venv/bin/python -m pytest tests/ -q` — expect all pass.
+2. **Backend (Tasks 1-6):** on server — `git pull && docker compose build --no-cache backend && docker compose up -d backend`.
+3. **robots.txt (Task 7):** `npm run build` locally + `rsync -avz dist/ vutt:~/VUTT/dist/` (build copies `public/robots.txt` → `dist/`).
+4. **Monitoring (Task 8):** apply `docs/monitoring-bot-traffic.md` D1+D2+D3 on the server; D4 deferred to autumn.
+5. **Verify on server:** `curl -s -A "Googlebot" https://vutt.utlib.ut.ee/work/<public-id> | grep -c data-page` (>0); confirm a restricted work still returns 403; `curl https://vutt.utlib.ut.ee/robots.txt | grep GPTBot`.
+6. **Search Console:** request re-indexing for a sample of affected `/work/{id}` URLs. Monitor "Crawled – currently not indexed" and impressions over subsequent weeks (not guaranteed, discretionary).
+
+---
+
+## Self-Review notes (coverage)
+
+- Spec Part A (full text, main+marginalia, per-page, cache incl. `_metadata.json` mtime, size guardrail, no-cloaking, neutral module, access gating) → Tasks 2,3,4,6 (gating unchanged: endpoint still 403s restricted works before caching).
+- Spec Part B (sitemap lastmod = max mtime; 1h TTL already bounds staleness) → Task 5 (TTL unchanged, already 3600s).
+- Spec Part C (robots.txt block training, allow search/referral incl. Firecrawl/Perplexity-User; separate comment lines; group non-inheritance) → Task 7.
+- Spec Part D (image logging, size-bounded rotation, GoAccess private report, privacy/retention, review cadence, Zabbix deferred) → Task 8.
+```

--- a/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
+++ b/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
@@ -1,0 +1,171 @@
+# Prerender full-text for SEO discoverability + AI-bot policy
+
+**Date:** 2026-07-03
+**Status:** Design (approved for spec review)
+
+## Problem
+
+Google Search Console reports ~1,660 `/work/{id}` and `/persons/{id}` pages as
+**"Crawled – currently not indexed"** (only ~437 indexed). Diagnosis: the pages are
+technically fine (correct self-referencing canonicals — verified), but the bot-facing
+prerendered HTML (`build_meta_html`) contains **only bibliographic metadata** (title,
+creators, year, place, publisher, archive refs). ~2,000 work pages therefore look
+**thin and structurally near-identical** to Google's quality layer → crawled but not
+indexed.
+
+The actual mission problem is the mirror image: **nobody knows the corpus exists.** The
+material is substantial but undiscoverable because the unique content — the transcribed
+text itself — is never exposed to search engines.
+
+(Separately, the "Alternative page with proper canonical tag" report is a single page,
+`/stats`, canonicalizing to `/` by design — intentional, not addressed here.)
+
+## Goal
+
+Expose each work's full transcribed text in the bot-facing prerender so search engines
+can index the corpus by its actual words — **while not inviting AI-training scrapers to
+hammer the server**, particularly the scanned page images (the expensive, scrape-attractive
+asset; the concern that drives peers like Uppsala to deploy Anubis).
+
+## Constraints & context
+
+- **Moving target:** transcriptions are edited continuously. Whatever is exposed must
+  stay current at crawl time, and edits must (eventually) prompt Google to re-crawl.
+- **Whole-work pages, not per-page URLs.** ~20k page-level URLs would balloon the sitemap
+  and crawl surface for negligible benefit. One rich page per work.
+- **AI-bot blocking is non-trivial and partly futile via robots.txt.** Compliant bots
+  (GPTBot, Google-Extended, CCBot, ClaudeBot) honor it; the aggressive/unlabeled scrapers
+  ignore it and spoof UAs. Genuine enforcement (Cloudflare AI Labyrinth, Anubis PoW) is a
+  separate, heavy project — explicitly out of scope.
+- Text is cheap bandwidth; **images are the load risk.** Image protection must be
+  UA-agnostic (rate-limit), not reliant on bot cooperation.
+
+## What each protection layer actually buys us (honest accounting)
+
+| Layer | Stops | Doesn't stop | Cost | Status |
+|---|---|---|---|---|
+| robots.txt AI rules | Compliant AI bots | Anything ignoring it | Free | **New (this work)** |
+| Image rate-limit (per-IP, nginx) | Bulk image download load — UA-agnostic | Distributed/rotating-IP scrapers | Low | **Already deployed** |
+| Anubis / Cloudflare PoW | Almost everything | — | High infra | Deferred (future project) |
+
+The rate-limit is the real teeth because it doesn't care whether a bot identifies itself.
+robots.txt is free politeness that catches the well-behaved AI crawlers. That's the honest
+baseline; true AI-proofing is named but not attempted here.
+
+## Design
+
+### Part A — Full work text in the prerender  *(substantive; in git)*
+
+**Where:** `build_meta_html(work_id, ...)` in `server/metadata_handler.py`, served to bots
+via `GET /meta/work/{work_id}` (`server/routers/public.py`).
+
+**Text source (reuse the indexer's path):** the Meilisearch indexer already reads page
+text authoritatively at `server/meili_doc.py:~640-683` — enumerate the work's page images
+in sorted order, read `data/{slug}/{base}.txt` (fallback to page `.json` `text_content`
+when the `.txt` is missing/empty). Factor this enumeration+read into a small shared helper
+(e.g. `read_work_page_texts(work_path) -> list[(page_num, raw_text)]`) so the prerender and
+the indexer stay consistent and don't drift.
+
+**Cleaning:** run each page's raw text through the existing `clean_text_for_search()`
+(`server/meili_doc.py:60`) — joins line-end hyphens, strips all VUTT XML/markdown markup →
+readable prose. Include **main text + marginalia**: use `_clean_search_text(page_text)`
+(`meili_doc.py:93`) which returns `(main_clean, marginalia_clean)`; render main text as the
+body and append cleaned marginalia in a labeled section (e.g. `<h2>Ääremärkused</h2>`), so
+both are indexable and distinguishable.
+
+**Rendering:** append the concatenated per-page prose into the existing `<body>` of
+`build_meta_html`, after the current bibliographic block and before the nav back-links.
+Keep everything else (canonical, OG/DC tags, cross-links) unchanged. Escape via the
+existing `_escape` helper.
+
+**Moving target → live but cheap (caching):** the endpoint already rebuilds fresh per
+request, so text is current at crawl time. To avoid re-reading/cleaning N page files on
+every crawl, add a **per-work HTML cache keyed on the max mtime of the work's page files**
+(`.txt`, falling back to page `.json`). Edit any page → key changes → next crawl rebuilds;
+otherwise serve cached HTML. This mirrors the existing `_home_cache` pattern in
+`public.py`. Cache entry: `{work_id: (max_mtime, html)}`; invalidate implicitly by key
+mismatch.
+
+**Access gating:** unchanged — honor `is_work_public` / `can_read_work`. Restricted works
+get **no text** (as today; `work_meta` already returns 403 for unauthorized).
+
+### Part B — Sitemap `lastmod` reflects text edits  *(small; in git)*
+
+**Where:** `build_sitemap_xml()` in `server/metadata_handler.py:426`.
+
+Today work `lastmod` = `_metadata.json` mtime, which **does not change when page text is
+edited** → Google never learns to re-crawl edited transcriptions. Change work `lastmod` to
+`max(page file mtimes, _metadata.json mtime)`. Reuse the same page-enumeration helper from
+Part A (bounded cost; sitemap is already cached in `_sitemap_cache`). Person `lastmod`
+(from `updated_at`) is unchanged.
+
+### Part C — robots.txt AI-bot rules  *(tiny; in git)*
+
+**Where:** `public/robots.txt` (built into `dist/`, served static by nginx).
+
+Add explicit blocks for known AI-training crawlers, keeping search engines fully allowed:
+
+```
+User-agent: GPTBot
+Disallow: /
+User-agent: Google-Extended
+Disallow: /
+User-agent: CCBot
+Disallow: /
+User-agent: ClaudeBot
+Disallow: /
+User-agent: anthropic-ai
+Disallow: /
+User-agent: Bytespider
+Disallow: /
+User-agent: PerplexityBot
+Disallow: /
+# (extendable; list needs occasional maintenance)
+```
+
+Retain the existing `User-agent: *` rules (which already `Disallow: /api/`, covering images
+for compliant bots) and the `Sitemap:` line.
+
+**Image load protection is already handled** by the deployed nginx rate-limit
+(`/api/images/` → `zone=vutt_api`, 10 r/s per IP, burst 50; `nginx.conf:64`). No code change.
+
+## Explicitly out of scope / deferred
+
+- **Tightening the image rate-limit.** 10 r/s per IP caps runaway load but a patient single
+  IP could still drain ~20k images in ~30 min. Decision: **leave as-is for now, monitor.**
+  If traffic/abuse grows, tighten via a stricter image-specific nginx zone (e.g. 2–4 r/s)
+  and/or `limit_conn` per IP — a one-line host-config change, not git, reversible.
+- **Anubis / Cloudflare-tier bot challenge.** Separate future project if scrapers become a
+  real problem despite the above.
+- **Per-page URLs / anchors.** Rejected — whole-work pages only.
+- **`/stats` canonical report.** Intentional behavior; no change.
+
+## Testing
+
+- **Unit:** shared page-text helper returns pages in order with `.txt`-authoritative /
+  `.json`-fallback behavior; `build_meta_html` output contains cleaned main text +
+  marginalia section for a public work, and omits text for a restricted work; cache key =
+  max page mtime and a changed mtime forces a rebuild.
+- **Sitemap:** `lastmod` for a work reflects a page-file mtime newer than `_metadata.json`.
+- **robots.txt:** served content includes the AI-bot blocks and retains `Sitemap:` +
+  existing `*` rules.
+- **Manual (server):** fetch `/meta/work/{id}` with a Googlebot UA and confirm full text is
+  present; confirm a restricted work still 403s; re-run seed/reindex unaffected.
+
+## Rollout
+
+- Backend change (Parts A, B): `git pull && docker compose build --no-cache backend &&
+  docker compose up -d backend`.
+- robots.txt (Part C): ships in frontend build → `npm run build` + `rsync -avz dist/ vutt:~/VUTT/dist/`.
+- After deploy: request re-indexing / validation in Search Console for a sample of the
+  affected `/work/{id}` URLs; expect "Crawled – currently not indexed" to shrink over
+  subsequent weeks as pages carry unique substantive content.
+
+## Success criteria
+
+- Bot-facing `/work/{id}` pages contain the full cleaned transcription (main + marginalia).
+- Editing a transcription bumps that work's sitemap `lastmod`.
+- robots.txt blocks the named AI crawlers while allowing Googlebot/Bingbot.
+- No regression to browser SPA behavior, access gating, or existing indexing pipeline.
+- Over weeks: measurable rise in "Indexed" count and appearance of corpus text in Google
+  results.

--- a/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
+++ b/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
@@ -158,12 +158,28 @@ User-agent: anthropic-ai
 Disallow: /
 User-agent: Bytespider      # ByteDance
 Disallow: /
-User-agent: PerplexityBot   # POLICY CHOICE — see note below
-Disallow: /
+# NOTE: AI search / referral / agent-fetch bots are intentionally NOT blocked
+# (allowed): OAI-SearchBot, PerplexityBot, FirecrawlAgent. See "Allowed" note below.
 ```
 
 Retain the existing `User-agent: *` rules (which already `Disallow: /api/`, covering images
 for compliant bots) and the `Sitemap:` line.
+
+**Intentionally allowed — AI search / referral / agent-fetch bots.** Consistent with the
+goal (be *discoverable*, including via AI intermediaries that send readers to the corpus),
+the following are **not** blocked:
+- **`OAI-SearchBot`** — ChatGPT-search visibility (distinct from GPTBot training). Left
+  allowed so ChatGPT-search can surface and link the corpus.
+- **`PerplexityBot`** — officially a search/indexing crawler ("not used to crawl content
+  for AI foundation models"); blocking it would only cost Perplexity-answer/referral
+  visibility. Allowed.
+- **`FirecrawlAgent`** — Firecrawl's crawler (respects robots.txt by default). It is
+  **multi-tenant**: one crawler serves all Firecrawl customers, so blocking it would cut
+  off every downstream agent/app at once — including legitimate on-demand fetches a user
+  triggered. It is a dual-use *fetch layer*, not a training-corpus builder, so it is
+  grouped with search/referral, not with GPTBot/CCBot. Allowed initially; **monitor access
+  logs for `FirecrawlAgent` volume** and block only if a single actor bulk-scrapes the
+  corpus. The nginx image rate-limit is the load backstop regardless.
 
 **Wording precision (important):**
 - **`Google-Extended`** is not a separate crawler UA. Google crawls with its normal UAs;
@@ -172,23 +188,21 @@ for compliant bots) and the `Sitemap:` line.
   Search**. Frame it as "opt out of Google-Extended uses while leaving Google Search
   crawling allowed" — not "block the Google-Extended crawler".
 - **`GPTBot` vs `OAI-SearchBot`:** OpenAI distinguishes `GPTBot` (training opt-out) from
-  `OAI-SearchBot` (ChatGPT-search visibility); they can be allowed/blocked independently. We
-  block `GPTBot` (training) and, by default, leave `OAI-SearchBot` unlisted (i.e. allowed)
-  so ChatGPT-search referrals remain possible — flag this as a reviewable choice.
-- **`PerplexityBot` is a policy choice, not the same category.** Perplexity documents
-  `PerplexityBot` as a **search/indexing** crawler "not used to crawl content for AI
-  foundation models," and recommends allowing it for visibility in Perplexity answers.
-  Blocking it therefore trades away Perplexity-answer/referral visibility. It is included
-  here only as a conservative "AI-mediated use is not a priority" stance (and amid reports
-  of stealth crawling). **Decision needed:** keep the block, or allow it for referral
-  visibility.
+  `OAI-SearchBot` (ChatGPT-search visibility); they can be allowed/blocked independently.
+  **Decision:** block `GPTBot` (training), allow `OAI-SearchBot` (referral visibility).
+
+**Decided policy (this iteration):** block **training/ingestion** bots only; allow all
+**AI search / referral / agent-fetch** bots. Revisit per the maintenance note if load/abuse
+appears.
 
 **Maintenance note (mechanism, not just a comment):** review this crawler list ~quarterly.
 Keep two conceptual buckets explicit and decide them separately: (1) **training/ingestion
-bots** (GPTBot, Google-Extended, CCBot, Bytespider) — block; (2) **AI search/referral bots**
-(OAI-SearchBot, PerplexityBot) — a visibility trade-off, not automatically blocked. Note
-that CCBot/ClaudeBot tokens are vendor-documented but UA spoofing is common, so robots.txt
-remains advisory (the nginx rate-limit is the UA-agnostic backstop).
+bots** (GPTBot, Google-Extended, CCBot, ClaudeBot, anthropic-ai, Bytespider) — block;
+(2) **AI search / referral / agent-fetch bots** (OAI-SearchBot, PerplexityBot,
+FirecrawlAgent) — allowed, a visibility trade-off; watch access logs and reclassify if one
+starts driving bulk load. Note that vendor tokens are documented but UA spoofing is common
+and Firecrawl is multi-tenant, so robots.txt remains advisory (the nginx rate-limit is the
+UA-agnostic backstop).
 
 **Image load protection is already handled** by the deployed nginx rate-limit
 (`/api/images/` → `zone=vutt_api`, 10 r/s per IP, burst 50; `nginx.conf:64`). No code change.
@@ -235,7 +249,9 @@ remains advisory (the nginx rate-limit is the UA-agnostic backstop).
 
 - Bot-facing `/work/{id}` pages contain the full cleaned transcription (main + marginalia).
 - Editing a transcription bumps that work's sitemap `lastmod`.
-- robots.txt blocks the named AI crawlers while allowing Googlebot/Bingbot.
+- robots.txt blocks the named AI training/ingestion crawlers while allowing Googlebot/
+  Bingbot and the AI search/referral/agent-fetch bots (OAI-SearchBot, PerplexityBot,
+  FirecrawlAgent).
 - No regression to browser SPA behavior, access gating, or existing indexing pipeline.
 - Over weeks: measurable rise in "Indexed" count and appearance of corpus text in Google
   results.

--- a/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
+++ b/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
@@ -59,32 +59,64 @@ baseline; true AI-proofing is named but not attempted here.
 **Where:** `build_meta_html(work_id, ...)` in `server/metadata_handler.py`, served to bots
 via `GET /meta/work/{work_id}` (`server/routers/public.py`).
 
+**Extract pure text helpers to a neutral module (avoid heavy import).** Do **not** import
+the full Meilisearch indexing module into `metadata_handler.py` — it risks cyclic/heavy
+imports and indexing side-effects. Move the pure text functions `split_marginalia`
+(`meili_doc.py:41`), `clean_text_for_search` (`:60`), `_clean_search_text` (`:93`), and the
+new `read_work_page_texts` into a small neutral module (e.g. `server/text_reading.py`).
+`meili_doc.py` and `metadata_handler.py` both import from there (keep back-compat re-exports
+in `meili_doc.py` if anything imports them by that path).
+
 **Text source (reuse the indexer's path):** the Meilisearch indexer already reads page
 text authoritatively at `server/meili_doc.py:~640-683` — enumerate the work's page images
 in sorted order, read `data/{slug}/{base}.txt` (fallback to page `.json` `text_content`
-when the `.txt` is missing/empty). Factor this enumeration+read into a small shared helper
-(e.g. `read_work_page_texts(work_path) -> list[(page_num, raw_text)]`) so the prerender and
-the indexer stay consistent and don't drift.
+when the `.txt` is missing/empty). Factor this enumeration+read into the shared helper
+`read_work_page_texts(work_path) -> list[(page_num, raw_text)]` so the prerender and the
+indexer stay consistent and don't drift.
 
-**Cleaning:** run each page's raw text through the existing `clean_text_for_search()`
-(`server/meili_doc.py:60`) — joins line-end hyphens, strips all VUTT XML/markdown markup →
-readable prose. Include **main text + marginalia**: use `_clean_search_text(page_text)`
-(`meili_doc.py:93`) which returns `(main_clean, marginalia_clean)`; render main text as the
-body and append cleaned marginalia in a labeled section (e.g. `<h2>Ääremärkused</h2>`), so
-both are indexable and distinguishable.
+**Cleaning:** run each page's raw text through `clean_text_for_search()` — joins line-end
+hyphens, strips all VUTT XML/markdown markup → readable prose. Include **main text +
+marginalia** via `_clean_search_text(page_text)` which returns `(main_clean, marginalia_clean)`.
 
-**Rendering:** append the concatenated per-page prose into the existing `<body>` of
-`build_meta_html`, after the current bibliographic block and before the nav back-links.
-Keep everything else (canonical, OG/DC tags, cross-links) unchanged. Escape via the
-existing `_escape` helper.
+**Rendering (preserve page context):** render **per page**, not one flat blob, so page
+context survives for both indexing and debugging. Append after the bibliographic block and
+before the nav back-links, e.g.:
+
+```html
+<section data-page="12">
+  <p>… cleaned main text of page 12 …</p>
+  <p class="marginalia"><em>Ääremärkused:</em> … cleaned marginalia …</p>
+</section>
+```
+
+Use a lightweight per-page wrapper (`<section data-page="N">`), not an `<h2>` per page
+(noisy in large works). Keep everything else (canonical, OG/DC tags, cross-links)
+unchanged. Escape via the existing `_escape` helper.
+
+**Not cloaking — same public content the user sees.** The prerender contains the **same
+public transcription that is available to the user in the SPA** — no SEO-only hidden text.
+This keeps dynamic rendering within Google's acceptable use (equivalence of bot and user
+content) and avoids any cloaking concern.
 
 **Moving target → live but cheap (caching):** the endpoint already rebuilds fresh per
 request, so text is current at crawl time. To avoid re-reading/cleaning N page files on
-every crawl, add a **per-work HTML cache keyed on the max mtime of the work's page files**
-(`.txt`, falling back to page `.json`). Edit any page → key changes → next crawl rebuilds;
-otherwise serve cached HTML. This mirrors the existing `_home_cache` pattern in
-`public.py`. Cache entry: `{work_id: (max_mtime, html)}`; invalidate implicitly by key
-mismatch.
+every crawl, add a **per-work HTML cache** keyed on
+`max(_metadata.json mtime, all page .txt/.json mtimes considered by the reader)`. The
+`_metadata.json` mtime is **required** in the key — otherwise a bibliographic-only edit
+(title/author/year/publisher) would leave the bot-facing HTML stale. Any change → key
+changes → next crawl rebuilds; otherwise serve cached HTML. Mirrors the existing
+`_home_cache` pattern in `public.py`. Cache entry: `{work_id: (cache_key, html)}`;
+invalidate implicitly by key mismatch.
+
+**Large-work guardrail (size):** log the rendered HTML byte size per work in debug/manual
+mode and emit a warning when uncompressed HTML exceeds a conservative threshold
+(~1.5–1.8 MB). Rationale: Google documents a **15 MB per-file fetch cap** for Googlebot,
+and very large / text-diluted pages tend to index less reliably; the exact "effective text
+budget" is not officially specified, so treat this as a monitoring signal, not a hard rule.
+Most works are far below this, but a decision is pre-registered for the rare oversized work:
+**accept truncation** (cap at N pages / M bytes with a "full text in app" note) rather than
+silently emit multi-MB HTML. "Full text" is therefore best-effort for exceptionally large
+works — this does **not** imply per-page URLs.
 
 **Access gating:** unchanged — honor `is_work_public` / `can_read_work`. Restricted works
 get **no text** (as today; `work_meta` already returns 403 for unauthorized).
@@ -99,32 +131,64 @@ edited** → Google never learns to re-crawl edited transcriptions. Change work 
 Part A (bounded cost; sitemap is already cached in `_sitemap_cache`). Person `lastmod`
 (from `updated_at`) is unchanged.
 
+**`lastmod` is a hint, not a guarantee.** Google treats sitemap `lastmod` and submission as
+signals, not commitments; "Crawled – currently not indexed" explicitly means Google has
+seen the page and may still choose not to index it. This change removes a real blocker (no
+freshness signal at all today) but does not guarantee re-crawl or indexing.
+
 ### Part C — robots.txt AI-bot rules  *(tiny; in git)*
 
 **Where:** `public/robots.txt` (built into `dist/`, served static by nginx).
 
-Add explicit blocks for known AI-training crawlers, keeping search engines fully allowed:
+Add robots.txt tokens that opt out of known AI-training / AI-ingestion crawlers, keeping
+search engines fully allowed. These are **robots.txt product tokens**, not necessarily
+distinct HTTP User-Agents:
 
 ```
-User-agent: GPTBot
+# --- AI training / ingestion opt-out (see maintenance note) ---
+User-agent: GPTBot          # OpenAI model-training crawler
 Disallow: /
-User-agent: Google-Extended
+User-agent: Google-Extended # robots.txt token: opts out of Gemini training/grounding
+Disallow: /                 #   — does NOT affect Google Search crawling or ranking
+User-agent: CCBot           # Common Crawl
 Disallow: /
-User-agent: CCBot
-Disallow: /
-User-agent: ClaudeBot
+User-agent: ClaudeBot       # Anthropic
 Disallow: /
 User-agent: anthropic-ai
 Disallow: /
-User-agent: Bytespider
+User-agent: Bytespider      # ByteDance
 Disallow: /
-User-agent: PerplexityBot
+User-agent: PerplexityBot   # POLICY CHOICE — see note below
 Disallow: /
-# (extendable; list needs occasional maintenance)
 ```
 
 Retain the existing `User-agent: *` rules (which already `Disallow: /api/`, covering images
 for compliant bots) and the `Sitemap:` line.
+
+**Wording precision (important):**
+- **`Google-Extended`** is not a separate crawler UA. Google crawls with its normal UAs;
+  this token only opts the site out of Google using crawled content for **Gemini training
+  and grounding**, and Google states it **does not affect inclusion or ranking in Google
+  Search**. Frame it as "opt out of Google-Extended uses while leaving Google Search
+  crawling allowed" — not "block the Google-Extended crawler".
+- **`GPTBot` vs `OAI-SearchBot`:** OpenAI distinguishes `GPTBot` (training opt-out) from
+  `OAI-SearchBot` (ChatGPT-search visibility); they can be allowed/blocked independently. We
+  block `GPTBot` (training) and, by default, leave `OAI-SearchBot` unlisted (i.e. allowed)
+  so ChatGPT-search referrals remain possible — flag this as a reviewable choice.
+- **`PerplexityBot` is a policy choice, not the same category.** Perplexity documents
+  `PerplexityBot` as a **search/indexing** crawler "not used to crawl content for AI
+  foundation models," and recommends allowing it for visibility in Perplexity answers.
+  Blocking it therefore trades away Perplexity-answer/referral visibility. It is included
+  here only as a conservative "AI-mediated use is not a priority" stance (and amid reports
+  of stealth crawling). **Decision needed:** keep the block, or allow it for referral
+  visibility.
+
+**Maintenance note (mechanism, not just a comment):** review this crawler list ~quarterly.
+Keep two conceptual buckets explicit and decide them separately: (1) **training/ingestion
+bots** (GPTBot, Google-Extended, CCBot, Bytespider) — block; (2) **AI search/referral bots**
+(OAI-SearchBot, PerplexityBot) — a visibility trade-off, not automatically blocked. Note
+that CCBot/ClaudeBot tokens are vendor-documented but UA spoofing is common, so robots.txt
+remains advisory (the nginx rate-limit is the UA-agnostic backstop).
 
 **Image load protection is already handled** by the deployed nginx rate-limit
 (`/api/images/` → `zone=vutt_api`, 10 r/s per IP, burst 50; `nginx.conf:64`). No code change.
@@ -142,10 +206,14 @@ for compliant bots) and the `Sitemap:` line.
 
 ## Testing
 
-- **Unit:** shared page-text helper returns pages in order with `.txt`-authoritative /
-  `.json`-fallback behavior; `build_meta_html` output contains cleaned main text +
-  marginalia section for a public work, and omits text for a restricted work; cache key =
-  max page mtime and a changed mtime forces a rebuild.
+- **Unit:** shared page-text helper (`read_work_page_texts`) returns pages in order with
+  `.txt`-authoritative / `.json`-fallback behavior; `build_meta_html` output contains
+  cleaned per-page main text in `<section data-page="N">` wrappers plus cleaned marginalia,
+  and omits text for a restricted work; cache key =
+  `max(_metadata.json mtime, page file mtimes)` — a changed **page** mtime *and* a changed
+  **`_metadata.json`** mtime each force a rebuild (guards the bibliographic-staleness case);
+  size-guardrail warning fires when rendered HTML exceeds the threshold, and the oversized
+  work is truncated per the pre-registered decision.
 - **Sitemap:** `lastmod` for a work reflects a page-file mtime newer than `_metadata.json`.
 - **robots.txt:** served content includes the AI-bot blocks and retains `Sitemap:` +
   existing `*` rules.
@@ -158,8 +226,10 @@ for compliant bots) and the `Sitemap:` line.
   docker compose up -d backend`.
 - robots.txt (Part C): ships in frontend build → `npm run build` + `rsync -avz dist/ vutt:~/VUTT/dist/`.
 - After deploy: request re-indexing / validation in Search Console for a sample of the
-  affected `/work/{id}` URLs; expect "Crawled – currently not indexed" to shrink over
-  subsequent weeks as pages carry unique substantive content.
+  affected `/work/{id}` URLs. "Crawled – currently not indexed" **may** shrink over
+  subsequent weeks as pages carry unique substantive content, but this is **not guaranteed**
+  — Google's crawl/index decisions are discretionary. Monitor impressions and indexed-count
+  over time rather than expecting an immediate change.
 
 ## Success criteria
 

--- a/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
+++ b/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
@@ -109,14 +109,19 @@ changes → next crawl rebuilds; otherwise serve cached HTML. Mirrors the existi
 invalidate implicitly by key mismatch.
 
 **Large-work guardrail (size):** log the rendered HTML byte size per work in debug/manual
-mode and emit a warning when uncompressed HTML exceeds a conservative threshold
-(~1.5–1.8 MB). Rationale: Google documents a **15 MB per-file fetch cap** for Googlebot,
-and very large / text-diluted pages tend to index less reliably; the exact "effective text
-budget" is not officially specified, so treat this as a monitoring signal, not a hard rule.
-Most works are far below this, but a decision is pre-registered for the rare oversized work:
-**accept truncation** (cap at N pages / M bytes with a "full text in app" note) rather than
-silently emit multi-MB HTML. "Full text" is therefore best-effort for exceptionally large
-works — this does **not** imply per-page URLs.
+mode and emit a warning when **uncompressed** HTML exceeds ~1.5–1.8 MB. Rationale: Google
+currently documents (Search Central, updated Feb 2026) that for Google Search **Googlebot
+crawls only the first 2 MB of supported text/HTML file types** and, once the limit is hit,
+stops fetching and sends only the already-downloaded part for indexing consideration
+(the separate 15 MB figure is the broader resource-download cap, not the HTML-indexing
+budget). So warn at ~1.5–1.8 MB and **deliberately truncate** oversized prerenders rather
+than emitting HTML Google may only partially use. A decision is pre-registered for the rare
+oversized work: **cap at N pages / M bytes with a visible "full text in app" note** rather
+than silently emit multi-MB HTML. "Full text" is therefore best-effort for exceptionally
+large works — this does **not** imply per-page URLs. (Context: the current largest work is
+706 pages ≈ 800 KB, comfortably under the limit — this guardrail is insurance, not a
+present constraint. The canonical/OG/title tags live in `<head>` at the top, so they are
+always within the 2 MB even if body text were truncated.)
 
 **Access gating:** unchanged — honor `is_work_public` / `can_read_work`. Restricted works
 get **no text** (as today; `work_meta` already returns 403 for unauthorized).
@@ -131,6 +136,14 @@ edited** → Google never learns to re-crawl edited transcriptions. Change work 
 Part A (bounded cost; sitemap is already cached in `_sitemap_cache`). Person `lastmod`
 (from `updated_at`) is unchanged.
 
+**Cache staleness decision.** The sitemap is served from `_sitemap_cache`, which today has
+a **1 h TTL** (`_sitemap_cache["expires"] = now + 3600`, `public.py:298`). So the improved
+`lastmod` propagates within ≤1 h of an edit — bounded, not stale-until-restart. That is
+acceptable given sitemaps are fetched infrequently; we keep the TTL rather than adding
+mtime-keying. **Decision:** optionally shorten the TTL to ~15 min if faster propagation is
+wanted, but 1 h is fine. (Explicitly noted so the improved lastmod isn't silently hidden
+behind an unbounded cache — it isn't.)
+
 **`lastmod` is a hint, not a guarantee.** Google treats sitemap `lastmod` and submission as
 signals, not commitments; "Crawled – currently not indexed" explicitly means Google has
 seen the page and may still choose not to index it. This change removes a real blocker (no
@@ -144,22 +157,37 @@ Add robots.txt tokens that opt out of known AI-training / AI-ingestion crawlers,
 search engines fully allowed. These are **robots.txt product tokens**, not necessarily
 distinct HTTP User-Agents:
 
+Comments go on their **own lines**, never inline after a directive value — some non-Google
+parsers mishandle `User-agent: GPTBot # ...`:
+
 ```
 # --- AI training / ingestion opt-out (see maintenance note) ---
-User-agent: GPTBot          # OpenAI model-training crawler
+
+# OpenAI model-training crawler
+User-agent: GPTBot
 Disallow: /
-User-agent: Google-Extended # robots.txt token: opts out of Gemini training/grounding
-Disallow: /                 #   — does NOT affect Google Search crawling or ranking
-User-agent: CCBot           # Common Crawl
+
+# Google product token for Gemini training/grounding opt-out.
+# Does not affect Google Search crawling or ranking.
+User-agent: Google-Extended
 Disallow: /
-User-agent: ClaudeBot       # Anthropic
+
+# Common Crawl
+User-agent: CCBot
+Disallow: /
+
+# Anthropic
+User-agent: ClaudeBot
 Disallow: /
 User-agent: anthropic-ai
 Disallow: /
-User-agent: Bytespider      # ByteDance
+
+# ByteDance
+User-agent: Bytespider
 Disallow: /
-# NOTE: AI search / referral / agent-fetch bots are intentionally NOT blocked
-# (allowed): OAI-SearchBot, PerplexityBot, FirecrawlAgent. See "Allowed" note below.
+
+# AI search / referral / agent-fetch bots are intentionally NOT blocked (allowed):
+# OAI-SearchBot, PerplexityBot, Perplexity-User, FirecrawlAgent. See "Allowed" note below.
 ```
 
 Retain the existing `User-agent: *` rules (which already `Disallow: /api/`, covering images
@@ -170,15 +198,18 @@ goal (be *discoverable*, including via AI intermediaries that send readers to th
 the following are **not** blocked:
 - **`OAI-SearchBot`** — ChatGPT-search visibility (distinct from GPTBot training). Left
   allowed so ChatGPT-search can surface and link the corpus.
-- **`PerplexityBot`** — officially a search/indexing crawler ("not used to crawl content
-  for AI foundation models"); blocking it would only cost Perplexity-answer/referral
-  visibility. Allowed.
-- **`FirecrawlAgent`** — Firecrawl's crawler (respects robots.txt by default). It is
-  **multi-tenant**: one crawler serves all Firecrawl customers, so blocking it would cut
-  off every downstream agent/app at once — including legitimate on-demand fetches a user
-  triggered. It is a dual-use *fetch layer*, not a training-corpus builder, so it is
-  grouped with search/referral, not with GPTBot/CCBot. Allowed initially; **monitor access
-  logs for `FirecrawlAgent` volume** and block only if a single actor bulk-scrapes the
+- **`PerplexityBot`** (and **`Perplexity-User`**) — Perplexity runs two agents:
+  `PerplexityBot` is a search/indexing crawler ("not used to crawl content for AI foundation
+  models"), and `Perplexity-User` performs **user-triggered** fetches. Both are allowed
+  (blocking would only cost Perplexity-answer/referral visibility); in logs, watch them as
+  **separate categories** — indexing vs. user-initiated retrieval.
+- **`FirecrawlAgent`** — Firecrawl's multi-tenant fetch/scrape layer; one crawler serves all
+  Firecrawl customers. It respects robots.txt **by default**, but Firecrawl also exposes an
+  enterprise `ignoreRobotsTxt` option and a customizable `robotsUserAgent`, so robots.txt
+  compliance is **not guaranteed**. It is allowed initially **not because it is inherently
+  harmless, but because blocking it would also block legitimate user-triggered retrieval**
+  across every downstream app at once. Treat it as **monitor-first, not trust-by-default**:
+  watch access logs for `FirecrawlAgent` volume and block if a single actor bulk-scrapes the
   corpus. The nginx image rate-limit is the load backstop regardless.
 
 **Wording precision (important):**
@@ -199,8 +230,9 @@ appears.
 Keep two conceptual buckets explicit and decide them separately: (1) **training/ingestion
 bots** (GPTBot, Google-Extended, CCBot, ClaudeBot, anthropic-ai, Bytespider) — block;
 (2) **AI search / referral / agent-fetch bots** (OAI-SearchBot, PerplexityBot,
-FirecrawlAgent) — allowed, a visibility trade-off; watch access logs and reclassify if one
-starts driving bulk load. Note that vendor tokens are documented but UA spoofing is common
+Perplexity-User, FirecrawlAgent) — allowed, a visibility trade-off; watch access logs
+(track indexing vs. user-triggered fetchers separately) and reclassify if one starts
+driving bulk load. Note that vendor tokens are documented but UA spoofing is common
 and Firecrawl is multi-tenant, so robots.txt remains advisory (the nginx rate-limit is the
 UA-agnostic backstop).
 
@@ -229,14 +261,21 @@ many thumbnails/page images), so the new log MUST have strict rotation: size-bas
 `vutt_access.log` rotation (currently ~14 daily gz rotations) stays sane. Goal: monitoring
 must never fill the disk.
 
+**Privacy / retention.** Because image (and page) logs contain **IP addresses and
+User-Agents**, keep retention **short**, access **admin-only**, and the data
+**purpose-limited** to abuse/load monitoring — not analytics or profiling. The short
+logrotate retention above doubles as the retention control.
+
 **D3 — GoAccess for aggregation + a real review habit.** Install GoAccess (no daemon/new
 service) and generate reports over `vutt_access.log` (page bots) and `vutt_images.log`
 (image scraping): top User-Agents, top IPs, request rates, status codes (incl. 429s).
-Produce a periodic **static HTML report via cron**, kept admin-private (e.g. behind the
-existing SSH-tunnel/private path), so review is a habit not ad-hoc `awk`. Define a light
-**review cadence**: weekly glance at top UAs/IPs; act if one UA/IP dominates image volume or
-trips many 429s (this is the trigger for reclassifying `FirecrawlAgent` / PerplexityBot /
-OAI-SearchBot per Part C's maintenance note).
+Produce a periodic **static HTML report via cron**. **The report must not leak** — it
+aggregates IPs/UAs, so it is itself sensitive: store it outside any web root, `chmod`
+admin-only, and expose it **only** via SSH tunnel or nginx Basic-Auth — **no public URL**.
+So review is a habit not ad-hoc `awk`. Define a light **review cadence**: weekly glance at
+top UAs/IPs; act if one UA/IP dominates image volume or trips many 429s (this is the trigger
+for reclassifying `FirecrawlAgent` / PerplexityBot / OAI-SearchBot per Part C's maintenance
+note).
 
 **D4 — Zabbix alerting (DEFERRED to autumn 2026).** Ideal end state is *push* alerts on
 request-rate / bandwidth / 429 spikes via the already-deployed Zabbix. Deferred pending
@@ -270,7 +309,13 @@ the GoAccess cron) in `docs/` or `scripts/` so the setup is documented and repea
   work is truncated per the pre-registered decision.
 - **Sitemap:** `lastmod` for a work reflects a page-file mtime newer than `_metadata.json`.
 - **robots.txt:** served content includes the AI-bot blocks and retains `Sitemap:` +
-  existing `*` rules.
+  existing `*` rules. **Group non-inheritance check:** a matching crawler uses only its own
+  most-specific `User-agent` group — specific groups do **not** inherit `User-agent: *`
+  rules. So (a) blocked bots (GPTBot etc.) are covered by their own `Disallow: /`
+  regardless of `*`, and (b) crucially, verify the `User-agent: *` group does **not**
+  contain anything that would restrict Googlebot/Bingbot from the `/work/` and `/persons/`
+  text pages (only `/api/`, `/search`, `/admin`, etc. as today). Confirm no allowed
+  search/referral bot is accidentally caught by a block group.
 - **Manual (server):** fetch `/meta/work/{id}` with a Googlebot UA and confirm full text is
   present; confirm a restricted work still 403s; re-run seed/reindex unaffected.
 
@@ -291,7 +336,9 @@ the GoAccess cron) in `docs/` or `scripts/` so the setup is documented and repea
 
 ## Success criteria
 
-- Bot-facing `/work/{id}` pages contain the full cleaned transcription (main + marginalia).
+- Bot-facing `/work/{id}` pages contain the full cleaned transcription (main + marginalia)
+  where safely below the HTML-size threshold; exceptionally large works are deliberately
+  capped with a visible "full text in app" note.
 - Editing a transcription bumps that work's sitemap `lastmod`.
 - robots.txt blocks the named AI training/ingestion crawlers while allowing Googlebot/
   Bingbot and the AI search/referral/agent-fetch bots (OAI-SearchBot, PerplexityBot,

--- a/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
+++ b/docs/superpowers/specs/2026-07-03-prerender-full-text-seo-design.md
@@ -207,6 +207,46 @@ UA-agnostic backstop).
 **Image load protection is already handled** by the deployed nginx rate-limit
 (`/api/images/` → `zone=vutt_api`, 10 r/s per IP, burst 50; `nginx.conf:64`). No code change.
 
+### Part D — Monitoring bot/scraper traffic  *(mostly host-config, not git)*
+
+The bot policy's "allow initially, monitor, reclassify" only works if traffic is actually
+visible. Current state (verified 2026-07-03): HTML-page hits **are** logged with User-Agent
+in `vutt_access.log` (default `combined` format), so page-level bots are greppable. But
+`/api/images/` has `access_log off` (site config line 159) → **image scraping — the real
+load concern — is invisible in logs today.** Umami (port 3000) only tracks browsers running
+its JS beacon → humans, not bots. The university's **Zabbix** already probes the site
+(uptime `HEAD /`) and is the natural home for push alerting later.
+
+**D1 — Log image requests (close the blind spot).** Replace `access_log off` in the
+`/api/images/` location with a **dedicated** log (e.g. `/var/log/nginx/vutt_images.log`) so
+image traffic is captured with UA/IP without polluting the main log. (Alternative: log only
+429s — rejected as primary because it misses high-volume 200s sitting just under the rate
+limit; the dedicated log + aggregation captures both.)
+
+**D2 — Bound log growth (REQUIRED).** Image requests are high-volume (normal browsing pulls
+many thumbnails/page images), so the new log MUST have strict rotation: size-based logrotate
+(e.g. rotate at ~100 MB or daily, keep ~7 rotations, `compress`). Also confirm the existing
+`vutt_access.log` rotation (currently ~14 daily gz rotations) stays sane. Goal: monitoring
+must never fill the disk.
+
+**D3 — GoAccess for aggregation + a real review habit.** Install GoAccess (no daemon/new
+service) and generate reports over `vutt_access.log` (page bots) and `vutt_images.log`
+(image scraping): top User-Agents, top IPs, request rates, status codes (incl. 429s).
+Produce a periodic **static HTML report via cron**, kept admin-private (e.g. behind the
+existing SSH-tunnel/private path), so review is a habit not ad-hoc `awk`. Define a light
+**review cadence**: weekly glance at top UAs/IPs; act if one UA/IP dominates image volume or
+trips many 429s (this is the trigger for reclassifying `FirecrawlAgent` / PerplexityBot /
+OAI-SearchBot per Part C's maintenance note).
+
+**D4 — Zabbix alerting (DEFERRED to autumn 2026).** Ideal end state is *push* alerts on
+request-rate / bandwidth / 429 spikes via the already-deployed Zabbix. Deferred pending
+university IT availability (holiday season). GoAccess + logs cover the interim; revisit in
+autumn.
+
+**Reproducibility:** since the nginx site config and logrotate live on the host (not in
+git), capture the applied snippets (the `/api/images/` logging diff, the logrotate file,
+the GoAccess cron) in `docs/` or `scripts/` so the setup is documented and repeatable.
+
 ## Explicitly out of scope / deferred
 
 - **Tightening the image rate-limit.** 10 r/s per IP caps runaway load but a patient single
@@ -239,6 +279,10 @@ UA-agnostic backstop).
 - Backend change (Parts A, B): `git pull && docker compose build --no-cache backend &&
   docker compose up -d backend`.
 - robots.txt (Part C): ships in frontend build → `npm run build` + `rsync -avz dist/ vutt:~/VUTT/dist/`.
+- Monitoring (Part D, host-config): edit the `/api/images/` location (dedicated log),
+  install the logrotate rule for it, `sudo nginx -t && sudo systemctl reload nginx`; install
+  GoAccess + cron report. Zabbix (D4) deferred to autumn. Commit the applied snippets to
+  `docs/`/`scripts/` for reproducibility.
 - After deploy: request re-indexing / validation in Search Console for a sample of the
   affected `/work/{id}` URLs. "Crawled – currently not indexed" **may** shrink over
   subsequent weeks as pages carry unique substantive content, but this is **not guaranteed**
@@ -253,5 +297,8 @@ UA-agnostic backstop).
   Bingbot and the AI search/referral/agent-fetch bots (OAI-SearchBot, PerplexityBot,
   FirecrawlAgent).
 - No regression to browser SPA behavior, access gating, or existing indexing pipeline.
+- Image requests are logged (with UA/IP) to a size-bounded dedicated log, and a GoAccess
+  report makes top UAs/IPs/status codes reviewable on a defined cadence — so the Part C
+  "monitor and reclassify" policy is actually actionable.
 - Over weeks: measurable rise in "Indexed" count and appearance of corpus text in Google
   results.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -14,4 +14,32 @@ Disallow: /statistics
 Disallow: /api/
 Disallow: /meili/
 
+# --- AI training / ingestion opt-out (review quarterly) ---
+
+# OpenAI model-training crawler
+User-agent: GPTBot
+Disallow: /
+
+# Google product token for Gemini training/grounding opt-out.
+# Does not affect Google Search crawling or ranking.
+User-agent: Google-Extended
+Disallow: /
+
+# Common Crawl
+User-agent: CCBot
+Disallow: /
+
+# Anthropic
+User-agent: ClaudeBot
+Disallow: /
+User-agent: anthropic-ai
+Disallow: /
+
+# ByteDance
+User-agent: Bytespider
+Disallow: /
+
+# AI search / referral / agent-fetch bots are intentionally NOT blocked (allowed):
+# OAI-SearchBot, PerplexityBot, Perplexity-User, FirecrawlAgent.
+
 Sitemap: https://vutt.utlib.ut.ee/sitemap.xml

--- a/server/cache_invalidation.py
+++ b/server/cache_invalidation.py
@@ -2,10 +2,12 @@ from .cache import invalidate_cache
 
 _sitemap_cache: dict = {"xml": None, "expires": 0.0}
 _home_cache: dict = {"html": None, "expires": 0.0}
+_work_meta_cache: dict = {}  # work_id -> (mtime_key: float, html: str)
 
 
 def invalidate_all_caches():
-    """Tühjendab kõik cache'id: kollektsioonid, soovitused, sitemap, bot-koduleht."""
+    """Tühjendab kõik cache'id: kollektsioonid, soovitused, sitemap ja bot-HTML."""
     invalidate_cache()
     _sitemap_cache["xml"] = None
     _home_cache["html"] = None
+    _work_meta_cache.clear()

--- a/server/meili_doc.py
+++ b/server/meili_doc.py
@@ -106,6 +106,32 @@ def _clean_search_text(page_text):
     return clean_text_for_search(main_text), clean_text_for_search(marginalia_text)
 
 
+
+
+def enumerate_page_images(doc_path):
+    """Loeb teose pildifailid järjekorras (sequence, siis failinimi).
+
+    Jätab välja `_thumb_` failid. ÜHINE loogika indekseerijale (build_work_documents)
+    ja bot-prerenderi teksti-lugejale (text_reading.read_work_page_texts) —
+    nii ei saa lehe-järjekord kahe tee vahel lahku minna.
+    """
+    def _seq(img_name):
+        jp = os.path.join(doc_path, os.path.splitext(img_name)[0] + '.json')
+        if os.path.exists(jp):
+            try:
+                with open(jp, 'r', encoding='utf-8') as fj:
+                    d = json.load(fj)
+                    s = d.get('sequence') or d.get('meta_content', {}).get('sequence')
+                    if s is not None:
+                        return int(s)
+            except Exception:
+                pass
+        return float('inf')
+
+    all_imgs = [f for f in os.listdir(doc_path)
+                if f.lower().endswith(('.jpg', '.jpeg', '.png')) and not f.startswith('_thumb_')]
+    return sorted(all_imgs, key=lambda f: (_seq(f), f))
+
 def build_text_annotations_text(text_annotations):
     """Koostab otsitava teksti text_annotations kommentaaridest.
 
@@ -564,22 +590,7 @@ def build_work_documents(doc_path, dir_name, collections, people_data, archives,
     """
     teose_id, doc_metadata = get_work_metadata(doc_path, dir_name, collections)
 
-    def _seq(img_name):
-        jp = os.path.join(doc_path, os.path.splitext(img_name)[0] + '.json')
-        if os.path.exists(jp):
-            try:
-                with open(jp, 'r', encoding='utf-8') as fj:
-                    d = json.load(fj)
-                    s = d.get('sequence') or d.get('meta_content', {}).get('sequence')
-                    if s is not None:
-                        return int(s)
-            except Exception:
-                pass
-        return float('inf')
-
-    all_imgs = [f for f in os.listdir(doc_path)
-                if f.lower().endswith(('.jpg', '.jpeg', '.png')) and not f.startswith('_thumb_')]
-    jpg_files = sorted(all_imgs, key=lambda f: (_seq(f), f))
+    jpg_files = enumerate_page_images(doc_path)
     if not jpg_files:
         return teose_id, []
 

--- a/server/metadata_handler.py
+++ b/server/metadata_handler.py
@@ -112,7 +112,9 @@ def _append_work_text(body_lines, found_path, work_url, work_id):
         if truncated:
             body_lines.append(f'<p><a href="{work_url}">Täistekst rakenduses</a></p>')
         body_lines.append('</div>')
-    if total >= PRERENDER_TEXT_WARN_BYTES:
+    # Hoiata ka siis kui KÄRBITI (üksik esimene leht võib ületada MAX-i enne
+    # kui total jõuab WARN-piirini → muidu jääks halvim juht signaalita).
+    if total >= PRERENDER_TEXT_WARN_BYTES or truncated:
         logger.warning(
             "Prerender HTML suur: work_id=%s text_bytes=%s truncated=%s",
             work_id, total, truncated,
@@ -130,7 +132,7 @@ def cached_work_meta_html(work_id, work_path, build_fn):
     _work_meta_cache[work_id] = (key, html)
     return html
 
-def build_meta_html(work_id: str, creator_persons=None) -> str:
+def build_meta_html(work_id: str, creator_persons=None, include_text: bool = True) -> str:
     """Genereerib Google'ile ja sotsiaalmeedia robotitele HTML-i koos metaandmetega.
 
     creator_persons: eel-resolvitud [{id, label}] loojate isikukaardid (route filtreerib)
@@ -218,7 +220,9 @@ def build_meta_html(work_id: str, creator_persons=None) -> str:
 
     # Täistekst botidele (sama avalik transkriptsioon, mida kasutaja SPA-s näeb —
     # EI ole SEO-only peidetud teksti → ei ole cloaking). Lehekülgede kaupa.
-    if found_path:
+    # include_text=False, kui ligipääsu ei õnnestunud hinnata (meta laadimata) —
+    # nii ei leki piiratud teose tekst veateel (vt work_meta endpoint fallback).
+    if found_path and include_text:
         _append_work_text(body_lines, found_path, work_url, work_id)
 
     body_lines.append(f'<p><a href="{work_url}">{work_url}</a></p>')

--- a/server/metadata_handler.py
+++ b/server/metadata_handler.py
@@ -1,12 +1,15 @@
 import os
 import json
 import html
+import logging
 from typing import Optional
 from urllib.parse import urlencode
 from .config import BASE_DIR
 from .utils import find_directory_by_id
+from .text_reading import read_work_page_texts, _clean_search_text, work_latest_mtime
 
 SITE_URL = "https://vutt.utlib.ut.ee"
+logger = logging.getLogger(__name__)
 
 _ROLE_LABELS = {
     "praeses": "Praeses",
@@ -72,6 +75,60 @@ def _build_coins(meta: dict) -> str:
 
     return urlencode(params)
 
+
+
+
+# Googlebot indekseerib esimesed ~2MB HTML-i. Hoiame teksti alla selle;
+# piiri ületamisel lõikame ja lisame "täistekst rakenduses" viite.
+PRERENDER_TEXT_MAX_BYTES = 1_600_000
+PRERENDER_TEXT_WARN_BYTES = 1_500_000
+
+
+def _append_work_text(body_lines, found_path, work_url, work_id):
+    """Lisab lehekülgede kaupa puhastatud põhiteksti + marginaalia body_lines-i."""
+    parts = []
+    total = 0
+    truncated = False
+    for page_num, raw in read_work_page_texts(found_path):
+        main_clean, marg_clean = _clean_search_text(raw)
+        if not main_clean and not marg_clean:
+            continue
+        seg = f'<section data-page="{page_num}">'
+        if main_clean:
+            seg += f'<p>{_escape(main_clean)}</p>'
+        if marg_clean:
+            seg += f'<p class="marginalia"><em>Ääremärkused:</em> {_escape(marg_clean)}</p>'
+        seg += '</section>'
+        seg_bytes = len(seg.encode('utf-8'))
+        if total + seg_bytes > PRERENDER_TEXT_MAX_BYTES:
+            truncated = True
+            break
+        parts.append(seg)
+        total += seg_bytes
+
+    if parts or truncated:
+        body_lines.append('<div class="work-text">')
+        body_lines.extend(parts)
+        if truncated:
+            body_lines.append(f'<p><a href="{work_url}">Täistekst rakenduses</a></p>')
+        body_lines.append('</div>')
+    if total >= PRERENDER_TEXT_WARN_BYTES:
+        logger.warning(
+            "Prerender HTML suur: work_id=%s text_bytes=%s truncated=%s",
+            work_id, total, truncated,
+        )
+
+
+def cached_work_meta_html(work_id, work_path, build_fn):
+    """Tagastab bot-HTML-i cache'ist, kui teose max-mtime pole muutunud."""
+    from .cache_invalidation import _work_meta_cache
+    key = work_latest_mtime(work_path)
+    cached = _work_meta_cache.get(work_id)
+    if cached is not None and cached[0] == key:
+        return cached[1]
+    html = build_fn()
+    _work_meta_cache[work_id] = (key, html)
+    return html
 
 def build_meta_html(work_id: str, creator_persons=None) -> str:
     """Genereerib Google'ile ja sotsiaalmeedia robotitele HTML-i koos metaandmetega.
@@ -158,6 +215,11 @@ def build_meta_html(work_id: str, creator_persons=None) -> str:
         if pid:
             person_url = f"{SITE_URL}/persons/{_escape(pid)}"
             body_lines.append(f'<p><a href="{person_url}">{_escape(plabel)}</a></p>')
+
+    # Täistekst botidele (sama avalik transkriptsioon, mida kasutaja SPA-s näeb —
+    # EI ole SEO-only peidetud teksti → ei ole cloaking). Lehekülgede kaupa.
+    if found_path:
+        _append_work_text(body_lines, found_path, work_url, work_id)
 
     body_lines.append(f'<p><a href="{work_url}">{work_url}</a></p>')
     # Tagasi-lingid hub-lehtedele (alati — jaotab crawl-graafi)
@@ -456,7 +518,9 @@ def build_sitemap_xml(
         if not is_work_public_fn(meta):
             continue
 
-        lastmod = _sitemap_lastmod(mtime)
+        # lastmod = max(_metadata.json, lehtede .txt/.json) → tekstimuudatus värskendab
+        latest = work_latest_mtime(path) or mtime
+        lastmod = _sitemap_lastmod(latest)
         loc = f"{SITE_URL}/work/{html.escape(work_id)}"
         lastmod_xml = f"\n    <lastmod>{lastmod}</lastmod>" if lastmod else ""
         urls.append(f"  <url>\n    <loc>{loc}</loc>{lastmod_xml}\n  </url>")

--- a/server/routers/public.py
+++ b/server/routers/public.py
@@ -287,8 +287,9 @@ async def work_meta(work_id: str, request: Request):
             lambda: build_meta_html(work_id, creator_persons=get_persons_for_work(work_id)),
         )
         return HTMLResponse(content=html)
-    # Tundmatu teos → fallback HTML (odav, ei cache'i).
-    return HTMLResponse(content=build_meta_html(work_id, creator_persons=get_persons_for_work(work_id)))
+    # Ligipääsu ei õnnestunud hinnata (meta laadimata / tundmatu teos) → fallback
+    # HTML ILMA täistekstita: piiratud teose tekst ei tohi veateel lekkida.
+    return HTMLResponse(content=build_meta_html(work_id, creator_persons=get_persons_for_work(work_id), include_text=False))
 
 @router.get("/sitemap.xml")
 async def sitemap_xml():

--- a/server/routers/public.py
+++ b/server/routers/public.py
@@ -10,7 +10,7 @@ from ..cache import get_cached_collections
 from ..cache_invalidation import _sitemap_cache, _home_cache
 from ..config import BASE_DIR
 from ..deps import optional_user as _get_optional_user, require_role
-from ..metadata_handler import build_home_meta_html, build_meta_html, build_person_meta_html, build_persons_meta_html, build_sitemap_xml
+from ..metadata_handler import build_home_meta_html, build_meta_html, build_person_meta_html, build_persons_meta_html, build_sitemap_xml, cached_work_meta_html
 from ..metadata_ops import save_work_metadata
 from ..prosopography.indices import _load_index, _load_work_collections
 from ..prosopography.relations import get_person_with_works, get_persons_for_work
@@ -278,9 +278,17 @@ async def work_meta(work_id: str, request: Request):
         user = _get_optional_user(request)
         if not can_read_work(meta, user):
             return HTMLResponse(content="<html><body>Ligipääs keelatud</body></html>", status_code=403)
-    # Loojate isikukaardid ristviidete jaoks (linkgraaf teos↔isik)
-    creator_persons = get_persons_for_work(work_id)
-    return HTMLResponse(content=build_meta_html(work_id, creator_persons=creator_persons))
+    found_path = find_directory_by_id(work_id)
+    if found_path and meta is not None:
+        # Avalik/lubatud teos → cache mtime-võtmega.
+        html = cached_work_meta_html(
+            work_id,
+            found_path,
+            lambda: build_meta_html(work_id, creator_persons=get_persons_for_work(work_id)),
+        )
+        return HTMLResponse(content=html)
+    # Tundmatu teos → fallback HTML (odav, ei cache'i).
+    return HTMLResponse(content=build_meta_html(work_id, creator_persons=get_persons_for_work(work_id)))
 
 @router.get("/sitemap.xml")
 async def sitemap_xml():

--- a/server/text_reading.py
+++ b/server/text_reading.py
@@ -1,0 +1,79 @@
+"""Neutraalne teksti-lugemise moodul bot-prerenderi ja sitemapi jaoks.
+
+Sõltub AINULT stdlibist + server.meili_doc puhtast osast (enumerate_page_images,
+clean_text_for_search, _clean_search_text). metadata_handler impordib SIIT, MITTE
+meilisearch_ops-ist (raske: ThreadPoolExecutor, git_ops).
+"""
+import os
+import json
+
+from .meili_doc import (
+    enumerate_page_images,
+    clean_text_for_search,   # re-export
+    _clean_search_text,      # re-export
+)
+
+__all__ = [
+    "read_work_page_texts",
+    "work_latest_mtime",
+    "clean_text_for_search",
+    "_clean_search_text",
+]
+
+
+def read_work_page_texts(work_path):
+    """Loeb teose lehtede toore teksti järjekorras.
+
+    Tagastab [(page_num, raw_text)]. `.txt` on autoriteet, lehe `.json`
+    `text_content` on fallback (sama reegel nagu indekseerijal).
+    """
+    pages = []
+    for idx, img_name in enumerate(enumerate_page_images(work_path)):
+        page_num = idx + 1
+        base = os.path.splitext(img_name)[0]
+        raw = ""
+        txt_path = os.path.join(work_path, base + '.txt')
+        if os.path.exists(txt_path):
+            try:
+                with open(txt_path, 'r', encoding='utf-8') as f:
+                    raw = f.read()
+            except Exception:
+                pass
+        if not raw:
+            jp = os.path.join(work_path, base + '.json')
+            if os.path.exists(jp):
+                try:
+                    with open(jp, 'r', encoding='utf-8') as jf:
+                        d = json.load(jf)
+                        raw = d.get('text_content', '') or ''
+                except Exception:
+                    pass
+        pages.append((page_num, raw))
+    return pages
+
+
+def work_latest_mtime(work_path):
+    """max mtime üle `_metadata.json` + lehtede `.txt`/`.json` failide.
+
+    Kasutatakse NII sitemap `lastmod` KUI bot-HTML cache-võtme jaoks — nii et
+    teksti- VÕI bibliograafiamuudatus värskendab mõlemat.
+    """
+    latest = 0.0
+    meta = os.path.join(work_path, '_metadata.json')
+    if os.path.exists(meta):
+        try:
+            latest = os.path.getmtime(meta)
+        except OSError:
+            pass
+    try:
+        for name in os.listdir(work_path):
+            if name.startswith('_'):
+                continue
+            if name.endswith('.txt') or name.endswith('.json'):
+                try:
+                    latest = max(latest, os.path.getmtime(os.path.join(work_path, name)))
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return latest

--- a/server/text_reading.py
+++ b/server/text_reading.py
@@ -24,14 +24,16 @@ __all__ = [
 def read_work_page_texts(work_path):
     """Loeb teose lehtede toore teksti järjekorras.
 
-    Tagastab [(page_num, raw_text)]. `.txt` on autoriteet, lehe `.json`
-    `text_content` on fallback (sama reegel nagu indekseerijal).
+    Tagastab [(page_num, raw_text)]. `page_num` on lehe päris `sequence`
+    (`.json`-ist), fallback järjekorra-positsioon (idx+1) kui sequence puudub.
+    `.txt` on teksti autoriteet, lehe `.json` `text_content` on fallback
+    (sama reegel nagu indekseerijal).
     """
     pages = []
     for idx, img_name in enumerate(enumerate_page_images(work_path)):
-        page_num = idx + 1
         base = os.path.splitext(img_name)[0]
         raw = ""
+        seq = None
         txt_path = os.path.join(work_path, base + '.txt')
         if os.path.exists(txt_path):
             try:
@@ -39,15 +41,21 @@ def read_work_page_texts(work_path):
                     raw = f.read()
             except Exception:
                 pass
-        if not raw:
-            jp = os.path.join(work_path, base + '.json')
-            if os.path.exists(jp):
-                try:
-                    with open(jp, 'r', encoding='utf-8') as jf:
-                        d = json.load(jf)
+        jp = os.path.join(work_path, base + '.json')
+        if os.path.exists(jp):
+            try:
+                with open(jp, 'r', encoding='utf-8') as jf:
+                    d = json.load(jf)
+                    s = d.get('sequence')
+                    if s is None:
+                        s = d.get('meta_content', {}).get('sequence')
+                    if s is not None:
+                        seq = int(s)
+                    if not raw:
                         raw = d.get('text_content', '') or ''
-                except Exception:
-                    pass
+            except Exception:
+                pass
+        page_num = seq if seq is not None else idx + 1
         pages.append((page_num, raw))
     return pages
 

--- a/tests/test_metadata_handler.py
+++ b/tests/test_metadata_handler.py
@@ -16,6 +16,15 @@ def _write_meta(tmp_path, meta: dict) -> str:
     return str(work_dir)
 
 
+def _write_page(work_dir_path, base, seq, txt):
+    """Lisab teosele lehe: {base}.jpg + {base}.json (sequence) + {base}.txt."""
+    import json as _json
+    p = Path(work_dir_path)
+    (p / f"{base}.jpg").write_bytes(b"x")
+    (p / f"{base}.json").write_text(_json.dumps({"sequence": seq}), encoding="utf-8")
+    (p / f"{base}.txt").write_text(txt, encoding="utf-8")
+
+
 @pytest.fixture()
 def patch_find(monkeypatch, tmp_path):
     """Monkeypatchi find_directory_by_id et tagastaks tmp_path kausta."""
@@ -374,3 +383,81 @@ def test_sitemap_includes_persons_and_excludes_tombstones():
     assert "https://vutt.utlib.ut.ee/persons/vutt:P1" in xml
     assert "2026-06-21" in xml
     assert "vutt:P2" not in xml
+
+
+def test_body_includes_page_text(patch_find):
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    path = _write_meta(tmp_path, FULL_META)
+    registry["work001"] = path
+    _write_page(path, "p1", 1, "Suecorum gloria in aeternum")
+    _write_page(path, "p2", 2, "Pars altera <m>nota marginalis</m> textus")
+    html = build_meta_html("work001")
+    assert 'data-page="1"' in html
+    assert "Suecorum gloria in aeternum" in html
+    assert 'data-page="2"' in html
+    # Marginaalia eraldi lõiguna
+    assert 'class="marginalia"' in html
+    assert "nota marginalis" in html
+    # Põhitekstist on marginaalia välja lõigatud
+    assert "Pars altera textus" in html
+
+
+def test_oversized_work_truncated_with_note(patch_find, monkeypatch):
+    import server.metadata_handler as mh
+    registry, tmp_path = patch_find
+    path = _write_meta(tmp_path, FULL_META)
+    registry["work001"] = path
+    # Väike piir, et test ei vaja megabaite
+    monkeypatch.setattr(mh, "PRERENDER_TEXT_MAX_BYTES", 200)
+    _write_page(path, "p1", 1, "A" * 300)
+    _write_page(path, "p2", 2, "B" * 300)
+    html = mh.build_meta_html("work001")
+    assert "Täistekst rakenduses" in html          # kärbe-märge olemas
+    assert "BBB" not in html                        # teine leht jäi välja
+    assert 'rel="canonical"' in html                # head-tagid alles (2MB sees)
+
+
+def test_sitemap_lastmod_uses_page_mtime(tmp_path):
+    import os, json as _json, datetime
+    from server.metadata_handler import build_sitemap_xml
+    # Loo päris kaust, kus lehe .txt on UUEM kui _metadata.json mtime
+    d = tmp_path / "slug"
+    d.mkdir()
+    (d / "_metadata.json").write_text(_json.dumps({"id": "w1", "collections": []}), encoding="utf-8")
+    txt = d / "a.txt"
+    txt.write_text("tekst", encoding="utf-8")
+    new_ts = 1_800_000_000.0  # kaugel tulevikus, kindlasti > _metadata mtime
+    os.utime(str(txt), (new_ts, new_ts))
+
+    cache = {"w1": (str(d), os.path.getmtime(str(d / "_metadata.json")))}
+    xml = build_sitemap_xml(cache, lambda m: True, lambda wid: {"id": "w1", "collections": []})
+    expected = datetime.datetime.fromtimestamp(new_ts, datetime.timezone.utc).strftime("%Y-%m-%d")
+    assert expected in xml
+
+
+def test_cached_work_meta_html_rebuilds_on_mtime_change(tmp_path):
+    import os
+    from server.metadata_handler import cached_work_meta_html
+    from server.cache_invalidation import _work_meta_cache
+    _work_meta_cache.clear()
+    d = tmp_path / "slug"
+    d.mkdir()
+    (d / "_metadata.json").write_text("{}", encoding="utf-8")
+    txt = d / "a.txt"
+    txt.write_text("v1", encoding="utf-8")
+
+    calls = {"n": 0}
+    def build():
+        calls["n"] += 1
+        return f"<html>{calls['n']}</html>"
+
+    h1 = cached_work_meta_html("w1", str(d), build)
+    h2 = cached_work_meta_html("w1", str(d), build)  # cache hit
+    assert h1 == h2
+    assert calls["n"] == 1
+
+    os.utime(str(txt), (2_000_000_000.0, 2_000_000_000.0))  # muudatus
+    h3 = cached_work_meta_html("w1", str(d), build)         # rebuild
+    assert calls["n"] == 2
+    assert h3 != h1

--- a/tests/test_metadata_handler.py
+++ b/tests/test_metadata_handler.py
@@ -403,6 +403,37 @@ def test_body_includes_page_text(patch_find):
     assert "Pars altera textus" in html
 
 
+def test_include_text_false_omits_transcription(patch_find):
+    """include_text=False (ligipääsu ei hinnatud) → mitte teksti, ainult metaandmed."""
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    path = _write_meta(tmp_path, FULL_META)
+    registry["work001"] = path
+    _write_page(path, "p1", 1, "Salajane transkriptsioon")
+    html = build_meta_html("work001", include_text=False)
+    assert "Salajane transkriptsioon" not in html
+    assert 'data-page=' not in html
+    assert 'class="work-text"' not in html
+    # Metaandmed/head siiski olemas
+    assert 'rel="canonical"' in html
+
+
+def test_oversized_first_page_still_warns(patch_find, monkeypatch, caplog):
+    """Esimene leht üksi ületab MAX → total jääb 0, aga kärbe → hoiatus siiski."""
+    import logging
+    import server.metadata_handler as mh
+    registry, tmp_path = patch_find
+    path = _write_meta(tmp_path, FULL_META)
+    registry["work001"] = path
+    monkeypatch.setattr(mh, "PRERENDER_TEXT_MAX_BYTES", 50)
+    monkeypatch.setattr(mh, "PRERENDER_TEXT_WARN_BYTES", 40)
+    _write_page(path, "p1", 1, "A" * 300)  # üksik segment > MAX
+    with caplog.at_level(logging.WARNING):
+        html = mh.build_meta_html("work001")
+    assert "Täistekst rakenduses" in html
+    assert any("Prerender HTML suur" in r.message for r in caplog.records)
+
+
 def test_oversized_work_truncated_with_note(patch_find, monkeypatch):
     import server.metadata_handler as mh
     registry, tmp_path = patch_find

--- a/tests/test_robots_txt.py
+++ b/tests/test_robots_txt.py
@@ -1,0 +1,30 @@
+# tests/test_robots_txt.py
+import os
+
+ROBOTS = os.path.join(os.path.dirname(__file__), "..", "public", "robots.txt")
+
+
+def _read():
+    with open(ROBOTS, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_blocks_training_bots():
+    txt = _read()
+    for ua in ["GPTBot", "Google-Extended", "CCBot", "ClaudeBot", "anthropic-ai", "Bytespider"]:
+        assert f"User-agent: {ua}" in txt, ua
+
+
+def test_does_not_block_search_referral_bots():
+    txt = _read()
+    # Need EI TOHI olla eraldi Disallow-grupis
+    for ua in ["OAI-SearchBot", "PerplexityBot", "Perplexity-User", "FirecrawlAgent"]:
+        assert f"User-agent: {ua}" not in txt, ua
+
+
+def test_keeps_sitemap_and_wildcard_group():
+    txt = _read()
+    assert "Sitemap: https://vutt.utlib.ut.ee/sitemap.xml" in txt
+    assert "User-agent: *" in txt
+    # Googlebot/Bingbot ei tohi olla üheski Disallow: / grupis
+    assert "\nUser-agent: Googlebot\nDisallow: /" not in txt

--- a/tests/test_text_reading.py
+++ b/tests/test_text_reading.py
@@ -34,6 +34,30 @@ def test_read_work_page_texts_txt_authoritative(tmp_path):
     assert pages == [(1, "TXT tekst"), (2, "ainult JSON")]
 
 
+def test_page_num_uses_sequence_not_position(tmp_path):
+    """data-page = päris sequence (nt fooliod 5,6), mitte 1,2 järjekorra-positsioon."""
+    from server.text_reading import read_work_page_texts
+    d = _make_work(tmp_path)
+    (d / "a.jpg").write_bytes(b"x")
+    (d / "a.json").write_text(json.dumps({"sequence": 5, "text_content": "A"}), encoding="utf-8")
+    (d / "a.txt").write_text("esimene", encoding="utf-8")
+    (d / "b.jpg").write_bytes(b"x")
+    (d / "b.json").write_text(json.dumps({"sequence": 6, "text_content": "B"}), encoding="utf-8")
+    (d / "b.txt").write_text("teine", encoding="utf-8")
+    pages = read_work_page_texts(str(d))
+    assert pages == [(5, "esimene"), (6, "teine")]
+
+
+def test_page_num_falls_back_to_position(tmp_path):
+    """Sequence puudub → page_num = idx+1."""
+    from server.text_reading import read_work_page_texts
+    d = _make_work(tmp_path)
+    (d / "a.jpg").write_bytes(b"x")
+    (d / "a.txt").write_text("tekst", encoding="utf-8")
+    pages = read_work_page_texts(str(d))
+    assert pages == [(1, "tekst")]
+
+
 def test_work_latest_mtime_tracks_page_edit(tmp_path):
     from server.text_reading import work_latest_mtime
     d = _make_work(tmp_path)

--- a/tests/test_text_reading.py
+++ b/tests/test_text_reading.py
@@ -1,0 +1,47 @@
+# tests/test_text_reading.py
+import json
+import os
+
+
+def _make_work(tmp_path):
+    d = tmp_path / "w"
+    d.mkdir()
+    return d
+
+
+def test_enumerate_orders_by_sequence(tmp_path):
+    from server.meili_doc import enumerate_page_images
+    d = _make_work(tmp_path)
+    # Kaks pilti, sequence tagurpidi failinime suhtes
+    (d / "b.jpg").write_bytes(b"x")
+    (d / "b.json").write_text(json.dumps({"sequence": 1}), encoding="utf-8")
+    (d / "a.jpg").write_bytes(b"x")
+    (d / "a.json").write_text(json.dumps({"sequence": 2}), encoding="utf-8")
+    (d / "_thumb_a.jpg").write_bytes(b"x")  # peab välja jääma
+    result = enumerate_page_images(str(d))
+    assert result == ["b.jpg", "a.jpg"]
+
+
+def test_read_work_page_texts_txt_authoritative(tmp_path):
+    from server.text_reading import read_work_page_texts
+    d = _make_work(tmp_path)
+    (d / "a.jpg").write_bytes(b"x")
+    (d / "a.json").write_text(json.dumps({"sequence": 1, "text_content": "JSON"}), encoding="utf-8")
+    (d / "a.txt").write_text("TXT tekst", encoding="utf-8")
+    (d / "b.jpg").write_bytes(b"x")
+    (d / "b.json").write_text(json.dumps({"sequence": 2, "text_content": "ainult JSON"}), encoding="utf-8")
+    pages = read_work_page_texts(str(d))
+    assert pages == [(1, "TXT tekst"), (2, "ainult JSON")]
+
+
+def test_work_latest_mtime_tracks_page_edit(tmp_path):
+    from server.text_reading import work_latest_mtime
+    d = _make_work(tmp_path)
+    (d / "_metadata.json").write_text("{}", encoding="utf-8")
+    (d / "a.jpg").write_bytes(b"x")
+    txt = d / "a.txt"
+    txt.write_text("v1", encoding="utf-8")
+    k1 = work_latest_mtime(str(d))
+    os.utime(str(txt), (k1 + 10, k1 + 10))  # simuleeri hilisemat muudatust
+    k2 = work_latest_mtime(str(d))
+    assert k2 > k1


### PR DESCRIPTION
## Summary
- adds shared page-text reading/order helpers and injects cleaned per-page transcription into bot prerender HTML with size guardrail
- updates sitemap lastmod and prerender cache to use max metadata/page mtime
- adds AI-training bot robots.txt policy and bot-traffic monitoring docs

## Tests
- .venv/bin/python -m pytest tests/ -q

## Notes
- Monitoring nginx/logrotate/GoAccess steps remain manual server rollout per docs/monitoring-bot-traffic.md