### PR TITLE
Reject incomplete OCR imports before staging cleanup

### DIFF
--- a/server/upload/import_work.py
+++ b/server/upload/import_work.py
@@ -45,7 +45,8 @@ def validate_remote_ocr_files(importable, remote_items, extract_page_num_func):
     missing_jpg = sorted(expected_pages - set(jpg_map))
     missing_txt = sorted(
         pn for pn in expected_pages
-        if pn in jpg_map and jpg_map[pn].replace('.jpg', '.txt') not in remote_set
+        if pn in jpg_map
+        and os.path.splitext(jpg_map[pn])[0] + '.txt' not in remote_set
     )
     if missing_jpg or missing_txt:
         problems = []

--- a/server/upload/import_work.py
+++ b/server/upload/import_work.py
@@ -31,6 +31,35 @@ def normalize_txt_file(path: str):
         pass  # normaliseerimise tõrge ei tohi importi katkestada
 
 
+def validate_remote_ocr_files(importable, remote_items, extract_page_num_func):
+    """Kontrollib enne importi, et igal oodatud lehel on remote JPG+TXT paar."""
+    remote_set = set(remote_items)
+    jpg_map = {}
+    for item in remote_items:
+        if item.endswith('.jpg') and '_pg_' in item:
+            pn = extract_page_num_func(item.rsplit('.', 1)[0])
+            if pn > 0:
+                jpg_map[pn] = item
+
+    expected_pages = {entry['page'] for entry in importable}
+    missing_jpg = sorted(expected_pages - set(jpg_map))
+    missing_txt = sorted(
+        pn for pn in expected_pages
+        if pn in jpg_map and jpg_map[pn].replace('.jpg', '.txt') not in remote_set
+    )
+    if missing_jpg or missing_txt:
+        problems = []
+        if missing_jpg:
+            problems.append(f"JPG puudub lehtedel {', '.join(map(str, missing_jpg))}")
+        if missing_txt:
+            problems.append(f"TXT puudub lehtedel {', '.join(map(str, missing_txt))}")
+        raise ValueError(
+            "OCR tulemus pole täielik: " + "; ".join(problems) +
+            ". Toiming katkestati ja OCR staging säilitati."
+        )
+    return jpg_map
+
+
 def import_as_work(
     upload_id: str,
     username: str = None,
@@ -112,22 +141,13 @@ def import_as_work(
         except Exception as e:
             raise ValueError(f"Ei saa lugeda OCR kausta: {e}")
 
-        # Map: page_num → jpg_filename
-        jpg_map = {}
-        for item in remote_items:
-            if item.endswith('.jpg') and '_pg_' in item:
-                pn = extract_page_num_func(item.rsplit('.', 1)[0])
-                if pn > 0:
-                    jpg_map[pn] = item
+        # Täielikkuse preflight ENNE allalaadimist: osalist teost ei impordita.
+        jpg_map = validate_remote_ocr_files(importable, remote_items, extract_page_num_func)
 
         # Lae alla iga soovitud leht
         downloaded = 0
         for entry in importable:
             pn = entry['page']
-            if pn not in jpg_map:
-                logger.warning(f"import {upload_id}: lk {pn} JPG puudub, vahele jäetud")
-                continue
-
             jpg_name = jpg_map[pn]
             txt_name = jpg_name.replace('.jpg', '.txt')
 
@@ -143,7 +163,7 @@ def import_as_work(
                 sftp.get(f"{remote_work}/{txt_name}", local_txt)
                 normalize_txt_file_func(local_txt)
             except FileNotFoundError:
-                open(local_txt, 'w').close()
+                raise ValueError(f"OCR TXT kadus allalaadimise ajal (lk {pn}); import katkestati")
             os.chmod(local_txt, 0o644)
 
             page_json = {"sequence": pn * 100, "status": "Toores", "page_tags": [], "comments": [], "history": []}

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -689,6 +689,29 @@ def replace_work_content(upload_id: str, target_work_id: str, metadata_updates: 
         existing_meta = json.load(f)
     work_id = existing_meta.get('id', target_work_id)
 
+    # Täielikkuse preflight ENNE vana sisu puutumist. Hiljem kontrollime remote
+    # loendit uuesti, et katta ka preflight'i ja downloadi vaheline muutus.
+    importable = [f for f in state.get('files', []) if f.get('has_ocr') and not f.get('deleted')]
+    if not importable:
+        raise HTTPException(status_code=400, detail="Imporditavaid lehekülgi pole (kõik kustutatud või OCR puudub)")
+    importable.sort(key=lambda f: f['page'])
+    remote_work = f"{OCR_SERVER_PATH}/{state['remote_work_path']}"
+    preflight_sftp = None
+    try:
+        preflight_sftp = _sftp_open(upload_id)
+        remote_items = preflight_sftp.listdir(remote_work)
+        _import_work.validate_remote_ocr_files(importable, remote_items, _extract_page_num)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"OCR kausta kontroll ebaõnnestus: {e}")
+    finally:
+        if preflight_sftp:
+            try:
+                preflight_sftp.close()
+            except Exception:
+                pass
+
     # Salvesta git HEAD rollback'i jaoks
     from .git_ops import get_or_init_repo
     repo = get_or_init_repo()
@@ -740,14 +763,8 @@ def replace_work_content(upload_id: str, target_work_id: str, metadata_updates: 
             logger.error(f"replace {upload_id}: rollback JPG liigutamine ebaõnnestus: {rb_jpg_err}")
         raise HTTPException(status_code=500, detail=f"Vana sisu eemaldamine ebaõnnestus: {e}")
 
-    # 7. Lae alla uued lehed SFTP kaudu
-    importable = [f for f in state.get('files', []) if f.get('has_ocr') and not f.get('deleted')]
-    if not importable:
-        raise HTTPException(status_code=400, detail="Imporditavaid lehekülgi pole (kõik kustutatud või OCR puudub)")
-    importable.sort(key=lambda f: f['page'])
-
-    remote_work = f"{OCR_SERVER_PATH}/{state['remote_work_path']}"
-
+    # 7. Lae alla uued lehed SFTP kaudu. Remote loend valideeritakse uuesti,
+    # sest fail võis preflight'i järel kaduda; sellisel juhul käivitub rollback.
     sftp = None
     downloaded = 0
     try:

--- a/server/upload_ops.py
+++ b/server/upload_ops.py
@@ -758,19 +758,14 @@ def replace_work_content(upload_id: str, target_work_id: str, metadata_updates: 
         except Exception as e:
             raise ValueError(f"Ei saa lugeda OCR kausta: {e}")
 
-        jpg_map = {}
-        for item in remote_items:
-            if item.endswith('.jpg') and '_pg_' in item:
-                pn = _extract_page_num(item.rsplit('.', 1)[0])
-                if pn > 0:
-                    jpg_map[pn] = item
+        # Sama täielikkuse invariant mis uue teose impordil: osalist asendust
+        # ei tohi edukaks lugeda ega selle staging'ut hiljem kustutada.
+        jpg_map = _import_work.validate_remote_ocr_files(
+            importable, remote_items, _extract_page_num
+        )
 
         for entry in importable:
             pn = entry['page']
-            if pn not in jpg_map:
-                logger.warning(f"replace {upload_id}: lk {pn} JPG puudub, vahele jäetud")
-                continue
-
             jpg_name = jpg_map[pn]
             txt_name = jpg_name.replace('.jpg', '.txt')
 
@@ -786,7 +781,7 @@ def replace_work_content(upload_id: str, target_work_id: str, metadata_updates: 
                 sftp.get(f"{remote_work}/{txt_name}", local_txt)
                 _normalize_txt_file(local_txt)
             except FileNotFoundError:
-                open(local_txt, 'w').close()
+                raise ValueError(f"OCR TXT kadus allalaadimise ajal (lk {pn}); asendus katkestati")
             os.chmod(local_txt, 0o644)
 
             page_json = {"sequence": pn * 100, "status": "Toores", "page_tags": [], "comments": [], "history": []}

--- a/tests/test_replace_work_content.py
+++ b/tests/test_replace_work_content.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from git import Repo
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -29,6 +30,113 @@ class _FakeRepo:
         self.head = type("Head", (), {
             "commit": type("Commit", (), {"hexsha": "abcdef1234567890"})()
         })()
+
+
+def _setup_replace_files(tmp_path, monkeypatch):
+    """Loob replace-testide upload state'i ja olemasoleva teose."""
+    import server.utils as utils
+
+    uploads_dir = tmp_path / "uploads"
+    data_dir = tmp_path / "data"
+    upload_id = "upl123"
+    slug = "vana-teos"
+    work_id = "wid123"
+    upload_dir = uploads_dir / upload_id
+    work_dir = data_dir / slug
+    upload_dir.mkdir(parents=True)
+    work_dir.mkdir(parents=True)
+    (upload_dir / "state.json").write_text(json.dumps({
+        "id": upload_id,
+        "status": "reviewing",
+        "remote_work_path": "AUTO-OCR/print/upl123/uus-teos",
+        "remote_staging_path": "AUTO-OCR/print/upl123",
+        "files": [{"page": 1, "has_ocr": True, "deleted": False}],
+        "meta": {"title": "Uus", "year": "1700", "slug": "uus-teos"},
+    }), encoding="utf-8")
+    (work_dir / "_metadata.json").write_text(json.dumps({"id": work_id, "title": "Vana"}), encoding="utf-8")
+    (work_dir / "vana-teos_pg_001.jpg").write_bytes(b"vana jpg")
+    (work_dir / "vana-teos_pg_001.txt").write_text("vana tekst", encoding="utf-8")
+    (work_dir / "vana-teos_pg_001.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(upload_ops, "UPLOADS_DIR", str(uploads_dir))
+    monkeypatch.setattr(upload_state, "UPLOADS_DIR", str(uploads_dir))
+    monkeypatch.setattr(upload_ops, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(utils, "find_directory_by_id", lambda wid: str(work_dir) if wid == work_id else None)
+    return upload_id, work_id, slug, work_dir, data_dir
+
+
+class _ListSftp:
+    def __init__(self, items):
+        self.items = items
+        self.closed = False
+        self.get_calls = []
+
+    def listdir(self, _path):
+        return self.items
+
+    def get(self, remote, local):
+        self.get_calls.append((remote, local))
+
+    def close(self):
+        self.closed = True
+
+
+def test_replace_incomplete_preflight_does_not_touch_existing_work(tmp_path, monkeypatch):
+    """Tavapärane puuduv remote fail avastatakse enne git rm-i ja JPG arhiveerimist."""
+    import server.git_ops as git_ops
+
+    upload_id, work_id, _slug, work_dir, data_dir = _setup_replace_files(tmp_path, monkeypatch)
+    sftp = _ListSftp(["uus-teos_pg_001.jpg"])
+    monkeypatch.setattr(upload_ops, "_sftp_open", lambda _upload_id: sftp)
+    monkeypatch.setattr(
+        git_ops, "get_or_init_repo",
+        lambda: (_ for _ in ()).throw(AssertionError("Gitini ei tohi jõuda")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        upload_ops.replace_work_content(upload_id, work_id, {}, "admin", background_tasks=None)
+
+    assert exc.value.status_code == 400
+    assert "TXT puudub lehtedel 1" in exc.value.detail
+    assert sftp.closed is True
+    assert (work_dir / "vana-teos_pg_001.jpg").read_bytes() == b"vana jpg"
+    assert (work_dir / "vana-teos_pg_001.txt").read_text(encoding="utf-8") == "vana tekst"
+    assert not (data_dir / "._trash").exists()
+
+
+def test_replace_remote_change_after_preflight_rolls_back_existing_work(tmp_path, monkeypatch):
+    """Kui fail kaob pärast preflight'i, taastab destruktiivse sammu rollback vana teose."""
+    import server.git_ops as git_ops
+
+    upload_id, work_id, slug, work_dir, data_dir = _setup_replace_files(tmp_path, monkeypatch)
+    repo = Repo.init(str(data_dir))
+    with repo.config_writer() as config:
+        config.set_value("user", "name", "test").set_value("user", "email", "test@example.test")
+    repo.index.add([
+        f"{slug}/_metadata.json",
+        f"{slug}/vana-teos_pg_001.txt",
+        f"{slug}/vana-teos_pg_001.json",
+    ])
+    repo.index.commit("Algseis")
+
+    sftps = [
+        _ListSftp(["uus-teos_pg_001.jpg", "uus-teos_pg_001.txt"]),
+        _ListSftp(["uus-teos_pg_001.jpg"]),
+    ]
+    monkeypatch.setattr(upload_ops, "_sftp_open", lambda _upload_id: sftps.pop(0))
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: repo)
+
+    with pytest.raises(HTTPException) as exc:
+        upload_ops.replace_work_content(upload_id, work_id, {}, "admin", background_tasks=None)
+
+    assert exc.value.status_code == 500
+    assert "TXT puudub lehtedel 1" in exc.value.detail
+    assert sftps == []
+    assert (work_dir / "vana-teos_pg_001.jpg").read_bytes() == b"vana jpg"
+    assert (work_dir / "vana-teos_pg_001.txt").read_text(encoding="utf-8") == "vana tekst"
+    assert (work_dir / "vana-teos_pg_001.json").read_text(encoding="utf-8") == "{}"
+    trash_root = data_dir / "._trash" / work_id / "replaced_content"
+    assert not list(trash_root.glob("*/*.jpg"))
 
 
 def test_replace_work_content_git_rm_viga_katkestab_ja_taastab_jpg(tmp_path, monkeypatch):
@@ -65,10 +173,16 @@ def test_replace_work_content_git_rm_viga_katkestab_ja_taastab_jpg(tmp_path, mon
     monkeypatch.setattr(utils, "find_directory_by_id", lambda wid: str(work_dir) if wid == work_id else None)
     monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: fake_repo)
 
-    def fail_sftp(_upload_id):
-        raise AssertionError("SFTP-d ei tohi pärast git rm viga avada")
+    preflight_sftp = _ListSftp(["uus-teos_pg_001.jpg", "uus-teos_pg_001.txt"])
+    sftp_calls = []
 
-    monkeypatch.setattr(upload_ops, "_sftp_open", fail_sftp)
+    def sftp_factory(_upload_id):
+        sftp_calls.append(_upload_id)
+        if len(sftp_calls) == 1:
+            return preflight_sftp
+        raise AssertionError("Teist SFTP ühendust ei tohi pärast git rm viga avada")
+
+    monkeypatch.setattr(upload_ops, "_sftp_open", sftp_factory)
 
     with pytest.raises(HTTPException) as exc:
         upload_ops.replace_work_content(upload_id, work_id, {}, "admin", background_tasks=None)

--- a/tests/test_save_and_transfer.py
+++ b/tests/test_save_and_transfer.py
@@ -118,10 +118,15 @@ def _fake_sftp():
 class _ImportSftp:
     """Minimaalne SFTP fake import_as_work testi jaoks."""
 
+    def __init__(self, items=None):
+        self.items = items or ["test-teos_pg_001.jpg", "test-teos_pg_001.txt"]
+        self.get_calls = []
+
     def listdir(self, _path):
-        return ["test-teos_pg_001.jpg", "test-teos_pg_001.txt"]
+        return self.items
 
     def get(self, remote, local):
+        self.get_calls.append((remote, local))
         if remote.endswith(".jpg"):
             Path(local).write_bytes(b"jpg")
         elif remote.endswith(".txt"):
@@ -136,6 +141,42 @@ class _ImportSftp:
 # =========================================================
 # import_as_work
 # =========================================================
+
+
+@pytest.mark.parametrize(("remote_items", "error_match"), [
+    (["test-teos_pg_001.jpg", "test-teos_pg_001.txt"], "JPG puudub lehtedel 2"),
+    (["test-teos_pg_001.jpg"], "TXT puudub lehtedel 1"),
+])
+def test_import_as_work_rejects_incomplete_remote_result_and_keeps_staging(
+    make_state, tmp_path, monkeypatch, remote_items, error_match
+):
+    """Puuduv oodatud JPG/TXT katkestab impordi enne downloadi ja staging'u koristust."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sftp = _ImportSftp(remote_items)
+    cleanup_calls = []
+    monkeypatch.setattr(upload_ops, "BASE_DIR", str(data_dir))
+    monkeypatch.setattr(upload_ops, "_sftp_open", lambda upload_id: sftp)
+    monkeypatch.setattr(upload_ops, "_ssh_rm_rf", lambda *args, **kwargs: cleanup_calls.append(args))
+
+    files = [{"page": 1, "has_ocr": True, "deleted": False}]
+    if "JPG" in error_match:
+        files.append({"page": 2, "has_ocr": True, "deleted": False})
+    upload_id, _state = make_state(
+        upload_id="incomplete123",
+        slug="test-teos",
+        status="reviewing",
+        files=files,
+        meta={"title": "Test teos", "year": "1700", "slug": "test-teos", "work_id": "wid123"},
+    )
+
+    with pytest.raises(ValueError, match=error_match):
+        upload_ops.import_as_work(upload_id, username="admin")
+
+    assert sftp.get_calls == []
+    assert cleanup_calls == []
+    assert not (data_dir / "test-teos").exists()
+    assert _read_state(Path(upload_ops.UPLOADS_DIR), upload_id)["status"] == "reviewing"
 
 
 def test_import_as_work_reports_git_commit_failure(make_state, tmp_path, monkeypatch):


### PR DESCRIPTION
## Kokkuvõte

- kontrollib enne uue teose importi, et igal state'is imporditaval lehel oleks OCR-serveris nii JPG kui TXT;
- katkestab puuduva faili korral enne ühegi lehe allalaadimist;
- eemaldab varasema vaikse „jäta leht vahele” käitumise;
- jätab vea korral upload state'i `reviewing` olekusse ning OCR staging'u puutumata;
- rakendab sama täielikkuse kontrolli olemasoleva teose sisu asendamisele;
- kui TXT kaob preflight'i ja tegeliku allalaadimise vahel, katkestatakse import/asendus, mitte ei looda tühja tekstifaili.

## Regressioonitestid

Kaetud on:

1. üks oodatud JPG puudub, teised lehed on olemas;
2. oodatud JPG on olemas, kuid TXT puudub;
3. kummalgi juhul ei alustata downloadi, ei koristata staging'ut, ei looda osalist teost ja state jääb `reviewing` olekusse.

## Kontrollid

- `.venv/bin/pytest -q` — 883 passed
- `npm run typecheck` — korras
- `npm test -- --reporter=dot` — 542 passed
- `git diff --check` — korras

Closes #162
