### PR TITLE
i18n: mitte-eesti brauser vaikimisi inglise keelde

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -65,7 +65,11 @@ i18n
   .use(initReactI18next)
   .init({
     resources,
-    fallbackLng: 'et',
+    // Mitte-eesti brauser → inglise (rahvusvaheline publik). Eesti brauser saab
+    // eesti keele (navigator tuvastab 'et'); tundmatu/muu keel langeb 'en' peale.
+    // Teine fallback 'et' = turvavõrk, kui mõni 'en' võti peaks puuduma.
+    // localStorage 'vutt_language' (käsitsi valik) on tuvastusjärjekorras esimene.
+    fallbackLng: ['en', 'et'],
     defaultNS: 'common',
     ns: ['common', 'auth', 'dashboard', 'workspace', 'search', 'statistics', 'admin', 'register', 'review', 'upload', 'prosopography', 'settings'],
 


### PR DESCRIPTION
## Muudatus
`src/i18n.ts`: `fallbackLng: 'et'` → `fallbackLng: ['en', 'et']`.

Seni sai iga brauser, mille keel polnud eesti ega inglise (de, fi, ru, fr…), **eesti keele** (fallback) — rahvusvahelisele publikule halvem kui inglise. Nüüd:

| Brauseri keel | Enne | Nüüd |
|---|---|---|
| `et*` | eesti | eesti |
| `en*` | inglise | inglise |
| muu / tuvastamatu | **eesti** | **inglise** |

Käsitsi keelevalik (localStorage `vutt_language`) on tuvastusjärjekorras esimene ja püsib üle seansside. Teine fallback `et` katab võimalikud puuduvad `en` võtmed.

## Mõju
- Ainult **kliendipoolne** UX — ei mõjuta SEO-d (Googlebot näeb staatilist et `index.html`-i).
- Eesti- ja inglisekeelsed brauserid: muutust pole.
- `npm run typecheck` puhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)