### PR TITLE
Harden prosopography bulk updates and optimistic concurrency

### DIFF
--- a/server/prosopography/person_crud.py
+++ b/server/prosopography/person_crud.py
@@ -220,7 +220,9 @@ def update_person(person_id: str, data: dict, username: str) -> dict:
             raise KeyError(person_id)
 
         client_updated_at = data.get("updated_at")
-        if client_updated_at and person.get("updated_at") != client_updated_at:
+        if not isinstance(client_updated_at, str) or not client_updated_at.strip():
+            raise ValueError("updated_at_required")
+        if person.get("updated_at") != client_updated_at:
             raise ValueError(f"conflict:{person['updated_at']}")
 
         old_label = (person.get("name") or {}).get("label") or ""
@@ -503,6 +505,7 @@ def bulk_update_occupation(
     occupation: dict,
     mode: str,
     person_ids: list,
+    username: str,
 ) -> dict:
     """
     Massiga ameti määramine/asendamine mitmele isikule korraga.
@@ -539,7 +542,15 @@ def bulk_update_occupation(
                 new_occupations = list(existing) + [occupation]
 
             person["occupations"] = new_occupations
-            state.atomic_write_json(_id_to_path(person_id), person)
+            person["updated_at"] = datetime.now(timezone.utc).isoformat()
+            person["updated_by"] = username
+            name = (person.get("name") or {}).get("label") or person_id
+            state.save_with_git(
+                _id_to_path(person_id),
+                json.dumps(person, ensure_ascii=False, indent=2),
+                username,
+                message=f"Prosopo ametite massmuudatus: {name} [{person_id}]",
+            )
             _indices()._update_index_entry(person)
             updated += 1
 

--- a/server/prosopography/router.py
+++ b/server/prosopography/router.py
@@ -768,6 +768,8 @@ async def prosopography_update(
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     except ValueError as e:
         msg = str(e)
+        if msg == "updated_at_required":
+            raise HTTPException(status_code=400, detail="updated_at on kohustuslik")
         if msg.startswith("conflict:"):
             current_updated_at = msg.split(":", 1)[1]
             raise HTTPException(
@@ -826,4 +828,5 @@ async def prosopography_bulk_occupation(
         occupation=occupation,
         mode=mode,
         person_ids=person_ids,
+        username=user["username"],
     )

--- a/tests/test_person_locks.py
+++ b/tests/test_person_locks.py
@@ -4,6 +4,8 @@ import sys
 import threading
 from pathlib import Path
 
+import pytest
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -48,6 +50,10 @@ def test_bulk_update_occupation_no_lost_update(tmp_path, monkeypatch):
     # Suuna failitee tmp-kausta ja muuda index-uuendus no-op'iks
     monkeypatch.setattr(ops, "PROSOPOGRAPHY_DIR", str(tmp_path))
     monkeypatch.setattr(ops, "_update_index_entry", lambda p: None)
+    monkeypatch.setattr(
+        ops, "save_with_git",
+        lambda path, content, *_args, **_kwargs: Path(path).write_text(content, encoding="utf-8"),
+    )
 
     pid = f"vutt:P{nanoid}"
     N = 20
@@ -55,7 +61,9 @@ def test_bulk_update_occupation_no_lost_update(tmp_path, monkeypatch):
 
     def worker(i):
         barrier.wait()  # sünkroniseeri start → maksimeeri võistlus
-        ops.bulk_update_occupation({"id": f"Q{i}", "label": f"amet{i}"}, "add", [pid])
+        ops.bulk_update_occupation(
+            {"id": f"Q{i}", "label": f"amet{i}"}, "add", [pid], username=f"user{i}"
+        )
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(N)]
     for t in threads:
@@ -66,3 +74,93 @@ def test_bulk_update_occupation_no_lost_update(tmp_path, monkeypatch):
     data = json.loads((tmp_path / f"{nanoid}.json").read_text(encoding="utf-8"))
     ids = {o["id"] for o in data["occupations"]}
     assert len(ids) == N, f"Oodati {N} ametit, sai {len(ids)} — lost update!"
+
+
+def test_bulk_occupation_updates_version_and_makes_open_form_stale(tmp_path, monkeypatch):
+    """Bulk-muudatus peab vana vormi timestampi aegunuks tegema ja git commiti looma."""
+    from server.prosopography import ops
+
+    pid = "vutt:Pabc123"
+    old_timestamp = "2026-01-01T00:00:00+00:00"
+    person_path = tmp_path / "abc123.json"
+    person_path.write_text(json.dumps({
+        "id": pid,
+        "name": {"label": "Test"},
+        "occupations": [],
+        "updated_at": old_timestamp,
+        "updated_by": "old-user",
+    }), encoding="utf-8")
+    save_calls = []
+
+    def fake_save(path, content, username, message=None, **_kwargs):
+        save_calls.append({"path": path, "username": username, "message": message})
+        Path(path).write_text(content, encoding="utf-8")
+        return {"success": True, "commit_hash": "abc123"}
+
+    monkeypatch.setattr(ops, "PROSOPOGRAPHY_DIR", str(tmp_path))
+    monkeypatch.setattr(ops, "_update_index_entry", lambda _person: None)
+    monkeypatch.setattr(ops, "_update_aliases_entry", lambda _person: None)
+    monkeypatch.setattr(ops, "save_with_git", fake_save)
+
+    result = ops.bulk_update_occupation(
+        {"id": "Q123", "label": "professor"}, "add", [pid], username="bulk-user"
+    )
+
+    saved = json.loads(person_path.read_text(encoding="utf-8"))
+    assert result["updated"] == 1
+    assert saved["updated_at"] != old_timestamp
+    assert saved["updated_by"] == "bulk-user"
+    assert save_calls[0]["username"] == "bulk-user"
+    assert "ametite massmuudatus" in save_calls[0]["message"]
+
+    with pytest.raises(ValueError, match="^conflict:"):
+        ops.update_person(pid, {
+            "updated_at": old_timestamp,
+            "name": {"label": "Vana avatud vorm"},
+            "occupations": [],
+        }, username="editor")
+
+    # Stale save ei tohi bulk-muudatust üle kirjutada.
+    after_conflict = json.loads(person_path.read_text(encoding="utf-8"))
+    assert after_conflict["occupations"] == [{"id": "Q123", "label": "professor"}]
+
+
+def test_update_person_endpoint_reports_missing_updated_at_as_400(client, login, monkeypatch):
+    import server.prosopography.router as router
+
+    def reject_missing(*_args, **_kwargs):
+        raise ValueError("updated_at_required")
+
+    monkeypatch.setattr(router, "get_person", lambda _person_id: {"relations": []})
+    monkeypatch.setattr(router, "update_person", reject_missing)
+    token = login("editor", "editorpass")
+    response = client.put(
+        "/prosopography/vutt%3APabc123",
+        json={"name": {"label": "Test"}},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "updated_at on kohustuslik"
+
+
+@pytest.mark.parametrize("missing_value", [None, ""])
+def test_update_person_requires_nonempty_updated_at(tmp_path, monkeypatch, missing_value):
+    from server.prosopography import ops
+
+    pid = "vutt:Pabc123"
+    person_path = tmp_path / "abc123.json"
+    person_path.write_text(json.dumps({
+        "id": pid,
+        "name": {"label": "Test"},
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }), encoding="utf-8")
+    monkeypatch.setattr(ops, "PROSOPOGRAPHY_DIR", str(tmp_path))
+
+    payload = {"name": {"label": "Ülekirjutus"}}
+    if missing_value is not None:
+        payload["updated_at"] = missing_value
+    with pytest.raises(ValueError, match="^updated_at_required$"):
+        ops.update_person(pid, payload, username="editor")
+
+    assert json.loads(person_path.read_text(encoding="utf-8"))["name"]["label"] == "Test"


### PR DESCRIPTION
## Kokkuvõte

- nõuab olemasoleva isikukaardi PUT-päringul mittetühja `updated_at` väärtust;
- tagastab puuduva timestampi korral selge HTTP 400 vastuse;
- säilitab aegunud timestampi korral senise 409 konflikti;
- bulk-ametimuudatus uuendab nüüd `updated_at` ja `updated_by` välju;
- bulk-ametimuudatus kirjutab isikukaardi `save_with_git` kaudu, mitte otse JSON-i;
- router edastab bulk-operatsioonile tegeliku kasutajanime.

## Regressioonitestid

- `updated_at` puudub või on tühi → kirjutamist ei toimu;
- endpoint tagastab puuduva timestampi korral 400;
- avatud vormi timestamp → bulk-ametimuudatus → vana vormi save annab konflikti;
- stale save ei kirjuta bulk-ametimuudatust üle;
- bulk-muudatus loob git-salvestuse ja märgib tegeliku autori;
- paralleelsete bulk-ametimuudatuste senine lost-update test jääb kehtima.

## Kontrollid

- `.venv/bin/pytest -q` — 889 passed
- `npm run typecheck` — korras
- `npm test -- --reporter=dot` — 542 passed
- `git diff --check` — korras

Closes #159
Closes #161
