### PR TITLE
Extract comment history panel from AnnotationsTab

### DIFF
--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
-import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useLocation } from 'react-router-dom';
-import { BookOpen, User, ExternalLink, Download, Edit3, Tag, Search, X, Trash2, FolderOpen, Bookmark, Check, BookDown, IdCard, SquarePen, FileSliders, StickyNote, History as HistoryIcon, ChevronDown, ChevronUp } from 'lucide-react';
+import { BookOpen, User, ExternalLink, Download, Edit3, Tag, Search, X, Trash2, FolderOpen, Bookmark, Check, BookDown, IdCard, SquarePen, FileSliders, StickyNote } from 'lucide-react';
 import DownloadModal from '../DownloadModal';
 import { Work, Page, Annotation, ArchiveRef } from '../../types';
 import type { TextAnnotation } from '../../types';
@@ -19,10 +18,8 @@ import { useCollection } from '../../contexts/CollectionContext';
 import { useMeiliIndex } from '../../contexts/MeilisearchContext';
 import { getCollectionColorClasses, getCollectionHierarchy } from '../../services/collectionService';
 import { formatYearDisplay } from '../../utils/yearDisplayUtils';
-import { fetchCommentHistory, restoreComment, CommentHistory } from '../../services/commentHistoryService';
-import { lineDiff } from '../../utils/lineDiff';
-import MarkdownView from '../MarkdownView';
 import PageCommentsPanel from './PageCommentsPanel';
+import CommentHistoryPanel from './CommentHistoryPanel';
 
 interface AnnotationsTabProps {
   work?: Work;
@@ -84,13 +81,8 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   const [showDownloadModal, setShowDownloadModal] = useState(false);
   const [editingAnnId, setEditingAnnId] = useState<number | null>(null);
   const [editingAnnText, setEditingAnnText] = useState('');
-  const [commentHistory, setCommentHistory] = useState<CommentHistory | null>(null);
-  const [historyLoading, setHistoryLoading] = useState(false);
-  const [historyError, setHistoryError] = useState<string | null>(null);
-  const [restoreOpen, setRestoreOpen] = useState(false);
   const highlightedCommentId = new URLSearchParams(location.search).get('comment');
 
-  const canRestore = isAtLeast(user?.role, 'editor');
   
   // Arhiivide register (nimed kuvamiseks)
   const [archives, setArchives] = useState<Record<string, { name: string; url?: string }>>({});
@@ -178,35 +170,6 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   const removeTag = (tagToRemove: string) => {
     // Eemalda sildi järgi
     setPageTags(page_tags.filter(t => getLabel(t, lang).toLowerCase() !== tagToRemove.toLowerCase()));
-  };
-
-  const loadHistory = async (force = false) => {
-    if (!force && (commentHistory || historyLoading)) return;
-    setHistoryLoading(true);
-    setHistoryError(null);
-    try {
-      setCommentHistory(await fetchCommentHistory(_page, authToken || undefined));
-    } catch (e) {
-      setHistoryError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setHistoryLoading(false);
-    }
-  };
-
-  const doRestore = async (
-    mode: 'version' | 'deleted', commentId: string, commitHash: string,
-  ) => {
-    try {
-      const updated = await restoreComment(
-        _page, { mode, comment_id: commentId, commit_hash: commitHash }, authToken || undefined,
-      );
-      // Restore-endpoint juba committis kettale — sünkroni ainult seis, ilma teise salvestuseta.
-      if (onCommentsRestored) onCommentsRestored(updated);
-      else setComments(updated);
-      await loadHistory(true);   // värskenda ajaloo-kaart uue seisuga
-    } catch (e) {
-      setHistoryError(e instanceof Error ? e.message : t('info.restoreError'));
-    }
   };
 
   return (
@@ -830,131 +793,14 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
         highlightedCommentId={highlightedCommentId}
       />
 
-      {/* Versiooniajalugu / taastamine — eraldi kaart kõige all (kontseptuaalselt
-          erinev igapäevasest kommenteerimisest: muudetud kommentaaride varasemad
-          versioonid diffina + kustutatud kommentaaride taaste). Ainult editor+. */}
-      {canRestore && (
-        <div className="mt-4 bg-white rounded-lg border border-gray-200 shadow-sm">
-          <button
-            onClick={async () => { await loadHistory(); setRestoreOpen(o => !o); }}
-            className="flex items-center gap-2 w-full px-5 py-3 text-left text-gray-700 hover:bg-gray-50 rounded-lg"
-          >
-            <HistoryIcon size={18} className="text-primary-600" />
-            <h4 className="font-bold">{t('info.versionHistory')}</h4>
-            {commentHistory && (
-              <span className="ml-1 text-xs text-gray-400">
-                ({Object.keys(commentHistory.versions).length + commentHistory.deleted.length})
-              </span>
-            )}
-            {restoreOpen
-              ? <ChevronUp size={16} className="ml-auto text-gray-400" />
-              : <ChevronDown size={16} className="ml-auto text-gray-400" />}
-          </button>
-
-          {restoreOpen && (
-            <div className="px-5 pb-5 space-y-5">
-              {historyLoading && <p className="text-xs text-gray-400">…</p>}
-              {historyError && <p className="text-xs text-red-600">{historyError}</p>}
-              {!historyLoading && commentHistory && (
-                <>
-                  {/* Muudetud kommentaaride varasemad versioonid (diff vana → praegune) */}
-                  <div>
-                    <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
-                      {t('info.editedComments')}
-                    </h5>
-                    {Object.keys(commentHistory.versions).length === 0 ? (
-                      <p className="text-xs text-gray-400 italic">{t('info.noOlderVersions')}</p>
-                    ) : (
-                      <div className="space-y-3">
-                        {Object.entries(commentHistory.versions).map(([cid, versions]) => {
-                          const cur = comments.find(c => c.id === cid);
-                          return (
-                            <div key={cid} className="border-l-2 border-gray-200 pl-3">
-                              {cur && (
-                                <p className="text-xs text-gray-500 mb-1.5 truncate">
-                                  <span className="font-semibold text-primary-700">{cur.author}</span>
-                                  {cur.text ? ` — ${cur.text.replace(/\s+/g, ' ').slice(0, 80)}` : ''}
-                                </p>
-                              )}
-                              <div className="space-y-2">
-                                {versions.map(v => (
-                                  <div key={v.commit_hash} className="bg-gray-50 border border-gray-100 rounded overflow-hidden">
-                                    <div>
-                                      {lineDiff(v.text, cur?.text ?? '').map((d, idx) => (
-                                        <div
-                                          key={idx}
-                                          className={`font-mono text-xs whitespace-pre-wrap break-words px-2 py-0.5 border-l-2 ${
-                                            d.type === 'add'
-                                              ? 'bg-green-50 text-green-900 border-green-400'
-                                              : d.type === 'del'
-                                                ? 'bg-red-50 text-red-900 border-red-300'
-                                                : 'text-gray-500 border-transparent'
-                                          }`}
-                                        >
-                                          <span className="select-none opacity-60 mr-1">
-                                            {d.type === 'add' ? '+' : d.type === 'del' ? '−' : ' '}
-                                          </span>
-                                          {d.text || ' '}
-                                        </div>
-                                      ))}
-                                    </div>
-                                    <div className="flex justify-between items-center text-xs text-gray-400 px-2 py-1 bg-white border-t border-gray-100">
-                                      <span>{v.author} · {new Date(v.timestamp).toLocaleString('et-EE')}</span>
-                                      <button
-                                        onClick={() => doRestore('version', cid, v.commit_hash)}
-                                        className="text-primary-600 hover:text-primary-800 font-medium"
-                                      >
-                                        {t('info.restoreText')}
-                                      </button>
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Kustutatud kommentaarid */}
-                  <div>
-                    <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
-                      {t('info.deletedComments')} ({commentHistory.deleted.length})
-                    </h5>
-                    {commentHistory.deleted.length === 0 ? (
-                      <p className="text-xs text-gray-400 italic">{t('info.noDeletedComments')}</p>
-                    ) : (
-                      <div className="space-y-2">
-                        {commentHistory.deleted.map(d => (
-                          <div key={d.id} className="bg-gray-50 border border-gray-100 rounded px-2 py-1.5">
-                            <div className="vutt-md-comment text-sm text-gray-700">
-                              <MarkdownView content={d.text} softBreaks />
-                            </div>
-                            <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
-                              <span>{d.author} · {new Date(d.created_at).toLocaleString('et-EE')}</span>
-                              <button
-                                onClick={() => doRestore('deleted', d.id, d.last_seen_commit)}
-                                className="text-primary-600 hover:text-primary-800 font-medium"
-                              >
-                                {t('info.restoreComment')}
-                              </button>
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-
-                  {commentHistory.truncated && (
-                    <p className="text-xs text-gray-400 italic">{t('info.historyTruncated')}</p>
-                  )}
-                </>
-              )}
-            </div>
-          )}
-        </div>
-      )}
+      <CommentHistoryPanel
+        page={_page}
+        comments={comments}
+        setComments={setComments}
+        onCommentsRestored={onCommentsRestored}
+        authToken={authToken}
+        user={user}
+      />
     </div>
   );
 };

--- a/src/components/editor/CommentHistoryPanel.tsx
+++ b/src/components/editor/CommentHistoryPanel.tsx
@@ -1,0 +1,190 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronDown, ChevronUp, History as HistoryIcon } from 'lucide-react';
+import type { Annotation, Page } from '../../types';
+import { isAtLeast } from '../../utils/roleUtils';
+import { fetchCommentHistory, restoreComment, type CommentHistory } from '../../services/commentHistoryService';
+import { lineDiff } from '../../utils/lineDiff';
+import MarkdownView from '../MarkdownView';
+
+interface CommentHistoryPanelProps {
+  page: Page;
+  comments: Annotation[];
+  setComments: (comments: Annotation[]) => void;
+  onCommentsRestored?: (comments: Annotation[]) => void;
+  authToken: string | null;
+  user: any;
+}
+
+// Kommentaaride versiooniajalugu ja taaste. Restore-endpoint salvestab ise kettale;
+// parenti sünkroniseeritakse ainult uue comments-massiiviga.
+const CommentHistoryPanel: React.FC<CommentHistoryPanelProps> = ({
+  page,
+  comments,
+  setComments,
+  onCommentsRestored,
+  authToken,
+  user,
+}) => {
+  const { t } = useTranslation(['workspace', 'common']);
+  const [commentHistory, setCommentHistory] = useState<CommentHistory | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [restoreOpen, setRestoreOpen] = useState(false);
+
+  const canRestore = isAtLeast(user?.role, 'editor');
+  if (!canRestore) return null;
+
+  const loadHistory = async (force = false) => {
+    if (!force && (commentHistory || historyLoading)) return;
+    setHistoryLoading(true);
+    setHistoryError(null);
+    try {
+      setCommentHistory(await fetchCommentHistory(page, authToken || undefined));
+    } catch (e) {
+      setHistoryError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const doRestore = async (
+    mode: 'version' | 'deleted', commentId: string, commitHash: string,
+  ) => {
+    try {
+      const updated = await restoreComment(
+        page, { mode, comment_id: commentId, commit_hash: commitHash }, authToken || undefined,
+      );
+      if (onCommentsRestored) onCommentsRestored(updated);
+      else setComments(updated);
+      await loadHistory(true);   // värskenda ajaloo-kaart uue seisuga
+    } catch (e) {
+      setHistoryError(e instanceof Error ? e.message : t('info.restoreError'));
+    }
+  };
+
+  return (
+    <div className="mt-4 bg-white rounded-lg border border-gray-200 shadow-sm">
+      <button
+        onClick={async () => { await loadHistory(); setRestoreOpen(o => !o); }}
+        className="flex items-center gap-2 w-full px-5 py-3 text-left text-gray-700 hover:bg-gray-50 rounded-lg"
+      >
+        <HistoryIcon size={18} className="text-primary-600" />
+        <h4 className="font-bold">{t('info.versionHistory')}</h4>
+        {commentHistory && (
+          <span className="ml-1 text-xs text-gray-400">
+            ({Object.keys(commentHistory.versions).length + commentHistory.deleted.length})
+          </span>
+        )}
+        {restoreOpen
+          ? <ChevronUp size={16} className="ml-auto text-gray-400" />
+          : <ChevronDown size={16} className="ml-auto text-gray-400" />}
+      </button>
+
+      {restoreOpen && (
+        <div className="px-5 pb-5 space-y-5">
+          {historyLoading && <p className="text-xs text-gray-400">…</p>}
+          {historyError && <p className="text-xs text-red-600">{historyError}</p>}
+          {!historyLoading && commentHistory && (
+            <>
+              {/* Muudetud kommentaaride varasemad versioonid (diff vana → praegune) */}
+              <div>
+                <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
+                  {t('info.editedComments')}
+                </h5>
+                {Object.keys(commentHistory.versions).length === 0 ? (
+                  <p className="text-xs text-gray-400 italic">{t('info.noOlderVersions')}</p>
+                ) : (
+                  <div className="space-y-3">
+                    {Object.entries(commentHistory.versions).map(([cid, versions]) => {
+                      const cur = comments.find(c => c.id === cid);
+                      return (
+                        <div key={cid} className="border-l-2 border-gray-200 pl-3">
+                          {cur && (
+                            <p className="text-xs text-gray-500 mb-1.5 truncate">
+                              <span className="font-semibold text-primary-700">{cur.author}</span>
+                              {cur.text ? ` — ${cur.text.replace(/\s+/g, ' ').slice(0, 80)}` : ''}
+                            </p>
+                          )}
+                          <div className="space-y-2">
+                            {versions.map(v => (
+                              <div key={v.commit_hash} className="bg-gray-50 border border-gray-100 rounded overflow-hidden">
+                                <div>
+                                  {lineDiff(v.text, cur?.text ?? '').map((d, idx) => (
+                                    <div
+                                      key={idx}
+                                      className={`font-mono text-xs whitespace-pre-wrap break-words px-2 py-0.5 border-l-2 ${
+                                        d.type === 'add'
+                                          ? 'bg-green-50 text-green-900 border-green-400'
+                                          : d.type === 'del'
+                                            ? 'bg-red-50 text-red-900 border-red-300'
+                                            : 'text-gray-500 border-transparent'
+                                      }`}
+                                    >
+                                      <span className="select-none opacity-60 mr-1">
+                                        {d.type === 'add' ? '+' : d.type === 'del' ? '−' : ' '}
+                                      </span>
+                                      {d.text || ' '}
+                                    </div>
+                                  ))}
+                                </div>
+                                <div className="flex justify-between items-center text-xs text-gray-400 px-2 py-1 bg-white border-t border-gray-100">
+                                  <span>{v.author} · {new Date(v.timestamp).toLocaleString('et-EE')}</span>
+                                  <button
+                                    onClick={() => doRestore('version', cid, v.commit_hash)}
+                                    className="text-primary-600 hover:text-primary-800 font-medium"
+                                  >
+                                    {t('info.restoreText')}
+                                  </button>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              {/* Kustutatud kommentaarid */}
+              <div>
+                <h5 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-2">
+                  {t('info.deletedComments')} ({commentHistory.deleted.length})
+                </h5>
+                {commentHistory.deleted.length === 0 ? (
+                  <p className="text-xs text-gray-400 italic">{t('info.noDeletedComments')}</p>
+                ) : (
+                  <div className="space-y-2">
+                    {commentHistory.deleted.map(d => (
+                      <div key={d.id} className="bg-gray-50 border border-gray-100 rounded px-2 py-1.5">
+                        <div className="vutt-md-comment text-sm text-gray-700">
+                          <MarkdownView content={d.text} softBreaks />
+                        </div>
+                        <div className="flex justify-between items-center text-xs text-gray-400 mt-1">
+                          <span>{d.author} · {new Date(d.created_at).toLocaleString('et-EE')}</span>
+                          <button
+                            onClick={() => doRestore('deleted', d.id, d.last_seen_commit)}
+                            className="text-primary-600 hover:text-primary-800 font-medium"
+                          >
+                            {t('info.restoreComment')}
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {commentHistory.truncated && (
+                <p className="text-xs text-gray-400 italic">{t('info.historyTruncated')}</p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CommentHistoryPanel;


### PR DESCRIPTION
## Summary
- Extract comment version history and restore UI into `CommentHistoryPanel`
- Move history loading/restore state out of `AnnotationsTab`
- Keep restore behaviour unchanged

Part of #141.

## Test
- npm run typecheck
- npm run build
