### PR TITLE
Extract work tags panel from AnnotationsTab

### DIFF
--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -1,17 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, Link, useLocation } from 'react-router-dom';
-import { BookOpen, User, ExternalLink, Edit3, Search, X, Trash2, Check, SquarePen } from 'lucide-react';
+import { useLocation } from 'react-router-dom';
+import { Edit3, X, Trash2, Check, SquarePen } from 'lucide-react';
 import { Work, Page, Annotation } from '../../types';
 import type { TextAnnotation } from '../../types';
 import { extractHighlightedText } from '../../utils/annUtils';
 import { LinkedEntity } from '../../types/LinkedEntity';
-import { getLabel } from '../../utils/metadataUtils';
-import { getEntityUrl } from '../../utils/entityUrl';
 import PageCommentsPanel from './PageCommentsPanel';
 import CommentHistoryPanel from './CommentHistoryPanel';
 import PageTagsPanel from './PageTagsPanel';
 import WorkInfoPanel from './WorkInfoPanel';
+import WorkTagsPanel from './WorkTagsPanel';
 
 interface AnnotationsTabProps {
   work?: Work;
@@ -66,7 +65,6 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
   onDeleteTextAnnotation,
 }) => {
   const { t } = useTranslation(['workspace', 'common', 'dashboard']);
-  const navigate = useNavigate();
   const location = useLocation();
   const [editingAnnId, setEditingAnnId] = useState<number | null>(null);
   const [editingAnnText, setEditingAnnText] = useState('');
@@ -88,72 +86,7 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
         onOpenMetaModal={onOpenMetaModal}
       />
 
-      {/* Genre / Teose märksõnad */}
-      {work && work.tags && work.tags.length > 0 && (
-        <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
-          <div className="flex items-center gap-2 mb-4 text-gray-800 border-b border-gray-100 pb-2">
-            <BookOpen size={18} className="text-green-600" />
-            <h4 className="font-bold">{t('metadata.tags')}</h4>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            {work.tags.map((tag, idx) => {
-              const label = getLabel(tag, lang);
-              const tagId = typeof tag !== 'string' ? (tag as any).id : null;
-              const entityType = typeof tag !== 'string' ? (tag as any).entity_type : null;
-              const isPersonTag = entityType === 'person' || tagId?.startsWith('vutt:P');
-              const prosopoId = tagId?.startsWith('vutt:P') ? tagId : null;
-              if (isPersonTag) {
-                return prosopoId ? (
-                  <Link
-                    key={idx}
-                    to={`/persons/${prosopoId}`}
-                    className="inline-flex items-center gap-1.5 bg-primary-50 border border-primary-200 rounded-full px-2.5 py-1 text-sm text-primary-700 hover:bg-primary-100 transition-colors"
-                    title={t('dashboard:workCard.viewPerson', 'Vaata isiku lehte')}
-                  >
-                    <User size={12} className="opacity-60" />
-                    {label}
-                  </Link>
-                ) : (
-                  <a
-                    key={idx}
-                    href={getEntityUrl(tagId, (tag as any).source) ?? '#'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 bg-primary-50 border border-primary-200 rounded-full px-2.5 py-1 text-sm text-primary-700 hover:bg-primary-100 transition-colors"
-                  >
-                    <User size={12} className="opacity-60" />
-                    {label}
-                    <ExternalLink size={10} className="opacity-50" />
-                  </a>
-                );
-              }
-              return (
-                <div key={idx} className="inline-flex items-center bg-green-50 border border-green-100 rounded-full overflow-hidden">
-                  <button
-                    onClick={() => navigate(`/search?teoseTags=${encodeURIComponent(label)}`)}
-                    className="px-2.5 py-1 text-sm text-green-800 hover:bg-green-100 transition-colors flex items-center gap-1"
-                    title={`Otsi žanrit: ${label}`}
-                  >
-                    {label}
-                    <Search size={12} className="opacity-50" />
-                  </button>
-                  {getEntityUrl(tagId, typeof tag !== 'string' ? (tag as any).source : undefined) && (
-                    <a
-                      href={getEntityUrl(tagId, typeof tag !== 'string' ? (tag as any).source : undefined)!}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="pr-2 pl-1 py-1 text-green-600 hover:text-green-800 hover:bg-green-100 border-l border-green-100 transition-colors h-full flex items-center"
-                      title={tagId || ''}
-                    >
-                      <ExternalLink size={10} />
-                    </a>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
+      <WorkTagsPanel work={work} lang={lang} />
 
       {/* Tekst-annotatsioonid */}
       {textAnnotations.length > 0 && (

--- a/src/components/editor/WorkTagsPanel.tsx
+++ b/src/components/editor/WorkTagsPanel.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router-dom';
+import { BookOpen, ExternalLink, Search, User } from 'lucide-react';
+import type { Work } from '../../types';
+import { getEntityUrl } from '../../utils/entityUrl';
+import { getLabel } from '../../utils/metadataUtils';
+
+interface WorkTagsPanelProps {
+  work?: Work;
+  lang: string;
+}
+
+const WorkTagsPanel: React.FC<WorkTagsPanelProps> = ({ work, lang }) => {
+  const { t } = useTranslation(['workspace', 'common', 'dashboard']);
+  const navigate = useNavigate();
+
+  if (!work?.tags?.length) return null;
+
+  return (
+    <div className="bg-white p-5 rounded-lg border border-gray-200 shadow-sm mb-6">
+      <div className="flex items-center gap-2 mb-4 text-gray-800 border-b border-gray-100 pb-2">
+        <BookOpen size={18} className="text-green-600" />
+        <h4 className="font-bold">{t('metadata.tags')}</h4>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {work.tags.map((tag, idx) => {
+          const label = getLabel(tag, lang);
+          const tagId = typeof tag !== 'string' ? (tag as any).id : null;
+          const entityType = typeof tag !== 'string' ? (tag as any).entity_type : null;
+          const isPersonTag = entityType === 'person' || tagId?.startsWith('vutt:P');
+          const prosopoId = tagId?.startsWith('vutt:P') ? tagId : null;
+          if (isPersonTag) {
+            return prosopoId ? (
+              <Link
+                key={idx}
+                to={`/persons/${prosopoId}`}
+                className="inline-flex items-center gap-1.5 bg-primary-50 border border-primary-200 rounded-full px-2.5 py-1 text-sm text-primary-700 hover:bg-primary-100 transition-colors"
+                title={t('dashboard:workCard.viewPerson', 'Vaata isiku lehte')}
+              >
+                <User size={12} className="opacity-60" />
+                {label}
+              </Link>
+            ) : (
+              <a
+                key={idx}
+                href={getEntityUrl(tagId, (tag as any).source) ?? '#'}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 bg-primary-50 border border-primary-200 rounded-full px-2.5 py-1 text-sm text-primary-700 hover:bg-primary-100 transition-colors"
+              >
+                <User size={12} className="opacity-60" />
+                {label}
+                <ExternalLink size={10} className="opacity-50" />
+              </a>
+            );
+          }
+          return (
+            <div key={idx} className="inline-flex items-center bg-green-50 border border-green-100 rounded-full overflow-hidden">
+              <button
+                onClick={() => navigate(`/search?teoseTags=${encodeURIComponent(label)}`)}
+                className="px-2.5 py-1 text-sm text-green-800 hover:bg-green-100 transition-colors flex items-center gap-1"
+                title={`Otsi žanrit: ${label}`}
+              >
+                {label}
+                <Search size={12} className="opacity-50" />
+              </button>
+              {getEntityUrl(tagId, typeof tag !== 'string' ? (tag as any).source : undefined) && (
+                <a
+                  href={getEntityUrl(tagId, typeof tag !== 'string' ? (tag as any).source : undefined)!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="pr-2 pl-1 py-1 text-green-600 hover:text-green-800 hover:bg-green-100 border-l border-green-100 transition-colors h-full flex items-center"
+                  title={tagId || ''}
+                >
+                  <ExternalLink size={10} />
+                </a>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default WorkTagsPanel;


### PR DESCRIPTION
## Summary
- Extract work-level tags display into `WorkTagsPanel`
- Keep tag links/search behaviour unchanged
- Further reduce `AnnotationsTab`

Part of #141.

## Test
- npm run typecheck
- npm run build
