### PR TITLE
Fix CI typecheck after comments panel extraction

### DIFF
--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -21,7 +21,6 @@ import { getCollectionColorClasses, getCollectionHierarchy } from '../../service
 import { formatYearDisplay } from '../../utils/yearDisplayUtils';
 import { fetchCommentHistory, restoreComment, CommentHistory } from '../../services/commentHistoryService';
 import { lineDiff } from '../../utils/lineDiff';
-import MarkdownEditor from '../MarkdownEditor';
 import MarkdownView from '../MarkdownView';
 import PageCommentsPanel from './PageCommentsPanel';
 


### PR DESCRIPTION
## Summary
- Remove unused `MarkdownEditor` import left in `AnnotationsTab` after extracting `PageCommentsPanel`

## Test
- npm run typecheck
- npm run build
