### PR TITLE
Prosopograafia i18n: jagatud Pagination + tõlkevõtmed + staatuse/confessiooni sildid

### DIFF
--- a/scripts/migrate_prosopo_status_labels.py
+++ b/scripts/migrate_prosopo_status_labels.py
@@ -1,0 +1,131 @@
+"""Ühekordne migratsioon: backfill mitmekeelsed `labels` staatuse/konfessiooni sildile.
+
+Vanad prosopograafia kaardid salvestasid statuses[]/confessions[] ainult eesti
+`label`-iga (ilma `labels` objektita) → detail-leht kuvab need eesti keeles ka
+inglise UI-s. See skript lisab igale kirjele `labels` objekti (nt {"et":..,"en":..})
+sõnavarast (`vocabularies.json` → seisused/konfessioonid), id järgi. Kuna
+`useEntityLabel` eelistab `labels[lang]`, parandab see KÕIK kuvakohad korraga.
+
+Kasutus (serveris, Dockeris):
+  docker exec vutt-backend python3 scripts/migrate_prosopo_status_labels.py --dry-run
+  docker exec vutt-backend python3 scripts/migrate_prosopo_status_labels.py --apply
+  docker exec vutt-backend python3 scripts/migrate_prosopo_status_labels.py --apply --commit
+
+Pärast --apply tee data/ git commit (käsitsi või --commit). Meilisearchi ei mõjuta
+(staatus/konfessioon ei ole otsingu-väljad).
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DATA_ROOT = os.getenv("VUTT_DATA_DIR", str(_PROJECT_ROOT / "data"))
+CONFIG_DIR = os.path.join(DATA_ROOT, "config")
+VOCAB_FILE = os.path.join(CONFIG_DIR, "vocabularies.json")
+PROSOPO_DIR = os.path.join(CONFIG_DIR, "prosopography")
+
+FIELDS = ("statuses", "confessions")
+VOCAB_KEYS = {"statuses": "seisused", "confessions": "konfessioonid"}
+
+
+def _load_vocab_map():
+    """Ehita {field: {id: label_dict}} sõnavarast."""
+    with open(VOCAB_FILE, "r", encoding="utf-8") as f:
+        vocab = json.load(f)
+    maps = {}
+    for field, vkey in VOCAB_KEYS.items():
+        m = {}
+        for item in vocab.get(vkey, []) or []:
+            iid = item.get("id")
+            label = item.get("label")
+            if iid and isinstance(label, dict):
+                # Ainult mittetühjad keeleväärtused
+                clean = {k: v for k, v in label.items() if v}
+                if clean:
+                    m[iid] = clean
+        maps[field] = m
+    return maps
+
+
+def _migrate_record(data, maps):
+    """Muuda kirjet kohapeal; tagasta muudetud kirjete arv."""
+    changed = 0
+    for field in FIELDS:
+        entries = data.get(field)
+        if not isinstance(entries, list):
+            continue
+        vmap = maps.get(field, {})
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            iid = entry.get("id")
+            if not iid or iid not in vmap:
+                continue
+            new_labels = vmap[iid]
+            if entry.get("labels") != new_labels:
+                entry["labels"] = new_labels
+                changed += 1
+    return changed
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true", help="Kirjuta muudatused (muidu dry-run)")
+    ap.add_argument("--dry-run", action="store_true", help="Ainult näita muudatusi (vaikimisi, kui --apply puudub)")
+    ap.add_argument("--commit", action="store_true", help="Pärast --apply tee data/ git commit")
+    ap.add_argument("--limit", type=int, default=0, help="Töötle ainult N esimest muudetavat faili (test)")
+    args = ap.parse_args()
+
+    if not os.path.exists(VOCAB_FILE):
+        print(f"Sõnavara puudub: {VOCAB_FILE}", file=sys.stderr)
+        return 1
+    if not os.path.isdir(PROSOPO_DIR):
+        print(f"Prosopograafia kaust puudub: {PROSOPO_DIR}", file=sys.stderr)
+        return 1
+
+    maps = _load_vocab_map()
+    print(f"Sõnavara: {len(maps['statuses'])} seisust, {len(maps['confessions'])} konfessiooni")
+
+    files_changed = 0
+    entries_changed = 0
+    for fpath in sorted(Path(PROSOPO_DIR).glob("*.json")):
+        try:
+            data = json.loads(fpath.read_text(encoding="utf-8"))
+        except Exception as e:
+            print(f"SKIP {fpath.name}: {e}", file=sys.stderr)
+            continue
+
+        n = _migrate_record(data, maps)
+        if n == 0:
+            continue
+
+        files_changed += 1
+        entries_changed += n
+        if args.apply:
+            fpath.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        else:
+            print(f"[dry-run] {fpath.name}: {n} kirjet")
+
+        if args.limit and files_changed >= args.limit:
+            break
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] {files_changed} faili, {entries_changed} kirjet backfill'itud.")
+
+    if args.apply and args.commit and files_changed:
+        msg = f"Backfill mitmekeelsed labels staatuse/konfessiooni sildile ({files_changed} kaarti)"
+        try:
+            subprocess.run(["git", "-C", DATA_ROOT, "add", "-A", "config/prosopography"], check=True)
+            subprocess.run(["git", "-C", DATA_ROOT, "commit", "-m", msg], check=True)
+            print(f"data/ git commit tehtud: {msg}")
+        except subprocess.CalledProcessError as e:
+            print(f"git commit ebaõnnestus: {e}", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  /** Väline paigutus (nt "mt-10 pt-6 border-t border-gray-200") */
+  className?: string;
+}
+
+// Nummerdatud lehed ellipsis'ega: alati esimene+viimane, praeguse ümber ±1
+const getPageNumbers = (currentPage: number, totalPages: number): (number | string)[] => {
+  const pages: (number | string)[] = [];
+  if (totalPages <= 7) {
+    for (let i = 1; i <= totalPages; i++) pages.push(i);
+  } else {
+    pages.push(1);
+    if (currentPage > 3) pages.push('...');
+    for (let i = Math.max(2, currentPage - 1); i <= Math.min(totalPages - 1, currentPage + 1); i++) {
+      pages.push(i);
+    }
+    if (currentPage < totalPages - 2) pages.push('...');
+    pages.push(totalPages);
+  }
+  return pages;
+};
+
+/**
+ * Jagatud pagineerimiskomponent (Dashboard + PersonsPage). Nummerdatud lehed
+ * ellipsis'ega desktopil, "x/y" indikaator mobiilil. Tõlked: common:buttons.
+ */
+const Pagination: React.FC<PaginationProps> = ({ currentPage, totalPages, onPageChange, className = '' }) => {
+  const { t } = useTranslation('common');
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className={`flex justify-center items-center gap-2 ${className}`}>
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        aria-label={t('common:buttons.previous')}
+        className="flex items-center gap-1 px-3 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 font-medium hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <ChevronLeft size={18} />
+        <span className="hidden sm:inline">{t('common:buttons.previous')}</span>
+      </button>
+
+      {/* Mobiilne lehekülje indikaator */}
+      <span className="sm:hidden text-sm font-medium text-gray-600">{currentPage}/{totalPages}</span>
+
+      <div className="hidden sm:flex items-center gap-1 mx-2">
+        {getPageNumbers(currentPage, totalPages).map((page, idx) => (
+          page === '...' ? (
+            <span key={`ellipsis-${idx}`} className="px-2 text-gray-400">...</span>
+          ) : (
+            <button
+              key={page}
+              onClick={() => onPageChange(page as number)}
+              className={`w-10 h-10 rounded-lg font-medium transition-colors ${currentPage === page
+                ? 'bg-primary-600 text-white'
+                : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
+                }`}
+            >
+              {page}
+            </button>
+          )
+        ))}
+      </div>
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        aria-label={t('common:buttons.next')}
+        className="flex items-center gap-1 px-3 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 font-medium hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        <span className="hidden sm:inline">{t('common:buttons.next')}</span>
+        <ChevronRight size={18} />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/locales/en/prosopography.json
+++ b/src/locales/en/prosopography.json
@@ -215,6 +215,10 @@
   "persons": "persons",
   "immatriculation": "Matriculation",
   "statuses": "Statuses",
+  "workRelations": "Connections through works",
+  "sharedWorks_one": "{{count}} shared work",
+  "sharedWorks_other": "{{count}} shared works",
+  "history": "Change history",
   "tags": "Keywords",
   "loadMore": "Load more",
   "bulkOccupation": {

--- a/src/locales/et/prosopography.json
+++ b/src/locales/et/prosopography.json
@@ -215,6 +215,10 @@
   "persons": "isikut",
   "immatriculation": "Immatrikuleerumine",
   "statuses": "Seisused",
+  "workRelations": "Seosed teoste kaudu",
+  "sharedWorks_one": "{{count}} ühine teos",
+  "sharedWorks_other": "{{count}} ühist teost",
+  "history": "Muudatuste ajalugu",
   "tags": "Märksõnad",
   "loadMore": "Lae veel",
   "bulkOccupation": {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,10 +12,11 @@ import AdvancedFilters from '../components/AdvancedFilters';
 import { useUser } from '../contexts/UserContext';
 import { useCollection } from '../contexts/CollectionContext';
 import { useMeiliIndex } from '../contexts/MeilisearchContext';
-import { Search, AlertTriangle, ArrowUpDown, X, ChevronLeft, ChevronRight, User, Library, ChevronDown, Lock, LogIn } from 'lucide-react';
+import { Search, AlertTriangle, ArrowUpDown, X, User, Library, ChevronDown, Lock, LogIn } from 'lucide-react';
 import CollectionPicker from '../components/CollectionPicker';
 import CollectionInfoBanner from '../components/CollectionInfoBanner';
 import SafeHtml from '../components/SafeHtml';
+import Pagination from '../components/Pagination';
 import BulkTagsPicker from '../components/BulkTagsPicker';
 import BulkGenrePicker from '../components/BulkGenrePicker';
 import { LinkedEntity } from '../types/LinkedEntity';
@@ -780,23 +781,6 @@ const Dashboard: React.FC = () => {
                 window.scrollTo(0, 0);
               };
 
-              // Generate page numbers to show
-              const getPageNumbers = () => {
-                const pages: (number | string)[] = [];
-                if (totalPages <= 7) {
-                  for (let i = 1; i <= totalPages; i++) pages.push(i);
-                } else {
-                  pages.push(1);
-                  if (currentPage > 3) pages.push('...');
-                  for (let i = Math.max(2, currentPage - 1); i <= Math.min(totalPages - 1, currentPage + 1); i++) {
-                    pages.push(i);
-                  }
-                  if (currentPage < totalPages - 2) pages.push('...');
-                  pages.push(totalPages);
-                }
-                return pages;
-              };
-
               return (
                 <>
                   <DashboardResultsHeader
@@ -845,51 +829,12 @@ const Dashboard: React.FC = () => {
                       </div>
 
                       {/* Pagination */}
-                      {totalPages > 1 && (
-                        <div className="flex justify-center items-center gap-2 mt-10 pt-6 border-t border-gray-200">
-                          <button
-                            onClick={() => handlePageChange(currentPage - 1)}
-                            disabled={currentPage === 1}
-                            aria-label={t('common:buttons.previous')}
-                            className="flex items-center gap-1 px-3 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 font-medium hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                          >
-                            <ChevronLeft size={18} />
-                            <span className="hidden sm:inline">{t('common:buttons.previous')}</span>
-                          </button>
-
-                          {/* Mobiilne lehekülje indikaator */}
-                          <span className="sm:hidden text-sm font-medium text-gray-600">{currentPage}/{totalPages}</span>
-
-                          <div className="hidden sm:flex items-center gap-1 mx-2">
-                            {getPageNumbers().map((page, idx) => (
-                              page === '...' ? (
-                                <span key={`ellipsis-${idx}`} className="px-2 text-gray-400">...</span>
-                              ) : (
-                                <button
-                                  key={page}
-                                  onClick={() => handlePageChange(page as number)}
-                                  className={`w-10 h-10 rounded-lg font-medium transition-colors ${currentPage === page
-                                    ? 'bg-primary-600 text-white'
-                                    : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50'
-                                    }`}
-                                >
-                                  {page}
-                                </button>
-                              )
-                            ))}
-                          </div>
-
-                          <button
-                            onClick={() => handlePageChange(currentPage + 1)}
-                            disabled={currentPage === totalPages}
-                            aria-label={t('common:buttons.next')}
-                            className="flex items-center gap-1 px-3 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 font-medium hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                          >
-                            <span className="hidden sm:inline">{t('common:buttons.next')}</span>
-                            <ChevronRight size={18} />
-                          </button>
-                        </div>
-                      )}
+                      <Pagination
+                        currentPage={currentPage}
+                        totalPages={totalPages}
+                        onPageChange={handlePageChange}
+                        className="mt-10 pt-6 border-t border-gray-200"
+                      />
                     </>
                   ) : (
                     <div className="text-center py-16 bg-white rounded-xl border border-gray-200 border-dashed">

--- a/src/prosopography/components/WorkRelationsCard.tsx
+++ b/src/prosopography/components/WorkRelationsCard.tsx
@@ -68,7 +68,7 @@ const WorkRelationsCard: React.FC<{ personId: string }> = ({ personId }) => {
                 </Link>
               </div>
               <span className="text-xs text-gray-400 shrink-0 ml-3">
-                {rel.shared_works_count} {t('sharedWorks', 'ühist teost')}
+                {t('sharedWorks', { count: rel.shared_works_count })}
               </span>
             </button>
 

--- a/src/prosopography/components/personForm/helpers.ts
+++ b/src/prosopography/components/personForm/helpers.ts
@@ -274,11 +274,12 @@ export function draftToPayload(
     death: buildDatePayload(draft.death) ?? (original?.death ?? null as any),
     statuses: (draft.statuses ?? []).map(qId => {
       const vocabItem = seisusedVocab.find(s => s.id === qId);
-      return { id: qId, label: vocabItem?.label?.et ?? qId };
+      // Salvesta mitmekeelne labels-objekt → useEntityLabel kuvab UI-keeles
+      return { id: qId, label: vocabItem?.label?.et ?? qId, labels: vocabItem?.label };
     }),
     confessions: (draft.confessions ?? []).map(qId => {
       const vocabItem = konfessioonidVocab.find(k => k.id === qId);
-      return { id: qId, label: vocabItem?.label?.et ?? qId };
+      return { id: qId, label: vocabItem?.label?.et ?? qId, labels: vocabItem?.label };
     }),
     origin: {
       place: draft.origin_place || null,

--- a/src/prosopography/pages/PersonDetailPage.tsx
+++ b/src/prosopography/pages/PersonDetailPage.tsx
@@ -765,7 +765,7 @@ const PersonDetailPage: React.FC = () => {
                 )}
               </div>
               <div className="flex items-center gap-2">
-                {historyLoading && <span className="text-xs text-gray-400">Laadin…</span>}
+                {historyLoading && <span className="text-xs text-gray-400">{t('common:loading')}</span>}
                 {historyOpen ? <ChevronDown size={16} className="text-gray-400" /> : <ChevronRight size={16} className="text-gray-400" />}
               </div>
             </button>

--- a/src/prosopography/pages/PersonsPage.tsx
+++ b/src/prosopography/pages/PersonsPage.tsx
@@ -2,8 +2,9 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { isAtLeast } from '../../utils/roleUtils';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, Link, useSearchParams } from 'react-router-dom';
-import { ArrowDownAZ, Search, UserPlus, Users, CheckSquare, Square, GitMerge, X, ChevronLeft, ChevronRight, Map, List } from 'lucide-react';
+import { ArrowDownAZ, Search, UserPlus, Users, CheckSquare, Square, GitMerge, X, Map, List } from 'lucide-react';
 import Header from '../../components/Header';
+import Pagination from '../../components/Pagination';
 import PersonCard from '../components/PersonCard';
 import PersonsMap from '../components/PersonsMap';
 import MergePersonsModal from '../components/MergePersonsModal';
@@ -450,28 +451,13 @@ const PersonsPage: React.FC = () => {
           />
         )}
 
-        {view === 'list' && !(loading || false) && totalPages > 1 && (
-          <div className="flex justify-center items-center gap-3 mt-8 pt-6 border-t border-gray-200">
-            <button
-              onClick={() => setOffset(offset - LIMIT)}
-              disabled={offset === 0}
-              className="flex items-center gap-1 px-3 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 text-sm font-medium hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-            >
-              <ChevronLeft size={16} />
-              {t('common:pagination.previous', 'Eelmine')}
-            </button>
-            <span className="text-sm text-gray-500 font-mono">
-              {currentPage} / {totalPages}
-            </span>
-            <button
-              onClick={() => setOffset(offset + LIMIT)}
-              disabled={offset + LIMIT >= total}
-              className="flex items-center gap-1 px-3 py-2 rounded-lg border border-gray-300 bg-white text-gray-700 text-sm font-medium hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-            >
-              {t('common:pagination.next', 'Järgmine')}
-              <ChevronRight size={16} />
-            </button>
-          </div>
+        {view === 'list' && !loading && (
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={(page) => { setOffset((page - 1) * LIMIT); window.scrollTo(0, 0); }}
+            className="mt-8 pt-6 border-t border-gray-200"
+          />
         )}
       </main>
 

--- a/src/prosopography/types.ts
+++ b/src/prosopography/types.ts
@@ -147,8 +147,8 @@ export interface ProsopoRecord {
     coordinates: string | null;
   };
   floruit?: { year_from?: number | null; year_to?: number | null } | null;
-  statuses: { id: string; label: string }[];
-  confessions: { id: string; label: string }[];
+  statuses: { id: string; label: string; labels?: { et?: string; en?: string } }[];
+  confessions: { id: string; label: string; labels?: { et?: string; en?: string } }[];
   occupations: any[];
   education: any[];
   burial: any | null;


### PR DESCRIPTION
## Probleemid (kasutaja raporteeritud)
1. Prosopo isiku lehel tõlkevõtmeta stringid: "Seosed teoste kaudu", "1 ühist teost", "Muudatuste ajalugu", "Laadin…".
2. `/persons` pagineerimine ("Eelmine/Järgmine") ainult eesti keeles — vale tõlkevõti `common:pagination.*` (ei eksisteeri).
3. Staatused (aadel, vaimulk) ja confession (luterlane) kuvatakse detail-lehel eesti keeles ka inglise UI-s, kuigi edit-lehel on inglise vasted olemas.

## Muudatused

### Jagatud Pagination
- Uus `src/components/Pagination.tsx` — nummerdatud lehed + ellipsis + mobiili-indikaator, tõlked `common:buttons`.
- `Dashboard.tsx` ja `PersonsPage.tsx` kasutavad seda. PersonsPage sai nummerdatud lehed ja korrektse tõlke (oli katkine `common:pagination.*` → nüüd komponendi `common:buttons.*`).

### i18n-võtmed
- `prosopography.json` (et+en): `workRelations`, `sharedWorks_one/_other` (mitmus), `history`.
- `WorkRelationsCard` "ühist teost" → `t('sharedWorks', {count})`. `PersonDetailPage` "Laadin…" → `common:loading`.

### Staatus/confession sildid (andmete migreerimine)
- Juurpõhjus: salvestamisel pandi kirja ainult eesti `label` (`vocabItem.label.et`), ilma mitmekeelse `labels` objektita → `useEntityLabel` (mis eelistab `labels[lang]`) langeb eesti `label`-ile.
- `types.ts` + `helpers.ts`: salvestus paneb nüüd kirja `labels` (mitmekeelne) sõnavarast.
- `scripts/migrate_prosopo_status_labels.py`: backfillib olemasolevad ~2218 kaarti sõnavarast (`--dry-run`/`--apply`/`--commit`). Idempotentne, testitud fixture'iga.

## Test
`npm run typecheck` puhas; migratsiooniskript testitud (dry-run ei kirjuta, apply backfillib, re-run 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)