### PR TITLE
Otsingu debounce + AbortController (#87)

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -34,6 +34,8 @@ const SCROLL_STORAGE_KEY = 'vutt_dashboard_scroll';
 const RETURN_URL_KEY = 'vutt_return_url';
 const DASHBOARD_URL_KEY = 'vutt_dashboard_url';
 
+const SEARCH_DEBOUNCE_MS = 400;
+
 const Dashboard: React.FC = () => {
   const { t, i18n } = useTranslation(['dashboard', 'common', 'auth']);
   const { user } = useUser();
@@ -341,6 +343,8 @@ const Dashboard: React.FC = () => {
   // Perform search when params change
   useEffect(() => {
     if (!index) return;
+    const controller = new AbortController();
+    let cancelled = false;
     const fetchWorks = async () => {
       setLoading(true);
       setError(null);
@@ -362,8 +366,10 @@ const Dashboard: React.FC = () => {
           type: selectedType ? [selectedType] : undefined,
           collection: selectedCollection || undefined,
           onlyFirstPage: sort !== 'recent',
-          lang: getLangCode(i18n.language)
+          lang: getLangCode(i18n.language),
+          signal: controller.signal
         });
+        if (cancelled) return;
         setWorks(result.works);
         setFacets(result.facets);
 
@@ -374,18 +380,24 @@ const Dashboard: React.FC = () => {
         // Uue otsingutulemuse korral on shift-valiku ankur (lehekohalik) aegunud
         lastSelectedIndexRef.current = null;
       } catch (e: any) {
-        console.error("Search failed", e);
-        setError(e.message || "Tundmatu viga ühendamisel.");
+        if (!cancelled && !controller.signal.aborted) {
+          console.error("Search failed", e);
+          setError(e.message || "Tundmatu viga ühendamisel.");
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
 
     const timer = setTimeout(() => {
       fetchWorks();
-    }, 400);
+    }, SEARCH_DEBOUNCE_MS);
 
-    return () => clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      controller.abort();
+    };
   }, [index, queryParam, yearStart, yearEnd, sort, authorParam, respondensParam, printerParam, statusParam, selectedTags, selectedGenre, selectedType, selectedCollection, refreshCounter, i18n.language]);
 
   // Multi-select helper funktsioonid

--- a/src/pages/search/hooks/useSearchFacets.ts
+++ b/src/pages/search/hooks/useSearchFacets.ts
@@ -22,6 +22,12 @@ export interface FacetsState {
     tagLabels: Record<string, string>; // Q-kood → label (laetud tags_object-ist)
 }
 
+const FACET_DEBOUNCE_MS = 400;
+
+const isAbortError = (error: unknown) =>
+    (error instanceof DOMException && error.name === 'AbortError') ||
+    (typeof error === 'object' && error !== null && (error as { name?: string }).name === 'AbortError');
+
 export function useSearchFacets(
     urlParams: SearchUrlParams,
     lang: string,
@@ -39,12 +45,15 @@ export function useSearchFacets(
 
     // Alglaadimine: vocabularies + aliased + (kui pole aktiivset filtrit) facetid
     useEffect(() => {
-        const load = async () => {
+        const controller = new AbortController();
+        let cancelled = false;
+        const timer = window.setTimeout(async () => {
             try {
                 const [vocabs, aliasRes] = await Promise.all([
                     getVocabularies(),
-                    fetch(`${FILE_API_URL}/people-aliases`).then(r => r.ok ? r.json() : null).catch(() => null)
+                    fetch(`${FILE_API_URL}/people-aliases`, { signal: controller.signal }).then(r => r.ok ? r.json() : null).catch(e => isAbortError(e) ? null : Promise.reject(e))
                 ]);
+                if (cancelled) return;
                 setVocabularies(vocabs);
                 if (aliasRes?.status === 'success' && aliasRes.aliases) setAliasMap(aliasRes.aliases);
 
@@ -54,22 +63,28 @@ export function useSearchFacets(
 
                 const facetLang = getLangCode(lang);
                 const [tags, genres, types, authors, labels] = await Promise.all([
-                    getTeoseTagsFacets(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd),
-                    getGenreFacets(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd),
-                    getTypeFacets(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd),
-                    getAuthorFacets(index, selectedCollection || undefined, urlParams.yearStart, urlParams.yearEnd),
-                    getTagsLabelMap(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd),
+                    getTeoseTagsFacets(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd, controller.signal),
+                    getGenreFacets(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd, controller.signal),
+                    getTypeFacets(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd, controller.signal),
+                    getAuthorFacets(index, selectedCollection || undefined, urlParams.yearStart, urlParams.yearEnd, controller.signal),
+                    getTagsLabelMap(index, selectedCollection || undefined, facetLang, urlParams.yearStart, urlParams.yearEnd, controller.signal),
                 ]);
+                if (cancelled) return;
                 setTagLabels(labels);
                 setAvailableTeoseTags(mergeSelectedIntoTags(tags, urlParams.teoseTags));
                 setAvailableGenres(mergeSelectedIntoFacets(genres, urlParams.genres));
                 setAvailableTypes(mergeSelectedIntoFacets(types, urlParams.types));
                 setAvailableAuthors(authors);
             } catch (e) {
-                console.warn('Filtrite andmete laadimine ebaõnnestus:', e);
+                if (!cancelled && !controller.signal.aborted && !isAbortError(e)) console.warn('Filtrite andmete laadimine ebaõnnestus:', e);
             }
+        }, FACET_DEBOUNCE_MS);
+
+        return () => {
+            cancelled = true;
+            window.clearTimeout(timer);
+            controller.abort();
         };
-        load();
     }, [selectedCollection, lang, urlParams.yearStart, urlParams.yearEnd,
         urlParams.q, urlParams.workId, urlParams.author,
         urlParams.teoseTags.length, urlParams.genres.length, urlParams.types.length, index]);

--- a/src/pages/search/hooks/useSearchResults.ts
+++ b/src/pages/search/hooks/useSearchResults.ts
@@ -11,6 +11,8 @@ export interface SearchResultsState {
     error: string | null;
 }
 
+const SEARCH_DEBOUNCE_MS = 400;
+
 export function useSearchResults(urlParams: SearchUrlParams, lang: string, selectedCollection: string | null): SearchResultsState {
     const index = useMeiliIndex();
     const [results, setResults] = useState<ContentSearchResponse | null>(null);
@@ -30,8 +32,9 @@ export function useSearchResults(urlParams: SearchUrlParams, lang: string, selec
 
         if (!index) return;
 
+        const controller = new AbortController();
         let cancelled = false;
-        const run = async () => {
+        const timer = window.setTimeout(async () => {
             setLoading(true);
             setError(null);
             try {
@@ -48,16 +51,21 @@ export function useSearchResults(urlParams: SearchUrlParams, lang: string, selec
                     subjectPerson: urlParams.subjectPerson || undefined,
                     collection: selectedCollection || undefined,
                     lang: getLangCode(lang),
+                    signal: controller.signal,
                 });
                 if (!cancelled) setResults(data);
             } catch (e: any) {
-                if (!cancelled) setError(e.message || 'Otsinguviga');
+                if (!cancelled && !controller.signal.aborted) setError(e.message || 'Otsinguviga');
             } finally {
                 if (!cancelled) setLoading(false);
             }
+        }, SEARCH_DEBOUNCE_MS);
+
+        return () => {
+            cancelled = true;
+            window.clearTimeout(timer);
+            controller.abort();
         };
-        run();
-        return () => { cancelled = true; };
     }, [urlParams.q, urlParams.page, urlParams.yearStart, urlParams.yearEnd,
         urlParams.scope, urlParams.workId,
         urlParams.teoseTags.join(','), urlParams.pageTags.join(','),

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -18,6 +18,10 @@ const pushYearFilter = (filter: string[], yearStart?: number, yearEnd?: number):
   if (yearEnd) filter.push(`year_start <= ${yearEnd}`);
 };
 
+const isAbortError = (error: unknown): boolean =>
+  (error instanceof DOMException && error.name === 'AbortError') ||
+  (typeof error === 'object' && error !== null && (error as { name?: string }).name === 'AbortError');
+
 // Interface for dashboard search options
 export interface DashboardSearchOptions {
   yearStart?: number;
@@ -35,6 +39,7 @@ export interface DashboardSearchOptions {
   genre?: string[]; // Žanri filter (OR loogika - mitu valikut lubatud)
   type?: string[]; // Tüübi filter (OR loogika - mitu valikut lubatud)
   lang?: string; // Keele filter (et, en) - kasutatakse genre/type/tags väljadega
+  signal?: AbortSignal; // Poolelioleva Meilisearchi päringu katkestamine
 }
 
 // Facetide vastuse tüüp
@@ -60,7 +65,8 @@ export const getTeoseTagsFacets = async (
   collection?: string,
   _lang: string = 'et',
   yearStart?: number,
-  yearEnd?: number
+  yearEnd?: number,
+  signal?: AbortSignal
 ): Promise<{ tag: string; count: number }[]> => {
   checkMixedContent();
 
@@ -79,7 +85,7 @@ export const getTeoseTagsFacets = async (
       filter,
       limit: 0,
       facets: [facetField]
-    });
+    }, signal ? { signal } : undefined);
 
     const facetDistribution = response.facetDistribution?.[facetField] || {};
 
@@ -89,6 +95,7 @@ export const getTeoseTagsFacets = async (
 
     return result;
   } catch (error) {
+    if (signal?.aborted || isAbortError(error)) throw error;
     console.error("getTeoseTagsFacets error:", error);
     return [];
   }
@@ -101,7 +108,8 @@ export const getGenreFacets = async (
   collection?: string,
   _lang: string = 'et',
   yearStart?: number,
-  yearEnd?: number
+  yearEnd?: number,
+  signal?: AbortSignal
 ): Promise<{ value: string; count: number }[]> => {
   checkMixedContent();
 
@@ -119,7 +127,7 @@ export const getGenreFacets = async (
       filter,
       limit: 0,
       facets: [facetField]
-    });
+    }, signal ? { signal } : undefined);
 
     const facetDistribution = response.facetDistribution?.[facetField] || {};
 
@@ -129,6 +137,7 @@ export const getGenreFacets = async (
 
     return result;
   } catch (error) {
+    if (signal?.aborted || isAbortError(error)) throw error;
     console.error("getGenreFacets error:", error);
     return [];
   }
@@ -141,7 +150,8 @@ export const getTypeFacets = async (
   collection?: string,
   _lang: string = 'et',
   yearStart?: number,
-  yearEnd?: number
+  yearEnd?: number,
+  signal?: AbortSignal
 ): Promise<{ value: string; count: number }[]> => {
   checkMixedContent();
 
@@ -159,7 +169,7 @@ export const getTypeFacets = async (
       filter,
       limit: 0,
       facets: [facetField]
-    });
+    }, signal ? { signal } : undefined);
 
     const facetDistribution = response.facetDistribution?.[facetField] || {};
 
@@ -169,6 +179,7 @@ export const getTypeFacets = async (
 
     return result;
   } catch (error) {
+    if (signal?.aborted || isAbortError(error)) throw error;
     console.error("getTypeFacets error:", error);
     return [];
   }
@@ -205,7 +216,8 @@ export const getTagsLabelMap = async (
   collection?: string,
   lang: string = 'et',
   yearStart?: number,
-  yearEnd?: number
+  yearEnd?: number,
+  signal?: AbortSignal
 ): Promise<Record<string, string>> => {
   checkMixedContent();
   try {
@@ -217,7 +229,7 @@ export const getTagsLabelMap = async (
       filter,
       limit: 200,
       attributesToRetrieve: ['tags_object'],
-    });
+    }, signal ? { signal } : undefined);
 
     const map: Record<string, string> = {};
     const cap = (s: string) => s ? s[0].toUpperCase() + s.slice(1) : s;
@@ -232,6 +244,7 @@ export const getTagsLabelMap = async (
     }
     return map;
   } catch (error) {
+    if (signal?.aborted || isAbortError(error)) throw error;
     console.error('getTagsLabelMap error:', error);
     return {};
   }
@@ -242,7 +255,8 @@ export const getAuthorFacets = async (
   index: Index,
   collection?: string,
   yearStart?: number,
-  yearEnd?: number
+  yearEnd?: number,
+  signal?: AbortSignal
 ): Promise<{ value: string; count: number }[]> => {
   checkMixedContent();
 
@@ -257,7 +271,7 @@ export const getAuthorFacets = async (
       filter,
       limit: 0,
       facets: ['author_names', 'respondens_names']
-    });
+    }, signal ? { signal } : undefined);
 
     // Liida author_names ja respondens_names kokku
     const authorFacets = response.facetDistribution?.['author_names'] || {};
@@ -271,6 +285,7 @@ export const getAuthorFacets = async (
       .map(([value, count]) => ({ value, count: count as number }))
       .sort((a, b) => b.count - a.count);
   } catch (error) {
+    if (signal?.aborted || isAbortError(error)) throw error;
     console.error("getAuthorFacets error:", error);
     return [];
   }
@@ -376,7 +391,7 @@ export const searchWorks = async (index: Index, query: string, options?: Dashboa
       searchParams.sort = ['year:asc'];
     }
 
-    const response = await index.search(query, searchParams);
+    const response = await index.search(query, searchParams, options?.signal ? { signal: options.signal } : undefined);
 
     // Kui kasutame distinct, siis iga hit on unikaalne teos
     // Kui EI kasuta distinct (relevance), siis peame grupeerima frontendis, säilitades järjekorra
@@ -433,6 +448,7 @@ export const searchWorks = async (index: Index, query: string, options?: Dashboa
     };
 
   } catch (error: any) {
+    if (options?.signal?.aborted || isAbortError(error)) throw error;
     console.error("Meilisearch error:", error);
     throw new Error(`Ühenduse viga (${MEILI_HOST}): ${error.message}`);
   }
@@ -492,6 +508,8 @@ export const searchContent = async (index: Index, query: string, page: number = 
     if (!query) filter.push('has_annotations = true');
   }
 
+  const requestConfig = options.signal ? { signal: options.signal } : undefined;
+
   try {
     // Kui otsime ühe teose piires, näitame kogu lehekülje teksti kõigi highlight'idega
     if (options.workId) {
@@ -507,7 +525,7 @@ export const searchContent = async (index: Index, query: string, page: number = 
         highlightPostTag: HIGHLIGHT_POST_TAG,
         attributesToSearchOn: attributesToSearchOn,
         matchingStrategy: (query ? 'frequency' : 'last') as unknown as MatchingStrategies
-      });
+      }, requestConfig);
 
       const totalHits = response.estimatedTotalHits || 0;
 
@@ -542,7 +560,7 @@ export const searchContent = async (index: Index, query: string, page: number = 
           limit: 0,
           facets: ['originaal_kataloog', genreFacetField, typeFacetField, tagsFacetField, 'author_names', 'respondens_names'],
           attributesToSearchOn: attributesToSearchOn
-        }),
+        }, requestConfig),
         // Päring 2: Sisu (teosed)
         index.search('', {
           offset,
@@ -552,7 +570,7 @@ export const searchContent = async (index: Index, query: string, page: number = 
           attributesToRetrieve: ['id', 'work_id', 'lehekylje_number', 'lehekylje_tekst', 'marginaalia_tekst', 'title', 'year', 'year_display', 'originaal_kataloog', 'lehekylje_pilt', 'tags', 'tags_object', 'page_tags', 'page_tags_object', tagsField, 'comments', 'text_annotations', 'genre', 'genre_object', 'type', 'type_object', 'creators', 'collections', 'collections_hierarchy'],
           sort: ['year:asc'], // Vaikimisi sortimine aasta järgi kui otsingut pole
           attributesToSearchOn: attributesToSearchOn
-        })
+        }, requestConfig)
       ]);
 
       facetDistribution = statsResponse.facetDistribution || {};
@@ -603,7 +621,7 @@ export const searchContent = async (index: Index, query: string, page: number = 
           limit: STATS_LIMIT,
           attributesToRetrieve: ['id', 'work_id', 'title', 'year', 'location', 'publisher', 'creators', 'genre_object', 'type_object', 'collections', 'collections_hierarchy', 'author_names', 'respondens_names', 'tags_object', genreFacetField, typeFacetField, tagsFacetField],
           attributesToSearchOn: attributesToSearchOn
-        }),
+        }, requestConfig),
         // Päring 2: Sisu (kuvatavad teosed, distinct)
         index.search(query, {
           offset,
@@ -617,14 +635,14 @@ export const searchContent = async (index: Index, query: string, page: number = 
           highlightPreTag: HIGHLIGHT_PRE_TAG,
           highlightPostTag: HIGHLIGHT_POST_TAG,
           attributesToSearchOn: attributesToSearchOn
-        }),
+        }, requestConfig),
         // Päring 3: Lehekülgede arvud teoste kaupa (work_id facet)
         index.search(query, {
           filter,
           limit: 0,
           facets: ['work_id'],
           attributesToSearchOn: attributesToSearchOn
-        })
+        }, requestConfig)
       ]);
 
       // Arvuta unikaalsete teoste statistika käsitsi

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,7 @@ export interface ContentSearchOptions {
   author?: string;        // V2: autori filter (creators massiivist)
   subjectPerson?: string; // VUTT isiku ID (vutt:Pxxxxxx) teema-filtrina (tags_ids kaudu)
   pageTags?: string[];    // Lehekülje märksõnad (AND loogika, page_tags_ids)
+  signal?: AbortSignal;   // Poolelioleva Meilisearchi päringu katkestamine
 }
 
 /**


### PR DESCRIPTION
Closes #87

## Mida
SearchPage ja Dashboard otsingupäringud saavad **400ms debounce'i** ja katkestatakse **AbortControlleriga** uue päringu / filtrivahetuse korral. Väldib võidujooksu (vananenud tulemus üle värske) ja tarbetuid Meilisearch-päringuid tippides.

## Muudatused
- **`searchService.ts`** — `searchContent`, `searchWorks` ja facet-helperid võtavad `AbortSignal`-i ja annavad selle Meilisearch SDK-le (`index.search(..., ..., { signal })`).
- **`useSearchResults.ts`**, **`useSearchFacets.ts`** — 400ms debounce + `AbortController`; pooleliolev päring katkestatakse cleanupis.
- **`Dashboard.tsx`** — dashboardi Meili-päring saab `AbortSignal`-i; vana päring katkestatakse uue korral. Debounce ühtlustatud 400ms peale (`SEARCH_DEBOUNCE_MS`).
- **`types.ts`** — `ContentSearchOptions.signal`.

## Abordi tuvastus (oluline detail)
Meilisearch SDK (0.37) **mähib** abordi `DOMException`-i `MeiliSearchCommunicationError`-iks (`httpErrorHandler`), seega `error.name === 'AbortError'` EI tööta SDK teel. Abordi vaigistus tugineb seetõttu **`signal.aborted`** olekule; `error.name`-kontroll jääb ainult toore `fetch(/people-aliases)` juurde, kus see on õige.

## Valideeritud
- `npm run typecheck` — puhas