### PR TITLE
Fix restricted work access checks and fail-closed metadata

### DIFF
--- a/server/git_ops.py
+++ b/server/git_ops.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from git import Repo, Actor
 from git.exc import InvalidGitRepositoryError, GitCommandError
 from .config import BASE_DIR, get_logger
-from .utils import sanitize_id
+from .utils import atomic_write_text, sanitize_id
 
 logger = get_logger(__name__)
 
@@ -324,11 +324,9 @@ def save_with_git(filepath, content, username, message=None, additional_files=No
     except Exception:
         is_first_commit = True
 
-    # Kirjuta põhifail
-    with open(filepath, 'w', encoding='utf-8') as f:
-        f.write(content)
-    # Sea failiõigused loetavaks kõigile (Docker/root probleemi vältimiseks)
-    os.chmod(filepath, 0o644)
+    # Atomaarne kirjutus: ligipääsukontrolli lugeja ei tohi näha poolikut
+    # _metadata.json-i (sama helper sobib ka txt/json lisafailidele).
+    atomic_write_text(filepath, content)
 
     # Kogu kõik failid indeksisse lisamiseks
     files_to_add = [relative_path]
@@ -336,9 +334,7 @@ def save_with_git(filepath, content, username, message=None, additional_files=No
     # Kirjuta ja lisa lisafailid
     if additional_files:
         for add_filepath, add_content in additional_files:
-            with open(add_filepath, 'w', encoding='utf-8') as f:
-                f.write(add_content)
-            os.chmod(add_filepath, 0o644)
+            atomic_write_text(add_filepath, add_content)
             add_relative = os.path.relpath(add_filepath, BASE_DIR)
             files_to_add.append(add_relative)
 

--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from starlette.concurrency import run_in_threadpool
 
-from ..access_ops import can_write_work
+from ..access_ops import can_read_work, can_write_work
 from ..auth import is_at_least
 from ..cache import get_cached_suggestions
 from ..cache_invalidation import invalidate_all_caches as _invalidate_all_caches
@@ -32,9 +32,44 @@ from ..metadata_ops import bulk_update_field, save_work_metadata
 from ..people_ops import process_person_fields_metadata
 from ..prosopography.relations import update_page_person_mentions
 from ..utils import find_directory_by_id
-from ..work_meta import read_work_meta_direct_sync as _read_work_meta_direct_sync
-
 router = APIRouter()
+
+
+def _read_catalog_metadata(catalog: str) -> dict:
+    """Laeb teose meta ligipääsukontrolliks; vigane/puuduv meta on fail-closed."""
+    if not catalog or catalog != os.path.basename(catalog):
+        raise HTTPException(status_code=400, detail="Vigane teose tee")
+    work_dir = os.path.join(BASE_DIR, catalog)
+    meta_path = os.path.join(work_dir, "_metadata.json")
+    if not os.path.isdir(work_dir) or not os.path.exists(meta_path):
+        raise HTTPException(status_code=404, detail="Teost ei leitud")
+    try:
+        with open(meta_path, "r", encoding="utf-8") as f:
+            meta = json.load(f)
+    except Exception:
+        raise HTTPException(status_code=503, detail="Teose metaandmeid ei saa praegu lugeda")
+    if not isinstance(meta, dict):
+        raise HTTPException(status_code=503, detail="Teose metaandmed on vigased")
+    return meta
+
+
+def _require_catalog_access(catalog: str, user: dict, *, write: bool = False) -> dict:
+    meta = _read_catalog_metadata(catalog)
+    allowed = can_write_work(meta, user) if write else can_read_work(meta, user)
+    if not allowed:
+        raise HTTPException(status_code=403, detail="Puudub õigus sellele teosele")
+    return meta
+
+
+def _catalog_from_filepath(filepath: str) -> tuple[str, str]:
+    """Normaliseerib git-diffi tee kujule ``catalog/filename``."""
+    parts = [part for part in str(filepath or "").replace("\\", "/").strip("/").split("/") if part]
+    if len(parts) < 2 or any(part in (".", "..") for part in parts):
+        raise HTTPException(status_code=400, detail="Vigane failitee")
+    catalog, filename = parts[-2], parts[-1]
+    if catalog != os.path.basename(catalog) or filename != os.path.basename(filename):
+        raise HTTPException(status_code=400, detail="Vigane failitee")
+    return catalog, os.path.join(catalog, filename)
 
 
 @router.post("/save")
@@ -51,17 +86,8 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
     catalog, filename = os.path.basename(data.get('original_path', '')), os.path.basename(data.get('file_name', ''))
     if not catalog or not filename: raise HTTPException(status_code=400, detail="Vigased teed")
 
-    # Kirjutamisõiguse kontroll: piiratud kollektsiooni teosesse saab kirjutada ainult
-    # editor allowed_collections kattuvusega või admin (Leid G). Avalikud teosed läbivad alati.
-    _work_meta_path = os.path.join(BASE_DIR, catalog, '_metadata.json')
-    if os.path.exists(_work_meta_path):
-        try:
-            with open(_work_meta_path, 'r', encoding='utf-8') as f:
-                _work_meta = json.load(f)
-        except Exception:
-            _work_meta = None
-        if _work_meta is not None and not can_write_work(_work_meta, user):
-            raise HTTPException(status_code=403, detail="Puudub õigus sellesse teosesse kirjutada")
+    # Puuduv/vigane meta ei tohi muuta piiratud teose kontrolli fail-open'iks.
+    await run_in_threadpool(_require_catalog_access, catalog, user, write=True)
 
     txt_path = os.path.join(BASE_DIR, catalog, filename)
     additional = []
@@ -127,9 +153,13 @@ async def update_work_metadata(request: Request, background_tasks: BackgroundTas
 @router.post("/get-work-metadata")
 async def get_work_meta_direct(request: Request, user=Depends(require_role("editor"))):
     data = await get_json_data(request)
-    # Faililugemine threadpoolis, et mitte blokeerida event loopi
-    # (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 4).
-    metadata = await run_in_threadpool(_read_work_meta_direct_sync, data.get('work_id'), data.get('original_path', ''))
+    path = find_directory_by_id(data.get("work_id"))
+    if path is None:
+        raw_path = data.get("original_path", "")
+        catalog = os.path.basename(raw_path) if raw_path else ""
+    else:
+        catalog = os.path.basename(path)
+    metadata = await run_in_threadpool(_require_catalog_access, catalog, user)
     return {"status": "success", "metadata": metadata}
 
 @router.post("/get-metadata-suggestions")
@@ -150,16 +180,27 @@ async def recent_edits(request: Request, user=Depends(get_user)):
 @router.post("/git-history")
 async def git_history(request: Request, user=Depends(require_role("editor"))):
     data = await get_json_data(request)
-    path = os.path.join(os.path.basename(data.get('original_path', '')), os.path.basename(data.get('file_name', '')))
+    catalog = os.path.basename(data.get('original_path', ''))
+    filename = os.path.basename(data.get('file_name', ''))
+    if not catalog or not filename:
+        raise HTTPException(status_code=400, detail="Vigane failitee")
+    await run_in_threadpool(_require_catalog_access, catalog, user)
+    path = os.path.join(catalog, filename)
     return {"status": "success", "history": get_file_git_history(path)}
 
 @router.post("/commit-diff")
 async def commit_diff(request: Request, user=Depends(require_role("editor"))):
     data = await get_json_data(request)
-    commit_hash, filepath = data.get('commit_hash'), data.get('filepath', '')
-    clean_path = os.path.join(filepath.strip('/').split('/')[-2], filepath.strip('/').split('/')[-1]) if '/' in filepath else None
+    commit_hash = data.get('commit_hash')
+    catalog, clean_path = _catalog_from_filepath(data.get('filepath', ''))
+    try:
+        await run_in_threadpool(_require_catalog_access, catalog, user)
+    except HTTPException as exc:
+        # Admini Review-vaade peab jätkuvalt nägema config/prosopography committe;
+        # editorile on mitte-teose tee alati keelatud.
+        if not (exc.status_code == 404 and is_at_least(user['role'], 'admin')):
+            raise
     diff_res = get_commit_diff(commit_hash, filepaths=clean_path)
-    if not diff_res or not diff_res.get('diff'): diff_res = get_commit_diff(commit_hash)
     return {"status": "success", **diff_res} if diff_res else {"status": "error"}
 
 def _validate_page_paths(data):
@@ -199,6 +240,7 @@ def _read_current_comments(json_path):
 async def page_comments_history(request: Request, user=Depends(require_role("editor"))):
     data = await get_json_data(request)
     _catalog, _filename, json_relpath, json_path, _txt = _validate_page_paths(data)
+    await run_in_threadpool(_require_catalog_access, _catalog, user)
     current = _read_current_comments(json_path)
     result = await run_in_threadpool(build_comment_history, json_relpath, current)
     return {"status": "success", **result}
@@ -216,6 +258,7 @@ async def page_comments_restore(
         raise HTTPException(status_code=400, detail="Vigased parameetrid")
 
     catalog, _filename, json_relpath, json_path, txt_path = _validate_page_paths(data)
+    await run_in_threadpool(_require_catalog_access, catalog, user, write=True)
 
     # commit_hash peab kuuluma SELLE faili ajalukku (mitte suvaline git-objekt)
     history = get_file_git_history(json_relpath, max_count=500)
@@ -261,6 +304,9 @@ async def page_comments_restore(
 async def git_restore(request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("editor"))):
     data = await get_json_data(request)
     catalog, filename = os.path.basename(data.get('original_path', '')), os.path.basename(data.get('file_name', ''))
+    if not catalog or not filename:
+        raise HTTPException(status_code=400, detail="Vigane failitee")
+    await run_in_threadpool(_require_catalog_access, catalog, user, write=True)
     path = os.path.join(BASE_DIR, catalog, filename)
     content = get_file_at_commit(os.path.join(catalog, filename), data.get('commit_hash'))
     if content is None: raise HTTPException(status_code=400, detail="Ei leitud")

--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -69,7 +69,9 @@ def _catalog_from_filepath(filepath: str) -> tuple[str, str]:
     catalog, filename = parts[-2], parts[-1]
     if catalog != os.path.basename(catalog) or filename != os.path.basename(filename):
         raise HTTPException(status_code=400, detail="Vigane failitee")
-    return catalog, os.path.join(catalog, filename)
+    # Ligipääsuotsus kasutab teose kataloogi (eelviimane segment), kuid git-filter
+    # peab säilitama kogu repo-suhtelise tee, sh config/prosopography prefiksi.
+    return catalog, "/".join(parts)
 
 
 @router.post("/save")

--- a/server/routers/public.py
+++ b/server/routers/public.py
@@ -32,15 +32,12 @@ async def toggle_shareable(work_id: str, request: Request, background_tasks: Bac
         return {"status": "error", "message": "Teos ei leitud"}
 
     meta_path = os.path.join(folder, '_metadata.json')
-    # Kirjutamisõiguse kontroll praeguse (toggle-eelse) seisu põhjal (Leid G).
-    if os.path.exists(meta_path):
-        try:
-            with open(meta_path, 'r', encoding='utf-8') as f:
-                _cur_meta = json.load(f)
-        except Exception:
-            _cur_meta = None
-        if _cur_meta is not None and not can_write_work(_cur_meta, user):
-            raise HTTPException(status_code=403, detail="Puudub õigus selle teose jagamist muuta")
+    # Ligipääsukontroll on fail-closed: vigane või puuduv meta ei tähenda avalikku teost.
+    _cur_meta = _load_work_metadata(work_id)
+    if _cur_meta is None:
+        raise HTTPException(status_code=503, detail="Teose metaandmeid ei saa praegu lugeda")
+    if not can_write_work(_cur_meta, user):
+        raise HTTPException(status_code=403, detail="Puudub õigus selle teose jagamist muuta")
     slug = os.path.basename(folder)
     save_work_metadata(
         meta_path,
@@ -101,10 +98,11 @@ async def download_work(request: Request, work_id: str, content: str = "both"):
 
     # Ligipääsukontroll
     meta_for_access = _load_work_metadata(work_id)
-    if meta_for_access is not None:
-        user = _get_optional_user(request)
-        if not can_read_work(meta_for_access, user):
-            raise HTTPException(status_code=403, detail="Ligipääs keelatud")
+    if meta_for_access is None:
+        raise HTTPException(status_code=503, detail="Teose metaandmeid ei saa praegu lugeda")
+    user = _get_optional_user(request)
+    if not can_read_work(meta_for_access, user):
+        raise HTTPException(status_code=403, detail="Ligipääs keelatud")
 
     slug = os.path.basename(folder)
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -19,47 +19,41 @@ metadata_lock = threading.RLock()  # _metadata.json operatsioonid
 page_json_lock = threading.RLock()  # Lehekülje .json failide operatsioonid
 
 
-def atomic_write_json(filepath, data, indent=2):
-    """Kirjutab JSON faili atomically (temp file + rename).
-
-    See tagab, et serveri crashi korral ei jää fail poolikuks.
-    os.replace() on atomic operatsioon POSIX süsteemides.
-
-    Args:
-        filepath: Sihtfaili absoluutne tee
-        data: JSON-serialiseeritavad andmed
-        indent: JSON indentatsiooni tase (default 2)
-    """
+def atomic_write_text(filepath, content):
+    """Kirjutab tekstifaili atomaarselt (temp-fail + os.replace)."""
     dir_name = os.path.dirname(filepath)
     if dir_name:
         os.makedirs(dir_name, exist_ok=True)
     tmp_path = None
 
     try:
-        # Loo temp fail samas kataloogis (vajalik atomic rename jaoks)
         with tempfile.NamedTemporaryFile(
             mode='w',
             encoding='utf-8',
             dir=dir_name,
             delete=False,
             prefix='.tmp_',
-            suffix='.json'
+            suffix='.txt'
         ) as tmp:
-            json.dump(data, tmp, ensure_ascii=False, indent=indent)
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
             tmp_path = tmp.name
 
-        # Atomic rename (asendab olemasoleva faili)
+        os.chmod(tmp_path, 0o644)
         os.replace(tmp_path, filepath)
-        # Sea õigused loetavaks kõigile (Docker/root probleemi vältimiseks)
-        os.chmod(filepath, 0o644)
     except Exception:
-        # Kustuta temp fail kui os.replace() ebaõnnestus
         if tmp_path and os.path.exists(tmp_path):
             try:
                 os.remove(tmp_path)
             except OSError:
                 pass
         raise
+
+
+def atomic_write_json(filepath, data, indent=2):
+    """Kirjutab JSON faili atomaarselt (temp-fail + os.replace)."""
+    atomic_write_text(filepath, json.dumps(data, ensure_ascii=False, indent=indent))
 
 # Nanoid seadistus
 NANOID_LENGTH = 6

--- a/server/work_meta.py
+++ b/server/work_meta.py
@@ -6,17 +6,13 @@ Tõstetud ``server/main.py``-st Faas 0 refaktoreeringus
 public/SEO (meta, sitemap), collections (ligipääsukontroll), download,
 shareable, viewer-token.
 
-Kaks funktsiooni:
-- ``load_work_metadata``: otsib kataloogi work_id järgi, tagastab dict või ``None``.
-  Kasutatakse seal, kus teos võib-olla ei eksisteeri (privilee kontroll, viewer-token).
-- ``read_work_meta_direct_sync``: blokeeriv sünkroonne lugemine threadpooli jaoks.
-  Tagastab ``{}`` (mitte ``None``) puuduva faili korral — ``/get-work-metadata``
-  eeldab tühja dict'i, et frontend saaks tühja vormi näidata.
+``load_work_metadata`` otsib kataloogi work_id järgi ja tagastab dict või ``None``.
+Ligipääsukontrolli kutsujad peavad ``None`` korral käituma fail-closed, sest see võib
+lisaks puuduvale teosele tähendada vigast metaandmete faili.
 """
 import json
 import os
 
-from .config import BASE_DIR
 from .utils import find_directory_by_id
 
 
@@ -37,24 +33,3 @@ def load_work_metadata(work_id: str):
             return json.load(f)
     except Exception:
         return None
-
-
-def read_work_meta_direct_sync(work_id: str, original_path: str):
-    """Loeb teose _metadata.json blokeeriva I/O-na (kutsutud threadpoolist).
-
-    Lahutatud /get-work-metadata endpointist, et sync faililugemine ei blokeeriks
-    event loopi (vt docs/koodi_ulevaade_2026-06-24_gemini_soovitused.md Leid 4).
-
-    Tagastab ``{}`` (mitte ``None``) puuduva faili korral: endpoint
-    /get-work-metadata eeldab tühja dict'i, et frontend saaks avada vormi uuele
-    teosele, millel metafail veel puudub.
-    """
-    path = find_directory_by_id(work_id) or os.path.join(BASE_DIR, os.path.basename(original_path or ''))
-    meta_path = os.path.join(path, '_metadata.json')
-    if os.path.exists(meta_path):
-        try:
-            with open(meta_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        except Exception:
-            return {}
-    return {}

--- a/tests/test_backend_smoke.py
+++ b/tests/test_backend_smoke.py
@@ -360,6 +360,11 @@ def test_save_triggers_page_person_mentions_update(client, login, monkeypatch, t
     monkeypatch.setattr(editing_router, "save_with_git", lambda *a, **kw: {"commit_hash": "abc12345"})
     monkeypatch.setattr(editing_router, "sync_work_to_meilisearch_async", lambda *a: None)
     monkeypatch.setattr(editing_router, "BASE_DIR", str(tmp_path))
+    work_dir = tmp_path / "teos1"
+    work_dir.mkdir()
+    (work_dir / "_metadata.json").write_text(
+        json.dumps({"id": "workAAA", "collections": []}), encoding="utf-8"
+    )
 
     calls = []
     monkeypatch.setattr(editing_router, "update_page_person_mentions", lambda wid, wdir: calls.append((wid, wdir)))
@@ -386,6 +391,11 @@ def test_save_reports_git_commit_failure(client, login, monkeypatch, tmp_path):
     monkeypatch.setattr(editing_router, "sync_work_to_meilisearch_async", lambda *a: None)
     monkeypatch.setattr(editing_router, "update_page_person_mentions", lambda *a: None)
     monkeypatch.setattr(editing_router, "BASE_DIR", str(tmp_path))
+    work_dir = tmp_path / "teos1"
+    work_dir.mkdir()
+    (work_dir / "_metadata.json").write_text(
+        json.dumps({"id": "workAAA", "collections": []}), encoding="utf-8"
+    )
 
     token = login("editor", "editorpass")
     response = client.post("/save", headers={"Authorization": f"Bearer {token}"}, json={

--- a/tests/test_page_comments_endpoints.py
+++ b/tests/test_page_comments_endpoints.py
@@ -40,6 +40,9 @@ def page_repo(backend_env, tmp_path, monkeypatch):
     txt = folder / "pg1.txt"
     jp = folder / "pg1.json"
     txt.write_text("lehe tekst", encoding="utf-8")
+    (folder / "_metadata.json").write_text(
+        json.dumps({"id": "work1", "collections": []}), encoding="utf-8"
+    )
 
     def commit(comments, msg):
         jp.write_text(json.dumps({"comments": comments}, ensure_ascii=False, indent=2),

--- a/tests/test_restricted_work_endpoint_access.py
+++ b/tests/test_restricted_work_endpoint_access.py
@@ -2,6 +2,7 @@
 import json
 
 import pytest
+from git import Repo
 
 
 @pytest.fixture
@@ -10,7 +11,6 @@ def restricted_work_env(backend_env, monkeypatch, tmp_path):
     import server.routers.editing as editing
     import server.routers.public as public
     import server.utils as utils
-    import server.work_meta as work_meta
 
     data_dir = tmp_path / "data"
     work_dir = data_dir / "secret-work"
@@ -30,7 +30,6 @@ def restricted_work_env(backend_env, monkeypatch, tmp_path):
     })
     monkeypatch.setattr(editing, "BASE_DIR", str(data_dir))
     monkeypatch.setattr(public, "BASE_DIR", str(data_dir))
-    monkeypatch.setattr(work_meta, "BASE_DIR", str(data_dir))
     monkeypatch.setattr(utils, "BASE_DIR", str(data_dir))
     utils.WORK_ID_CACHE.clear()
     utils.WORK_ID_CACHE["secret1"] = str(work_dir)
@@ -45,6 +44,43 @@ def restricted_work_env(backend_env, monkeypatch, tmp_path):
 
 def _auth(token):
     return {"Authorization": f"Bearer {token}"}
+
+
+def test_admin_sees_full_prosopography_path_diff(client, login, backend_env, monkeypatch, tmp_path):
+    """Kolmesegmendiline config/prosopography tee ei tohi kaotada config/ prefiksit."""
+    import server.git_ops as git_ops
+    import server.routers.editing as editing
+
+    data_dir = tmp_path / "git-data"
+    person_dir = data_dir / "config" / "prosopography"
+    person_dir.mkdir(parents=True)
+    person_path = person_dir / "abc123.json"
+    repo = Repo.init(str(data_dir))
+    with repo.config_writer() as config:
+        config.set_value("user", "name", "test").set_value("user", "email", "test@example.test")
+
+    person_path.write_text(json.dumps({"id": "vutt:Pabc123", "notes": "vana"}), encoding="utf-8")
+    repo.index.add(["config/prosopography/abc123.json"])
+    repo.index.commit("Prosopo algseis")
+    person_path.write_text(json.dumps({"id": "vutt:Pabc123", "notes": "uus"}), encoding="utf-8")
+    repo.index.add(["config/prosopography/abc123.json"])
+    commit = repo.index.commit("Prosopo muudatus")
+
+    monkeypatch.setattr(editing, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(git_ops, "_git_repo", repo)
+
+    token = login("admin", "adminpass")
+    response = client.post("/commit-diff", json={
+        "commit_hash": commit.hexsha,
+        "filepath": "config/prosopography/abc123.json",
+    }, headers=_auth(token))
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["status"] == "success"
+    assert "config/prosopography/abc123.json" in payload["diff"]
+    assert 'uus' in payload["diff"]
 
 
 @pytest.mark.parametrize(("path", "body"), [

--- a/tests/test_restricted_work_endpoint_access.py
+++ b/tests/test_restricted_work_endpoint_access.py
@@ -1,0 +1,117 @@
+"""Regressioonitestid issues #157 ja #158: teose endpointid on fail-closed."""
+import json
+
+import pytest
+
+
+@pytest.fixture
+def restricted_work_env(backend_env, monkeypatch, tmp_path):
+    import server.access_ops as access_ops
+    import server.routers.editing as editing
+    import server.routers.public as public
+    import server.utils as utils
+    import server.work_meta as work_meta
+
+    data_dir = tmp_path / "data"
+    work_dir = data_dir / "secret-work"
+    work_dir.mkdir(parents=True)
+    meta_path = work_dir / "_metadata.json"
+    meta_path.write_text(json.dumps({
+        "id": "secret1",
+        "slug": "secret-work",
+        "title": "Piiratud teos",
+        "collections": ["restricted"],
+    }), encoding="utf-8")
+    (work_dir / "page1.txt").write_text("salajane tekst", encoding="utf-8")
+    (work_dir / "page1.json").write_text(json.dumps({"comments": []}), encoding="utf-8")
+
+    monkeypatch.setattr(access_ops, "get_cached_collections", lambda: {
+        "restricted": {"visibility": "restricted"},
+    })
+    monkeypatch.setattr(editing, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(public, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(work_meta, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(utils, "BASE_DIR", str(data_dir))
+    utils.WORK_ID_CACHE.clear()
+    utils.WORK_ID_CACHE["secret1"] = str(work_dir)
+
+    yield {
+        "work_dir": work_dir,
+        "meta_path": meta_path,
+    }
+
+    utils.WORK_ID_CACHE.clear()
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.parametrize(("path", "body"), [
+    ("/get-work-metadata", {"work_id": "secret1"}),
+    ("/git-history", {"original_path": "secret-work", "file_name": "page1.txt"}),
+    ("/commit-diff", {"commit_hash": "deadbeef", "filepath": "secret-work/page1.txt"}),
+    ("/page-comments/history", {"original_path": "secret-work", "file_name": "page1.txt"}),
+    ("/page-comments/restore", {
+        "original_path": "secret-work", "file_name": "page1.txt",
+        "mode": "version", "comment_id": "c1", "commit_hash": "deadbeef",
+    }),
+    ("/git-restore", {
+        "original_path": "secret-work", "file_name": "page1.txt", "commit_hash": "deadbeef",
+    }),
+])
+def test_editor_cannot_read_or_restore_restricted_work(
+    client, login, restricted_work_env, path, body
+):
+    token = login("editor", "editorpass")
+    response = client.post(path, json=body, headers=_auth(token))
+    assert response.status_code == 403, response.text
+
+
+def test_editor_cannot_save_restricted_work(client, login, restricted_work_env):
+    token = login("editor", "editorpass")
+    response = client.post("/save", json={
+        "original_path": "secret-work",
+        "file_name": "page1.txt",
+        "text_content": "ülekirjutus",
+    }, headers=_auth(token))
+    assert response.status_code == 403, response.text
+    assert (restricted_work_env["work_dir"] / "page1.txt").read_text(encoding="utf-8") == "salajane tekst"
+
+
+def test_anonymous_cannot_download_restricted_work(client, restricted_work_env):
+    response = client.get("/download/secret1?content=text")
+    assert response.status_code == 403, response.text
+
+
+def test_editor_cannot_toggle_restricted_work(client, login, restricted_work_env):
+    token = login("editor", "editorpass")
+    response = client.post(
+        "/work/secret1/shareable", json={"shareable": True}, headers=_auth(token)
+    )
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.parametrize("operation", ["download", "save", "shareable"])
+def test_malformed_metadata_is_fail_closed(
+    client, login, restricted_work_env, operation
+):
+    restricted_work_env["meta_path"].write_text('{"collections": [', encoding="utf-8")
+
+    if operation == "download":
+        response = client.get("/download/secret1?content=text")
+    else:
+        token = login("editor", "editorpass")
+        if operation == "save":
+            response = client.post("/save", json={
+                "original_path": "secret-work",
+                "file_name": "page1.txt",
+                "text_content": "ülekirjutus",
+            }, headers=_auth(token))
+        else:
+            response = client.post(
+                "/work/secret1/shareable", json={"shareable": True}, headers=_auth(token)
+            )
+
+    assert response.status_code == 503, response.text
+    assert (restricted_work_env["work_dir"] / "page1.txt").read_text(encoding="utf-8") == "salajane tekst"

--- a/tests/test_work_meta.py
+++ b/tests/test_work_meta.py
@@ -1,15 +1,9 @@
 """
 Testid server/work_meta.py ühistele metadata-lugemise helperitele (Faas 0).
 
-Kaetud käitumine:
-- load_work_metadata: tagastab dict olemasoleva teose korral; None puuduva/
-  tundmatu work_id või korrumpeerunud JSON-i korral
-- read_work_meta_direct_sync: tagastab dict (mitte None) ka puuduva faili
-  korral — /get-work-metadata eeldab tühja vormi uuele teosele
-- read_work_meta_direct_sync: fallback original_path-ile, kui work_id ei leitu
-
-Need on refaktoreeringu Faas 0 tõstmised main.py-st; tagavad, et public/SEO,
-collections, download, shareable ja viewer-token saavad ühest kohast metadatat.
+Kaetud käitumine: `load_work_metadata` tagastab olemasoleva teose korral dict-i
+ning puuduva/tundmatu work_id või korrumpeerunud JSON-i korral None. Ligipääsu
+kutsujad tõlgendavad None väärtust fail-closed.
 """
 import json
 import os
@@ -79,67 +73,6 @@ def test_load_work_metadata_returns_none_when_no_meta_file(backend_env, tmp_path
     WORK_ID_CACHE[work_id] = folder
     try:
         assert load_work_metadata(work_id) is None
-    finally:
-        import shutil
-        shutil.rmtree(folder, ignore_errors=True)
-
-
-# ---------------------------------------------------------------------------
-# read_work_meta_direct_sync
-# ---------------------------------------------------------------------------
-
-def test_read_work_meta_direct_sync_returns_dict_for_existing(work_dir):
-    from server.work_meta import read_work_meta_direct_sync
-    result = read_work_meta_direct_sync(work_dir["work_id"], "")
-    assert result["title"] == "Testteos meta jaoks"
-
-
-def test_read_work_meta_direct_sync_returns_empty_dict_when_missing(work_dir):
-    """Puuduva _metadata.json korral tagastab {}, mitte None.
-
-    Erinevus load_work_metadata-st: /get-work-metadata endpoint eeldab tühja
-    dict'i, et frontend saaks avada vormi uuele teosele, millel metafail veel puudub.
-    """
-    from server.work_meta import read_work_meta_direct_sync
-    from server import main as main_mod
-    from server.utils import WORK_ID_CACHE
-
-    work_id = "direct-sync-empty-003"
-    folder = os.path.join(main_mod.BASE_DIR, "empty-meta-folder")
-    os.makedirs(folder, exist_ok=True)
-    WORK_ID_CACHE[work_id] = folder
-    try:
-        result = read_work_meta_direct_sync(work_id, "")
-        assert result == {}
-        assert result is not None
-    finally:
-        import shutil
-        shutil.rmtree(folder, ignore_errors=True)
-
-
-def test_read_work_meta_direct_sync_falls_back_to_original_path(work_dir):
-    """Kui work_id ei leita cache-st, kasutatakse original_path-i (basename)."""
-    from server.work_meta import read_work_meta_direct_sync
-    # Olematu work_id, aga original_path osutab olemasolevale kataloogile
-    original_path = os.path.join(os.path.dirname(work_dir["folder"]), "test-work-folder")
-    result = read_work_meta_direct_sync("tundmatu-id", original_path)
-    assert result["title"] == "Testteos meta jaoks"
-
-
-def test_read_work_meta_direct_sync_returns_empty_for_corrupt_json(backend_env, tmp_path):
-    """Korrumpeerunud JSON → {} (mitte erind)."""
-    from server import main as main_mod
-    from server.work_meta import read_work_meta_direct_sync
-    from server.utils import WORK_ID_CACHE
-
-    work_id = "corrupt-004"
-    folder = os.path.join(main_mod.BASE_DIR, "corrupt-folder")
-    os.makedirs(folder, exist_ok=True)
-    with open(os.path.join(folder, "_metadata.json"), "w") as f:
-        f.write("{ see pole json :::")
-    WORK_ID_CACHE[work_id] = folder
-    try:
-        assert read_work_meta_direct_sync(work_id, "") == {}
     finally:
         import shutil
         shutil.rmtree(folder, ignore_errors=True)


### PR DESCRIPTION
## Kokkuvõte

- lisab `can_read_work` / `can_write_work` kontrollid teose meta, git-ajaloo, diffi, kommentaaride ajaloo ja taastamise endpointidele;
- eemaldab `commit-diff` kogu commiti fallback'i, et ühe teose päring ei lekitaks sama commiti teisi faile;
- muudab download/save/shareable teed vigase või puuduva `_metadata.json` korral fail-closed'iks;
- muudab `save_with_git` failiülekirjutused atomaarseks, et lugeja ei näeks poolikut `_metadata.json`-i;
- lisab restricted-work ja malformed-metadata endpoint-regressioonitestid.

Admini Review-vaate config/prosopography failid jäävad diff-endpointis toetatuks. Mitte-admin saab diffi vaadata ainult teose kataloogis pärast ligipääsukontrolli.

## Kontrollid

- `.venv/bin/pytest -q` — 884 passed
- `npm run typecheck` — korras
- `npm test -- --reporter=dot` — 542 passed
- `git diff --check` — korras

Closes #157
Closes #158
