### PR TITLE
Bot-prerender: og:image + twitter-kaart kõigil bot-lehtedel

### DIFF
--- a/server/metadata_handler.py
+++ b/server/metadata_handler.py
@@ -19,6 +19,18 @@ logger = logging.getLogger(__name__)
 SITE_NAME = "VUTT"
 SITE_ALT_NAME = "Varauusaegsete tekstide töölaud"
 _OG_SITE_NAME = f'<meta property="og:site_name" content="{SITE_NAME}">'
+# og:image jagamispilt: ilma selleta näitavad sotsiaalmeedia/vestlusrakendused
+# linki pildita kaardina. Teose lehel kasutatakse teose enda avalikku thumbi
+# (/api/images/{id}/_thumb), mujal staatiline 1200×630 vutt-og.png.
+_OG_IMAGE_URL = f"{SITE_URL}/vutt-og.png"
+_OG_IMAGE_STATIC = (
+    f'<meta property="og:image" content="{_OG_IMAGE_URL}">\n'
+    '    <meta property="og:image:type" content="image/png">\n'
+    '    <meta property="og:image:width" content="1200">\n'
+    '    <meta property="og:image:height" content="630">\n'
+    '    <meta name="twitter:card" content="summary_large_image">\n'
+    f'    <meta name="twitter:image" content="{_OG_IMAGE_URL}">'
+)
 _WEBSITE_JSONLD = (
     '<script type="application/ld+json">\n'
     '    {"@context":"https://schema.org","@type":"WebSite",'
@@ -158,7 +170,7 @@ def build_meta_html(work_id: str, creator_persons=None, include_text: bool = Tru
 
     title = "VUTT - Varauusaegsete tekstide töölaud"
     description = "Vaata ja toimeta Tartu Ülikooli varauusaegseid akadeemilisi tekste."
-    image_url = f"{SITE_URL}/vutt-og.png"
+    image_url = _OG_IMAGE_URL
     meta = {}
 
     if found_path:
@@ -176,6 +188,20 @@ def build_meta_html(work_id: str, creator_persons=None, include_text: bool = Tru
             except Exception:
                 pass
         image_url = f"{SITE_URL}/api/images/{_escape(work_id)}/_thumb"
+
+    # Teose thumbi mõõdud varieeruvad → mõõte ei väida; staatilisel PNG-l fikseeritud.
+    if found_path:
+        og_image_tags = (
+            f'<meta property="og:image" content="{image_url}">\n'
+            '    <meta property="og:image:type" content="image/jpeg">'
+        )
+    else:
+        og_image_tags = (
+            f'<meta property="og:image" content="{image_url}">\n'
+            '    <meta property="og:image:type" content="image/png">\n'
+            '    <meta property="og:image:width" content="1200">\n'
+            '    <meta property="og:image:height" content="630">'
+        )
 
     safe_work_id = _escape(work_id)
     work_url = f"{SITE_URL}/work/{safe_work_id}"
@@ -262,10 +288,7 @@ def build_meta_html(work_id: str, creator_persons=None, include_text: bool = Tru
     <meta property="og:url" content="{work_url}">
     <meta property="og:title" content="{safe_title}">
     <meta property="og:description" content="{safe_desc}">
-    <meta property="og:image" content="{image_url}">
-    <meta property="og:image:type" content="image/jpeg">
-    <meta property="og:image:width" content="400">
-    <meta property="og:image:height" content="600">
+    {og_image_tags}
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{safe_title}">
@@ -321,6 +344,7 @@ def build_persons_meta_html(person_entries=None) -> str:
     <meta property="og:url" content="{persons_url}">
     <meta property="og:title" content="{safe_title}">
     <meta property="og:description" content="{safe_desc}">
+    {_OG_IMAGE_STATIC}
 </head>
 <body>
     {body_content}
@@ -395,6 +419,7 @@ def build_home_meta_html(work_id_cache, is_work_public_fn, load_meta_fn, work_co
     <meta property="og:url" content="{home_url}">
     <meta property="og:title" content="{safe_title}">
     <meta property="og:description" content="{safe_desc}">
+    {_OG_IMAGE_STATIC}
     {_WEBSITE_JSONLD}
 </head>
 <body>
@@ -484,6 +509,7 @@ def build_person_meta_html(person_id: str, work_links=None) -> Optional[str]:
     <meta property="og:url" content="{person_url}">
     <meta property="og:title" content="{safe_title}">
     <meta property="og:description" content="{safe_desc}">
+    {_OG_IMAGE_STATIC}
 </head>
 <body>
     {body_content}

--- a/tests/test_bot_link_graph.py
+++ b/tests/test_bot_link_graph.py
@@ -214,3 +214,51 @@ def test_person_work_title_escaped(patch_person):
     from server.metadata_handler import build_person_meta_html
     html = build_person_meta_html("vutt:P1", work_links=[{"work_id": "wx", "title": "<x>"}])
     assert "<x>" not in html
+
+
+# ---------------------------------------------------------------------------
+# og:image — sotsiaalmeedia jagamise pilt kõigil bot-lehtedel
+# ---------------------------------------------------------------------------
+
+OG_STATIC = 'property="og:image" content="https://vutt.utlib.ut.ee/vutt-og.png"'
+
+
+def test_home_has_og_image_and_twitter_card():
+    html = _home({}, lambda m: True, lambda wid: None, {})
+    assert OG_STATIC in html
+    assert 'name="twitter:card" content="summary_large_image"' in html
+    assert 'name="twitter:image" content="https://vutt.utlib.ut.ee/vutt-og.png"' in html
+
+
+def test_persons_hub_has_og_image():
+    from server.metadata_handler import build_persons_meta_html
+    html = build_persons_meta_html([])
+    assert OG_STATIC in html
+    assert 'name="twitter:card"' in html
+
+
+def test_person_page_has_og_image(patch_person):
+    from server.metadata_handler import build_person_meta_html
+    html = build_person_meta_html("vutt:P1", work_links=[])
+    assert OG_STATIC in html
+    assert 'name="twitter:card"' in html
+
+
+def test_work_og_image_is_thumb_without_bogus_dimensions(patch_find):
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    registry["work001"] = _write_meta(tmp_path, WORK_META)
+    html = build_meta_html("work001")
+    assert 'property="og:image" content="https://vutt.utlib.ut.ee/api/images/work001/_thumb"' in html
+    assert 'content="image/jpeg"' in html
+    # Thumbi mõõdud varieeruvad teoste kaupa — valesid fikseeritud mõõte ei tohi väita
+    assert 'og:image:width" content="400"' not in html
+    assert 'og:image:height" content="600"' not in html
+
+
+def test_unknown_work_fallback_og_image_is_static_png(patch_find):
+    from server.metadata_handler import build_meta_html
+    html = build_meta_html("puudub123")
+    assert OG_STATIC in html
+    assert 'content="image/png"' in html
+    assert 'content="image/jpeg"' not in html


### PR DESCRIPTION
## Mis muutus

Sotsiaalmeedias/vestlusrakendustes jagatud lingid näitasid kodulehe, /persons-i ja isikukaartide puhul pildita kaarti — bot-prerenderis polnud `og:image`'it. (Teose lehel oli thumb juba olemas.)

- **Koduleht, isikute-hub, isikukaart**: staatiline 1200×630 `vutt-og.png` (juba olemas `public/`-is) + `twitter:card summary_large_image`
- **Teose leht**: eemaldatud valed fikseeritud mõõdud `og:image:width=400/height=600` — tegelik thumb varieerub teoste kaupa (nt 814×560); valed vihjed võivad scraperites paigutust rikkuda
- **Tundmatu teose fallback**: staatiline PNG õige `og:image:type`-iga (varem väitis `image/jpeg` PNG kohta)

## Testid

5 uut testi (`tests/test_bot_link_graph.py`), kogu suite: 867 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)