### PR TITLE
Offload blocking I/O out of async routes (#111)

### DIFF
--- a/server/prosopography/places_ops.py
+++ b/server/prosopography/places_ops.py
@@ -246,7 +246,7 @@ def _collect_descendants(place_key: str, places: dict, max_depth: int = MAX_PLAC
     return result
 
 
-async def _propagate_place_change(place_key: str) -> None:
+def _propagate_place_change(place_key: str) -> None:
     """
     Pärast places.json muutmist uuendab kõik mõjutatud isikute indeksikirjed.
     Käivitatakse background task-ina.
@@ -277,7 +277,7 @@ async def _propagate_place_change(place_key: str) -> None:
         logger.info("_propagate_place_change: uuendas indeksi place_key=%s", place_key)
 
 
-async def _propagate_place_merge(source_key: str, target_key: str) -> None:
+def _propagate_place_merge(source_key: str, target_key: str) -> None:
     """
     Pärast kohade ühendamist uuendab nii source kui target isikud indeksis.
     Source isikute failid ütlevad nüüd target_key — indeks peab järele jõudma.

--- a/server/prosopography/router.py
+++ b/server/prosopography/router.py
@@ -6,6 +6,7 @@ import json
 import os
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Depends
 from fastapi.responses import FileResponse
+from starlette.concurrency import run_in_threadpool
 
 from ..auth import require_token
 from ..config import get_logger
@@ -108,7 +109,7 @@ async def _get_json(request: Request) -> dict:
 # =========================================================
 
 @router.get("")
-async def prosopography_list(
+def prosopography_list(
     request: Request,
     q: str = None,
     gender: str = None,
@@ -161,7 +162,8 @@ async def prosopography_query(request: Request):
     Väldib liiga pikka query stringi, kui ids massiiv on suur.
     """
     data = await _get_json(request)
-    return list_persons(
+    return await run_in_threadpool(
+        list_persons,
         q=data.get("q"),
         gender=data.get("gender"),
         occupation=data.get("occupation"),
@@ -183,7 +185,7 @@ async def prosopography_query(request: Request):
 
 
 @router.get("/map")
-async def prosopography_map(
+def prosopography_map(
     request: Request,
     q: str = None,
     gender: str = None,
@@ -224,7 +226,7 @@ async def prosopography_map(
 
 
 @router.get("/facets")
-async def prosopography_facets(
+def prosopography_facets(
     q: str = None,
     gender: str = None,
     ids: str = None,
@@ -245,7 +247,8 @@ async def prosopography_facets_post(request: Request):
     """POST variant /facets — kasuta kui ids nimekiri on pikk (414 vältimiseks)."""
     data = await _get_json(request)
     id_list = data.get("ids") or None
-    return get_person_facets(
+    return await run_in_threadpool(
+        get_person_facets,
         q=data.get("q"),
         gender=data.get("gender"),
         ids=id_list,
@@ -268,6 +271,23 @@ def _load_work_meta(work_id: str):
         return None
 
 
+def _collect_work_titles(work_ids):
+    """Blokeeriv osa: kuni 200 metadata-faili lugemine. Jookseb threadpool'is."""
+    result: dict = {}
+    for wid in work_ids[:200]:
+        if not isinstance(wid, str) or wid in result:
+            continue
+        meta = _load_work_meta(wid)
+        if meta is None:
+            continue
+        result[wid] = {
+            "title": meta.get("title") or "",
+            "year": meta.get("year"),
+            "restricted": not is_work_public(meta),
+        }
+    return result
+
+
 @router.post("/work-titles")
 async def prosopography_work_titles(request: Request):
     """Tagastab teoste pealkirjad ID järgi (sh kaitstud kollektsioonide teosed).
@@ -281,18 +301,8 @@ async def prosopography_work_titles(request: Request):
     work_ids = data.get("work_ids") or []
     if not isinstance(work_ids, list):
         raise HTTPException(status_code=400, detail="work_ids peab olema massiiv")
-    result: dict = {}
-    for wid in work_ids[:200]:
-        if not isinstance(wid, str) or wid in result:
-            continue
-        meta = _load_work_meta(wid)
-        if meta is None:
-            continue
-        result[wid] = {
-            "title": meta.get("title") or "",
-            "year": meta.get("year"),
-            "restricted": not is_work_public(meta),
-        }
+    # Kuni 200 metadata-faili lugemine — event-loopis blokeeriks kõiki teisi päringuid.
+    result = await run_in_threadpool(_collect_work_titles, work_ids)
     return {"titles": result}
 
 
@@ -303,7 +313,7 @@ async def prosopography_create(
 ):
     """Loob uue vutt:P kirje."""
     data = await _get_json(request)
-    person = create_person(data, username=user["username"])
+    person = await run_in_threadpool(create_person, data, username=user["username"])
     enrich_entity_labels_from_person_async(person)
     return person
 
@@ -322,7 +332,7 @@ async def enrichment_preview(
     Kutsutakse /persons/new vormi täitmisel.
     """
     from .enrichment import fetch_and_diff
-    diff = fetch_and_diff(scheme, id, {})
+    diff = await run_in_threadpool(fetch_and_diff, scheme, id, {})
     return diff
 
 
@@ -349,7 +359,7 @@ async def enrichment_preview_for_person(
     )
     if not ext_id:
         raise HTTPException(status_code=400, detail=f"Isikul puudub {scheme} identifikaator")
-    diff = fetch_and_diff(scheme, ext_id, person)
+    diff = await run_in_threadpool(fetch_and_diff, scheme, ext_id, person)
     return diff
 
 
@@ -370,7 +380,9 @@ async def prosopography_add_identifier(
     if not scheme or not ext_id:
         raise HTTPException(status_code=400, detail="Nõutud: scheme ja id")
     try:
-        person, diff = add_identifier(person_id, scheme, ext_id, username=user["username"])
+        person, diff = await run_in_threadpool(
+            add_identifier, person_id, scheme, ext_id, username=user["username"]
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     return {"person": person, "diff": diff}
@@ -390,7 +402,9 @@ async def prosopography_enrich(
     approved = data.get("approved", {})
     approved["_enrichment_scheme"] = data.get("_enrichment_scheme")
     try:
-        person = apply_enrichment(person_id, approved, username=user["username"])
+        person = await run_in_threadpool(
+            apply_enrichment, person_id, approved, username=user["username"]
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     return person
@@ -411,7 +425,9 @@ async def prosopography_upload_image(
     if not body:
         raise HTTPException(status_code=400, detail="Fail puudub")
     try:
-        person = upload_person_image(person_id, body, content_type, username=user["username"])
+        person = await run_in_threadpool(
+            upload_person_image, person_id, body, content_type, username=user["username"]
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     except ValueError as e:
@@ -437,7 +453,9 @@ async def prosopography_delete_image(
 ):
     """Kustutab isiku pildi."""
     try:
-        person = delete_person_image(person_id, username=user["username"])
+        person = await run_in_threadpool(
+            delete_person_image, person_id, username=user["username"]
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     return {"status": "ok", "updated_at": person["updated_at"]}
@@ -460,7 +478,7 @@ async def places_merge(
     if not target_key:
         raise HTTPException(status_code=400, detail="target_key on kohustuslik")
     try:
-        result = merge_places(source_key, target_key)
+        result = await run_in_threadpool(merge_places, source_key, target_key)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -472,7 +490,7 @@ async def places_merge(
 # ── Ajalugu ja taastamine ──────────────────────────────────
 
 @router.get("/{person_id:path}/history")
-async def person_history(person_id: str, user=Depends(_require_role("editor"))):
+def person_history(person_id: str, user=Depends(_require_role("editor"))):
     """Tagastab isikukaardi muudatuste ajaloo (git commitid)."""
     try:
         nanoid = _safe_nanoid(person_id)
@@ -484,7 +502,7 @@ async def person_history(person_id: str, user=Depends(_require_role("editor"))):
 
 
 @router.get("/{person_id:path}/diff")
-async def person_diff(person_id: str, commit: str, user=Depends(_require_role("editor"))):
+def person_diff(person_id: str, commit: str, user=Depends(_require_role("editor"))):
     """Tagastab commit-i muutunud väljade loendi võrreldes eelmise commitiga."""
     try:
         nanoid = _safe_nanoid(person_id)
@@ -533,7 +551,7 @@ async def person_restore(person_id: str, request: Request, user=Depends(_require
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     relative_path = f"config/prosopography/{nanoid}.json"
 
-    content = get_file_at_commit(relative_path, commit_hash)
+    content = await run_in_threadpool(get_file_at_commit, relative_path, commit_hash)
     if content is None:
         raise HTTPException(status_code=404, detail="Commit ei leitud")
 
@@ -548,15 +566,16 @@ async def person_restore(person_id: str, request: Request, user=Depends(_require
 
     path = os.path.join(PROSOPOGRAPHY_DIR, f"{nanoid}.json")
     name = (person.get("name") or {}).get("label") or person_id
-    save_with_git(
+    await run_in_threadpool(
+        save_with_git,
         path,
         json.dumps(person, ensure_ascii=False, indent=2),
         user["username"],
         message=f"Prosopo taastamine: {name} [{person_id}]",
     )
 
-    _update_index_entry(person)
-    _update_aliases_entry(person)
+    await run_in_threadpool(_update_index_entry, person)
+    await run_in_threadpool(_update_aliases_entry, person)
     return {"status": "ok", "person": person}
 
 
@@ -578,7 +597,9 @@ async def prosopography_merge(
     if not target_id:
         raise HTTPException(status_code=400, detail="target_id on kohustuslik.")
     try:
-        result = merge_person(source_id, target_id, username=user["username"])
+        result = await run_in_threadpool(
+            merge_person, source_id, target_id, username=user["username"]
+        )
     except KeyError as e:
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {e}")
     except ValueError as e:
@@ -594,7 +615,9 @@ async def prosopography_delete_person(
 ):
     """Kustutab isikukaardi jäädavalt (admin only). Blokeerib kui teostes/relations viited."""
     try:
-        result = delete_person(person_id, username=user["username"])
+        result = await run_in_threadpool(
+            delete_person, person_id, username=user["username"]
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     except ValueError as e:
@@ -610,13 +633,13 @@ async def prosopography_delete_person(
 
 
 @router.get("/relation-type-suggestions")
-async def prosopography_relation_type_suggestions():
+def prosopography_relation_type_suggestions():
     """Tagastab kõigis kaartides kasutatud unikaalsed seose tüübid. Avalik endpoint."""
     return get_relation_type_suggestions()
 
 
 @router.get("/work-relations/{person_id:path}")
-async def prosopography_work_relations(
+def prosopography_work_relations(
     person_id: str,
     limit: int = 10,
     offset: int = 0,
@@ -628,14 +651,14 @@ async def prosopography_work_relations(
 # ── Places register ────────────────────────────────────────────────────────
 
 @router.get("/places/wikidata-search")
-async def places_wikidata_search(request: Request, q: str = "", lang: str = "en"):
+def places_wikidata_search(request: Request, q: str = "", lang: str = "en"):
     """Otsib Wikidatast kohti nime järgi. Avalik (rate-limititud, et vältida proksi kuritarvitust)."""
     _check_wikidata_rate_limit(request)
     return search_places_wikidata(q.strip(), lang=lang)
 
 
 @router.get("/places/wikidata/{qid}")
-async def places_wikidata_fetch(qid: str, request: Request):
+def places_wikidata_fetch(qid: str, request: Request):
     """Pärib Wikidatast koha andmed (labelid, tüüp, P131 ülempiirkonnad). Avalik (rate-limititud)."""
     _check_wikidata_rate_limit(request)
     result = fetch_place_wikidata(qid)
@@ -645,13 +668,13 @@ async def places_wikidata_fetch(qid: str, request: Request):
 
 
 @router.get("/places")
-async def places_list():
+def places_list():
     """Tagastab kõik places.json kirjed. Avalik — töötab kõigil rollidel."""
     return get_places()
 
 
 @router.get("/places/meta")
-async def places_meta():
+def places_meta():
     """Tagastab origin_groups.json sisu + lubatud type väärtused. Avalik."""
     return get_places_meta()
 
@@ -670,13 +693,13 @@ async def groups_put(key: str, request: Request, user=Depends(_require_role("adm
     """Lisab või uuendab gruppi (admin). Body: {labels, sort_order, parent}"""
     data = await _get_json(request)
     try:
-        return put_group(key, data)
+        return await run_in_threadpool(put_group, key, data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.delete("/admin/groups/{key}")
-async def groups_delete(key: str, user=Depends(_require_role("admin"))):
+def groups_delete(key: str, user=Depends(_require_role("admin"))):
     """Kustutab grupi (admin)."""
     try:
         delete_group(key)
@@ -686,13 +709,13 @@ async def groups_delete(key: str, user=Depends(_require_role("admin"))):
 
 
 @router.post("/admin/groups/auto-assign")
-async def groups_auto_assign(user=Depends(_require_role("admin"))):
+def groups_auto_assign(user=Depends(_require_role("admin"))):
     """Rakendab automaatse parent seadmise teadaolevatele alamgruppidele."""
     return auto_assign_group_parents()
 
 
 @router.delete("/admin/places/{key}")
-async def places_delete(
+def places_delete(
     key: str,
     user=Depends(_require_role("admin")),
 ):
@@ -719,7 +742,7 @@ async def places_put(
     """
     data = await _get_json(request)
     try:
-        entry = put_place(key, data)
+        entry = await run_in_threadpool(put_place, key, data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -729,7 +752,7 @@ async def places_put(
 
 
 @router.get("/{person_id:path}")
-async def prosopography_get(
+def prosopography_get(
     person_id: str,
     user=Depends(_optional_user),
 ):
@@ -760,10 +783,12 @@ async def prosopography_update(
     """
     data = await _get_json(request)
     # Loe vana seis ENNE salvestust — server-side diff vastastikuste seoste jaoks
-    old_person = get_person(person_id)
+    old_person = await run_in_threadpool(get_person, person_id)
     old_relations = (old_person or {}).get("relations", [])
     try:
-        person = update_person(person_id, data, username=user["username"])
+        person = await run_in_threadpool(
+            update_person, person_id, data, username=user["username"]
+        )
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Isikut ei leitud: {person_id}")
     except ValueError as e:
@@ -784,7 +809,8 @@ async def prosopography_update(
     # Sünkroniseeri vastastikused seosed (best-effort — viga ei blokeeri 200 vastust)
     try:
         a_label = (person.get("name") or {}).get("label", "")
-        sync_reciprocals(
+        await run_in_threadpool(
+            sync_reciprocals,
             person_id,
             old_relations,
             person.get("relations", []),
@@ -802,7 +828,7 @@ async def prosopography_rebuild(
     user=Depends(_require_role("admin")),
 ):
     """Taastab kõik kolm read-modeli nullist (admin only)."""
-    rebuild_indices()
+    await run_in_threadpool(rebuild_indices)
     return {"status": "ok", "message": "Indeksid taastatud."}
 
 
@@ -824,7 +850,8 @@ async def prosopography_bulk_occupation(
     if not person_ids:
         raise HTTPException(status_code=400, detail="person_ids on kohustuslik")
 
-    return bulk_update_occupation(
+    return await run_in_threadpool(
+        bulk_update_occupation,
         occupation=occupation,
         mode=mode,
         person_ids=person_ids,

--- a/server/routers/admin.py
+++ b/server/routers/admin.py
@@ -4,6 +4,7 @@ import shutil
 import threading
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from starlette.concurrency import run_in_threadpool
 
 from ..auth import can_manage_user, delete_user, get_all_users, update_user_allowed_collections, update_user_role
 from ..config import BASE_DIR
@@ -24,19 +25,22 @@ from ..utils import build_work_id_cache, find_directory_by_id
 router = APIRouter()
 
 
+# sync def → Starlette jooksutab threadpool'is (faililugemine ei blokeeri event-loopi)
 @router.post("/admin/registrations")
-async def admin_registrations(user=Depends(require_role("admin"))):
+def admin_registrations(user=Depends(require_role("admin"))):
     return {"status": "success", "registrations": load_pending_registrations()["registrations"]}
 
 
 @router.post("/admin/registrations/approve")
 async def approve_registration(request: Request, user=Depends(require_role("admin"))):
     data = await get_json_data(request)
-    reg = get_registration_by_id(data.get("registration_id"))
+    reg = await run_in_threadpool(get_registration_by_id, data.get("registration_id"))
     if not reg or reg["status"] != "pending":
         raise HTTPException(status_code=400, detail="Vigane taotlus")
-    update_registration_status(reg["id"], "approved", user["username"])
-    token_data = create_invite_token(reg["email"], reg["name"], user["username"], username=reg.get("username"))
+    await run_in_threadpool(update_registration_status, reg["id"], "approved", user["username"])
+    token_data = await run_in_threadpool(
+        create_invite_token, reg["email"], reg["name"], user["username"], username=reg.get("username")
+    )
     return {
         "status": "success",
         "invite_token": token_data["token"],
@@ -51,7 +55,9 @@ async def approve_registration(request: Request, user=Depends(require_role("admi
 @router.post("/admin/registrations/reject")
 async def reject_registration(request: Request, user=Depends(require_role("admin"))):
     data = await get_json_data(request)
-    reg = update_registration_status(data.get("registration_id"), "rejected", user["username"])
+    reg = await run_in_threadpool(
+        update_registration_status, data.get("registration_id"), "rejected", user["username"]
+    )
     if not reg:
         raise HTTPException(status_code=400, detail="Vigane taotlus")
     return {"status": "success"}
@@ -65,7 +71,9 @@ async def admin_users(user=Depends(require_role("admin"))):
 @router.post("/admin/users/update-role")
 async def admin_update_role(request: Request, user=Depends(require_role("admin"))):
     data = await get_json_data(request)
-    success, message = update_user_role(data.get("username"), data.get("new_role"), user)
+    success, message = await run_in_threadpool(
+        update_user_role, data.get("username"), data.get("new_role"), user
+    )
     if not success:
         raise HTTPException(status_code=400, detail=message)
     return {"status": "success"}
@@ -76,7 +84,8 @@ async def admin_update_collections(request: Request, user=Depends(require_role("
     data = await get_json_data(request)
     # NB: anna allowed_collections muutmatult edasi (tüübikontroll on helperis,
     # et see kehtiks ka otseses ühiktestis); vastus sisaldab serveris salvestatud nimekirja
-    success, message, allowed = update_user_allowed_collections(
+    success, message, allowed = await run_in_threadpool(
+        update_user_allowed_collections,
         data.get("username"), data.get("allowed_collections", []), user)
     if not success:
         raise HTTPException(status_code=400, detail=message)
@@ -86,7 +95,7 @@ async def admin_update_collections(request: Request, user=Depends(require_role("
 @router.post("/admin/users/delete")
 async def admin_delete_user(request: Request, user=Depends(require_role("admin"))):
     data = await get_json_data(request)
-    success, message = delete_user(data.get("username"), user)
+    success, message = await run_in_threadpool(delete_user, data.get("username"), user)
     if not success:
         raise HTTPException(status_code=400, detail=message)
     return {"status": "success"}
@@ -112,7 +121,7 @@ async def admin_reset_password(request: Request, user=Depends(require_role("admi
     if target != user["username"] and not can_manage_user(user["role"], users[target].get("role", "contributor")):
         raise HTTPException(status_code=403, detail="Ei saa lähtestada võrdse või kõrgema õigusega kasutajat")
 
-    token_data, error = create_reset_token(target, user["username"])
+    token_data, error = await run_in_threadpool(create_reset_token, target, user["username"])
     if not token_data:
         raise HTTPException(status_code=400, detail=error)
     return {
@@ -125,12 +134,12 @@ async def admin_reset_password(request: Request, user=Depends(require_role("admi
 
 
 @router.post("/admin/trash")
-async def admin_trash(user=Depends(require_role("admin"))):
+def admin_trash(user=Depends(require_role("admin"))):
     return {"status": "success", "items": list_deleted_works()}
 
 
 @router.post("/admin/trash/{work_id}/restore")
-async def admin_trash_restore(work_id: str, user=Depends(require_role("admin"))):
+def admin_trash_restore(work_id: str, user=Depends(require_role("admin"))):
     res = restore_deleted_work(work_id, username=user["username"])
     if not res["ok"]:
         raise HTTPException(status_code=400, detail=res["error"])
@@ -138,7 +147,7 @@ async def admin_trash_restore(work_id: str, user=Depends(require_role("admin")))
 
 
 @router.get("/admin/work/{work_id}/metadata")
-async def admin_work_metadata(work_id: str, user=Depends(require_role("admin"))):
+def admin_work_metadata(work_id: str, user=Depends(require_role("admin"))):
     """Tagastab teose _metadata.json sisu."""
     path = find_directory_by_id(work_id)
     if not path:
@@ -151,7 +160,7 @@ async def admin_work_metadata(work_id: str, user=Depends(require_role("admin")))
 
 
 @router.get("/admin/work/{work_id}/trash-pages")
-async def admin_trash_pages(work_id: str, user=Depends(require_role("admin"))):
+def admin_trash_pages(work_id: str, user=Depends(require_role("admin"))):
     """Loetleb teose kustutatud leheküljed."""
     path = find_directory_by_id(work_id)
     if not path:
@@ -160,7 +169,7 @@ async def admin_trash_pages(work_id: str, user=Depends(require_role("admin"))):
 
 
 @router.post("/admin/work/{work_id}/trash-pages/{filename}/restore")
-async def admin_restore_page(work_id: str, filename: str, user=Depends(require_role("admin"))):
+def admin_restore_page(work_id: str, filename: str, user=Depends(require_role("admin"))):
     """Taastab kustutatud lehekülje prügikastist."""
     path = find_directory_by_id(work_id)
     if not path:
@@ -181,7 +190,7 @@ async def admin_git_failures(request: Request, user=Depends(require_role("admin"
 
 
 @router.post("/admin/git-health")
-async def admin_git_health(user=Depends(require_role("admin"))):
+def admin_git_health(user=Depends(require_role("admin"))):
     return {"status": "success", "git_ok": run_git_fsck()["ok"]}
 
 
@@ -197,7 +206,7 @@ async def admin_people_refresh_status(user=Depends(require_role("admin"))):
 
 
 @router.delete("/admin/work/{work_id}")
-async def admin_work_delete(work_id: str, user=Depends(require_role("admin"))):
+def admin_work_delete(work_id: str, user=Depends(require_role("admin"))):
     path = find_directory_by_id(work_id)
     if not path:
         raise HTTPException(status_code=404, detail="Teost ei leitud")

--- a/server/routers/auth.py
+++ b/server/routers/auth.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 
 from ..auth import create_session, delete_session, get_session, load_users, require_token, verify_user
 from ..config import SESSION_DURATION, get_logger
@@ -45,7 +46,8 @@ async def login(request: Request):
     if locked:
         logger.warning(f"Login blokeeritud (konto lukus): username={username!r} ip={client_ip} retry_after={acc_retry}s")
         return JSONResponse(status_code=429, content={"status": "error", "message": f"Liiga palju ebaõnnestunud katseid. Proovi uuesti {acc_retry}s pärast"})
-    user = verify_user(username, data.get("password", ""))
+    # bcrypt on CPU-raske (~100ms) — event-loopis blokeeriks kõiki teisi päringuid.
+    user = await run_in_threadpool(verify_user, username, data.get("password", ""))
     if user:
         clear_login_failures(username)
         from ..meilisearch_ops import generate_meili_token
@@ -128,7 +130,8 @@ async def register(request: Request):
     data = await request.json()
     if data.get("website"):
         return {"status": "success"}
-    registration, error = add_registration(
+    registration, error = await run_in_threadpool(
+        add_registration,
         data.get("name", ""),
         data.get("email", ""),
         data.get("affiliation"),
@@ -145,12 +148,13 @@ async def register_username_preview(email: str = ""):
     email = email.strip().lower()
     if not email or "@" not in email:
         return {"status": "success", "username": ""}
-    return {"status": "success", "username": suggest_username_for_email(email)}
+    username = await run_in_threadpool(suggest_username_for_email, email)
+    return {"status": "success", "username": username}
 
 
 @router.get("/invite/{token}")
 async def check_invite(token: str):
-    token_data, error = validate_invite_token(token)
+    token_data, error = await run_in_threadpool(validate_invite_token, token)
     if token_data:
         return {
             "status": "success",
@@ -170,7 +174,9 @@ async def set_password(request: Request):
     if not allowed:
         return JSONResponse(status_code=429, content={"status": "error", "message": "Liiga palju päringuid"})
     data = await request.json()
-    new_user, error = create_user_from_invite(data.get("token", ""), data.get("password", ""))
+    new_user, error = await run_in_threadpool(
+        create_user_from_invite, data.get("token", ""), data.get("password", "")
+    )
     if not new_user:
         raise HTTPException(status_code=400, detail=error)
     return {"status": "success", "username": new_user["username"]}
@@ -184,7 +190,9 @@ async def reset_validate(request: Request):
     if not allowed:
         return JSONResponse(status_code=429, content={"status": "error", "valid": False, "message": "Liiga palju päringuid"})
     data = await request.json()
-    token_data, error = validate_reset_token((data.get("token") or "").strip())
+    token_data, error = await run_in_threadpool(
+        validate_reset_token, (data.get("token") or "").strip()
+    )
     if token_data:
         return {
             "status": "success",
@@ -204,7 +212,9 @@ async def reset_set_password(request: Request):
     if not allowed:
         return JSONResponse(status_code=429, content={"status": "error", "message": "Liiga palju päringuid"})
     data = await request.json()
-    result, error = complete_password_reset((data.get("token") or "").strip(), data.get("password", ""))
+    result, error = await run_in_threadpool(
+        complete_password_reset, (data.get("token") or "").strip(), data.get("password", "")
+    )
     if not result:
         raise HTTPException(status_code=400, detail=error)
     return {"status": "success", "username": result["username"]}

--- a/server/routers/collections.py
+++ b/server/routers/collections.py
@@ -4,6 +4,7 @@ import re
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from git import Actor
+from starlette.concurrency import run_in_threadpool
 
 from ..auth import delete_user_sessions, load_users, save_users
 from ..cache import get_cached_archives, get_cached_collections
@@ -16,6 +17,11 @@ from ..utils import atomic_write_json, find_directory_by_id, metadata_lock
 
 logger = get_logger(__name__)
 router = APIRouter()
+
+
+def _read_json(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
 
 
 @router.get("/collections")
@@ -34,15 +40,14 @@ async def create_archive(request: Request, user=Depends(require_role("admin"))):
         raise HTTPException(status_code=400, detail="Lühend ja nimi on kohustuslikud")
     archives = {}
     if os.path.exists(ARCHIVES_FILE):
-        with open(ARCHIVES_FILE, 'r', encoding='utf-8') as f:
-            archives = json.load(f)
+        archives = await run_in_threadpool(_read_json, ARCHIVES_FILE)
     if archive_id in archives:
         raise HTTPException(status_code=409, detail=f"Arhiiv tähisega '{archive_id}' on juba olemas")
     entry: dict = {"name": name}
     if url:
         entry["url"] = url
     archives[archive_id] = entry
-    atomic_write_json(ARCHIVES_FILE, archives)
+    await run_in_threadpool(atomic_write_json, ARCHIVES_FILE, archives)
     _invalidate_all_caches()
     return {"status": "success", "id": archive_id, "archive": entry}
 
@@ -55,24 +60,23 @@ async def update_archive(archive_id: str, request: Request, user=Depends(require
         raise HTTPException(status_code=400, detail="Nimi on kohustuslik")
     archives = {}
     if os.path.exists(ARCHIVES_FILE):
-        with open(ARCHIVES_FILE, 'r', encoding='utf-8') as f:
-            archives = json.load(f)
+        archives = await run_in_threadpool(_read_json, ARCHIVES_FILE)
     if archive_id not in archives:
         raise HTTPException(status_code=404, detail=f"Arhiivi '{archive_id}' ei leitud")
     entry: dict = {"name": name}
     if url:
         entry["url"] = url
     archives[archive_id] = entry
-    atomic_write_json(ARCHIVES_FILE, archives)
+    await run_in_threadpool(atomic_write_json, ARCHIVES_FILE, archives)
     _invalidate_all_caches()
     return {"status": "success", "id": archive_id, "archive": entry}
 
+# sync def → threadpool: arhiivi kustutus skannib kõiki teoseid (_find_works_with_archive)
 @router.delete("/config/archives/{archive_id}")
-async def delete_archive(archive_id: str, force: bool = False, user=Depends(require_role("admin"))):
+def delete_archive(archive_id: str, force: bool = False, user=Depends(require_role("admin"))):
     archives = {}
     if os.path.exists(ARCHIVES_FILE):
-        with open(ARCHIVES_FILE, 'r', encoding='utf-8') as f:
-            archives = json.load(f)
+        archives = _read_json(ARCHIVES_FILE)
     if archive_id not in archives:
         raise HTTPException(status_code=404, detail=f"Arhiivi '{archive_id}' ei leitud")
     if not force:
@@ -100,8 +104,7 @@ async def admin_update_collection(collection_id: str, request: Request, backgrou
     # Loe olemaolev fail
     if not os.path.exists(COLLECTIONS_FILE):
         return {"status": "error", "message": "collections.json ei leitud"}
-    with open(COLLECTIONS_FILE, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+    data = await run_in_threadpool(_read_json, COLLECTIONS_FILE)
 
     if collection_id not in data:
         return {"status": "error", "message": f"Kollektsioon '{collection_id}' ei leitud"}
@@ -140,7 +143,7 @@ async def admin_update_collection(collection_id: str, request: Request, backgrou
         return {"status": "error", "message": "visibility peab olema 'public' või 'restricted'"}
 
     # Kirjuta tagasi
-    atomic_write_json(COLLECTIONS_FILE, data)
+    await run_in_threadpool(atomic_write_json, COLLECTIONS_FILE, data)
 
     # Invalideerib cache → järgmine /collections päring laeb uued andmed
     _invalidate_all_caches()
@@ -165,7 +168,7 @@ async def admin_update_collection(collection_id: str, request: Request, backgrou
             if updated != current:
                 changed_users.append(username)
             users_data[username]["allowed_collections"] = list(updated)
-        save_users(users_data)
+        await run_in_threadpool(save_users, users_data)
         # Invalideeri muutunud kasutajate sessioonid, et uus ligipääs jõustuks kohe (Leid I)
         for username in changed_users:
             delete_user_sessions(username)
@@ -173,12 +176,11 @@ async def admin_update_collection(collection_id: str, request: Request, backgrou
     return {"status": "success"}
 
 @router.get("/admin/collections/{collection_id}/users")
-async def admin_collection_users(collection_id: str, user=Depends(require_role("admin"))):
+def admin_collection_users(collection_id: str, user=Depends(require_role("admin"))):
     """Tagastab kollektsiooni metaandmed koos ligipääsuga kasutajate nimekirjaga."""
     if not os.path.exists(COLLECTIONS_FILE):
         return {"status": "error", "message": "collections.json ei leitud"}
-    with open(COLLECTIONS_FILE, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+    data = _read_json(COLLECTIONS_FILE)
     if collection_id not in data:
         return {"status": "error", "message": f"Kollektsioon '{collection_id}' ei leitud"}
     col = data[collection_id]
@@ -211,8 +213,7 @@ async def admin_create_collection(request: Request, user=Depends(require_role("s
 
     if not os.path.exists(COLLECTIONS_FILE):
         return {"status": "error", "message": "collections.json ei leitud"}
-    with open(COLLECTIONS_FILE, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+    data = await run_in_threadpool(_read_json, COLLECTIONS_FILE)
 
     if collection_id in data:
         return {"status": "error", "message": f"ID '{collection_id}' on juba kasutusel"}
@@ -229,7 +230,7 @@ async def admin_create_collection(request: Request, user=Depends(require_role("s
 
     data[collection_id] = new_col
 
-    atomic_write_json(COLLECTIONS_FILE, data)
+    await run_in_threadpool(atomic_write_json, COLLECTIONS_FILE, data)
 
     _invalidate_all_caches()
     return {"status": "success"}
@@ -295,13 +296,13 @@ def admin_collection_works_count(collection_id: str, user=Depends(require_role("
     count = len(_find_works_with_collection(collection_id))
     return {"status": "success", "count": count}
 
+# sync def → threadpool: skannib ja kirjutab kõiki mõjutatud teoseid + git commit
 @router.delete("/admin/collections/{collection_id}")
-async def admin_delete_collection(collection_id: str, background_tasks: BackgroundTasks, user=Depends(require_role("superadmin"))):
+def admin_delete_collection(collection_id: str, background_tasks: BackgroundTasks, user=Depends(require_role("superadmin"))):
     """Kustutab kollektsiooni ja eemaldab selle ID kõigi teoste metaandmetest. Keeldub kui on alamkollektsioone."""
     if not os.path.exists(COLLECTIONS_FILE):
         return {"status": "error", "message": "collections.json ei leitud"}
-    with open(COLLECTIONS_FILE, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+    data = _read_json(COLLECTIONS_FILE)
 
     if collection_id not in data:
         return {"status": "error", "message": f"Kollektsioon '{collection_id}' ei leitud"}

--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -99,8 +99,7 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
         # Säilita sequence väli kui on olemas (ära lase salvestamisel üle kirjutada)
         if os.path.exists(json_path):
             try:
-                with open(json_path, 'r', encoding='utf-8') as f:
-                    existing = json.load(f)
+                existing = await run_in_threadpool(_read_json_file, json_path)
                 existing_seq = existing.get('sequence') or existing.get('meta_content', {}).get('sequence')
                 if existing_seq is not None and meta_content.get('sequence') is None:
                     meta_content['sequence'] = existing_seq
@@ -108,7 +107,13 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
                 pass
         additional.append((json_path, json.dumps(meta_content, indent=2, ensure_ascii=False)))
 
-    git_result = save_with_git(txt_path, text, user['username'], additional_files=additional if additional else None)
+    git_result = await run_in_threadpool(
+        save_with_git,
+        txt_path,
+        text,
+        user['username'],
+        additional_files=additional if additional else None,
+    )
     background_tasks.add_task(sync_work_to_meilisearch_async, catalog)
     work_id = (data.get('meta_content') or {}).get('work_id')
     if work_id:
@@ -138,7 +143,8 @@ async def update_work_metadata(request: Request, background_tasks: BackgroundTas
     meta_path = os.path.join(path, '_metadata.json')
     slug = os.path.basename(path)
 
-    meta = save_work_metadata(
+    meta = await run_in_threadpool(
+        save_work_metadata,
         meta_path,
         data.get('metadata', {}),
         user['username'],
@@ -176,7 +182,12 @@ async def metadata_suggestions(request: Request, user=Depends(require_role("edit
 @router.get("/recent-edits")
 async def recent_edits(request: Request, user=Depends(get_user)):
     f_user = request.query_params.get('user') if is_at_least(user['role'], 'admin') else user['username']
-    res = get_recent_commits(username=f_user, limit=int(request.query_params.get('limit', 30)), skip=int(request.query_params.get('offset', 0)))
+    res = await run_in_threadpool(
+        get_recent_commits,
+        username=f_user,
+        limit=int(request.query_params.get('limit', 30)),
+        skip=int(request.query_params.get('offset', 0)),
+    )
     return {"status": "success", "commits": res["commits"], "has_more": res["has_more"], "is_admin": is_at_least(user['role'], 'admin')}
 
 @router.post("/git-history")
@@ -188,7 +199,8 @@ async def git_history(request: Request, user=Depends(require_role("editor"))):
         raise HTTPException(status_code=400, detail="Vigane failitee")
     await run_in_threadpool(_require_catalog_access, catalog, user)
     path = os.path.join(catalog, filename)
-    return {"status": "success", "history": get_file_git_history(path)}
+    history = await run_in_threadpool(get_file_git_history, path)
+    return {"status": "success", "history": history}
 
 @router.post("/commit-diff")
 async def commit_diff(request: Request, user=Depends(require_role("editor"))):
@@ -202,7 +214,7 @@ async def commit_diff(request: Request, user=Depends(require_role("editor"))):
         # editorile on mitte-teose tee alati keelatud.
         if not (exc.status_code == 404 and is_at_least(user['role'], 'admin')):
             raise
-    diff_res = get_commit_diff(commit_hash, filepaths=clean_path)
+    diff_res = await run_in_threadpool(get_commit_diff, commit_hash, filepaths=clean_path)
     return {"status": "success", **diff_res} if diff_res else {"status": "error"}
 
 def _validate_page_paths(data):
@@ -227,6 +239,16 @@ def _validate_page_paths(data):
     return catalog, raw_file, json_relpath, json_path, txt_path
 
 
+def _read_json_file(path: str):
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def _read_text_file(path: str):
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
 def _read_current_comments(json_path):
     """Loeb praeguse comments-massiivi kettalt (toetab meta_content wrapperit)."""
     if not os.path.exists(json_path):
@@ -243,7 +265,7 @@ async def page_comments_history(request: Request, user=Depends(require_role("edi
     data = await get_json_data(request)
     _catalog, _filename, json_relpath, json_path, _txt = _validate_page_paths(data)
     await run_in_threadpool(_require_catalog_access, _catalog, user)
-    current = _read_current_comments(json_path)
+    current = await run_in_threadpool(_read_current_comments, json_path)
     result = await run_in_threadpool(build_comment_history, json_relpath, current)
     return {"status": "success", **result}
 
@@ -263,12 +285,12 @@ async def page_comments_restore(
     await run_in_threadpool(_require_catalog_access, catalog, user, write=True)
 
     # commit_hash peab kuuluma SELLE faili ajalukku (mitte suvaline git-objekt)
-    history = get_file_git_history(json_relpath, max_count=500)
+    history = await run_in_threadpool(get_file_git_history, json_relpath, max_count=500)
     valid = {h['full_hash'] for h in history} | {h['hash'] for h in history}
     if commit_hash not in valid:
         raise HTTPException(status_code=400, detail="Commit ei kuulu selle faili ajalukku")
 
-    content = get_file_at_commit(json_relpath, commit_hash)
+    content = await run_in_threadpool(get_file_at_commit, json_relpath, commit_hash)
     if content is None:
         raise HTTPException(status_code=400, detail="Commitist ei leitud faili")
     restored = find_comment_in_content(content, comment_id)
@@ -277,8 +299,7 @@ async def page_comments_restore(
 
     if not os.path.exists(json_path):
         raise HTTPException(status_code=404, detail="Lehe metaandmeid ei leitud")
-    with open(json_path, 'r', encoding='utf-8') as f:
-        cur_data = json.load(f)
+    cur_data = await run_in_threadpool(_read_json_file, json_path)
     source = cur_data['meta_content'] if (
         isinstance(cur_data, dict) and isinstance(cur_data.get('meta_content'), dict)
     ) else cur_data
@@ -290,11 +311,13 @@ async def page_comments_restore(
     source['comments'] = new_comments
 
     # .txt jääb muutmata (taastame ainult kommentaari)
-    with open(txt_path, 'r', encoding='utf-8') as f:
-        txt = f.read()
+    txt = await run_in_threadpool(_read_text_file, txt_path)
 
-    save_with_git(
-        txt_path, txt, user['username'],
+    await run_in_threadpool(
+        save_with_git,
+        txt_path,
+        txt,
+        user['username'],
         message=f"Restore comment {comment_id}: {commit_hash[:8]}",
         additional_files=[(json_path, json.dumps(cur_data, indent=2, ensure_ascii=False))],
     )
@@ -310,17 +333,20 @@ async def git_restore(request: Request, background_tasks: BackgroundTasks, user=
         raise HTTPException(status_code=400, detail="Vigane failitee")
     await run_in_threadpool(_require_catalog_access, catalog, user, write=True)
     path = os.path.join(BASE_DIR, catalog, filename)
-    content = get_file_at_commit(os.path.join(catalog, filename), data.get('commit_hash'))
+    content = await run_in_threadpool(
+        get_file_at_commit, os.path.join(catalog, filename), data.get('commit_hash')
+    )
     if content is None: raise HTTPException(status_code=400, detail="Ei leitud")
 
     additional = None
     restored_text_annotations = None
     json_filename = os.path.splitext(filename)[0] + ".json"
     json_path = os.path.join(BASE_DIR, catalog, json_filename)
-    restored_json = get_file_at_commit(os.path.join(catalog, json_filename), data.get('commit_hash'))
+    restored_json = await run_in_threadpool(
+        get_file_at_commit, os.path.join(catalog, json_filename), data.get('commit_hash')
+    )
     if os.path.exists(json_path):
-        with open(json_path, 'r', encoding='utf-8') as f:
-            current_meta = json.load(f)
+        current_meta = await run_in_threadpool(_read_json_file, json_path)
         if restored_json is not None:
             try:
                 restored_meta = json.loads(restored_json)
@@ -335,7 +361,8 @@ async def git_restore(request: Request, background_tasks: BackgroundTasks, user=
             current_meta['updated_at'] = datetime.now().isoformat()
             additional = [(json_path, json.dumps(current_meta, indent=2, ensure_ascii=False))]
 
-    save_with_git(
+    await run_in_threadpool(
+        save_with_git,
         path,
         content,
         user['username'],
@@ -380,7 +407,8 @@ async def bulk_collection(request: Request, background_tasks: BackgroundTasks, u
                     return {'collections': [coll_id] if coll_id else []}
             return transform
 
-        bulk_update_field(
+        await run_in_threadpool(
+            bulk_update_field,
             os.path.join(path, '_metadata.json'),
             make_transform(),
             user['username'],
@@ -419,7 +447,8 @@ async def bulk_tags(request: Request, background_tasks: BackgroundTasks, user=De
                 return {'tags': cur}
             return transform
 
-        bulk_update_field(
+        await run_in_threadpool(
+            bulk_update_field,
             os.path.join(path, '_metadata.json'),
             make_transform(),
             user['username'],
@@ -462,7 +491,8 @@ async def bulk_genre(request: Request, background_tasks: BackgroundTasks, user=D
                 return {'genre': current}
             return transform
 
-        bulk_update_field(
+        await run_in_threadpool(
+            bulk_update_field,
             os.path.join(path, '_metadata.json'),
             make_transform(),
             user['username'],

--- a/server/routers/notifications.py
+++ b/server/routers/notifications.py
@@ -23,6 +23,7 @@ import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Depends
+from starlette.concurrency import run_in_threadpool
 
 from ..config import BASE_DIR
 from ..deps import get_user, require_role, get_json_data
@@ -40,24 +41,9 @@ from ..notifications_ops import (
 router = APIRouter()
 
 
-@router.post("/page-comments/reply")
-async def reply_to_page_comment(
-    request: Request,
-    background_tasks: BackgroundTasks,
-    user=Depends(require_role("editor")),
-):
-    """Lisab lehekülje kommentaarile vastuse ja loob kommentaari autorile teavituse."""
-    data = await get_json_data(request)
-    catalog = os.path.basename(data.get('original_path', ''))
-    filename = os.path.basename(data.get('file_name', ''))
-    comment_id = str(data.get('comment_id', '')).strip()
-    reply_text = unicodedata.normalize('NFC', str(data.get('text', '')).strip())
-    work_id = str(data.get('work_id', '')).strip()
-    page_number = int(data.get('page_number') or 0)
-
-    if not catalog or not filename or not comment_id or not reply_text:
-        raise HTTPException(status_code=400, detail="Puudulikud vastuse andmed")
-
+def _apply_reply_sync(catalog, filename, comment_id, reply_text, work_id, page_number, user):
+    """Blokeeriv osa: faililugemine + git commit + teavitus. Jookseb threadpool'is,
+    et event-loop ei külmuks (vt issue #111)."""
     txt_path = os.path.join(BASE_DIR, catalog, filename)
     json_path = os.path.join(BASE_DIR, catalog, os.path.splitext(filename)[0] + ".json")
     if not os.path.exists(txt_path) or not os.path.exists(json_path):
@@ -104,7 +90,6 @@ async def reply_to_page_comment(
         message=f"Vasta kommentaarile: {os.path.relpath(json_path, BASE_DIR)}",
         additional_files=[(json_path, json.dumps(meta_content, indent=2, ensure_ascii=False))]
     )
-    background_tasks.add_task(sync_work_to_meilisearch_async, catalog)
 
     recipient = target_comment.get('author_username') or find_username_by_display_name(target_comment.get('author'))
     if recipient and recipient != user['username']:
@@ -132,8 +117,71 @@ async def reply_to_page_comment(
     }
 
 
+def _deliver_notifications_sync(recipients, notification_type, title, body, link, user, users_by_username, recipient_mode):
+    """Blokeeriv teavituste kirjutamine (file write per saaja). Jookseb threadpool'is."""
+    created = [
+        create_notification(
+            recipient,
+            notification_type,
+            title,
+            body,
+            link,
+            actor=user,
+            metadata={"sent_by_role": user.get("role", "")},
+        )
+        for recipient in recipients
+    ]
+    recipient_names = [
+        users_by_username[recipient].get("name") or recipient
+        for recipient in recipients
+        if recipient in users_by_username
+    ]
+    if user.get("username"):
+        create_notification(
+            user["username"],
+            "sent_notification",
+            title,
+            body,
+            link,
+            actor=user,
+            metadata={
+                "sent_by_role": user.get("role", ""),
+                "recipient_mode": recipient_mode,
+                "recipient_usernames": recipients,
+                "recipient_names": recipient_names,
+                "delivered_count": len(created),
+            },
+        )
+    return len(created)
+
+
+@router.post("/page-comments/reply")
+async def reply_to_page_comment(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    user=Depends(require_role("editor")),
+):
+    """Lisab lehekülje kommentaarile vastuse ja loob kommentaari autorile teavituse."""
+    data = await get_json_data(request)
+    catalog = os.path.basename(data.get('original_path', ''))
+    filename = os.path.basename(data.get('file_name', ''))
+    comment_id = str(data.get('comment_id', '')).strip()
+    reply_text = unicodedata.normalize('NFC', str(data.get('text', '')).strip())
+    work_id = str(data.get('work_id', '')).strip()
+    page_number = int(data.get('page_number') or 0)
+
+    if not catalog or not filename or not comment_id or not reply_text:
+        raise HTTPException(status_code=400, detail="Puudulikud vastuse andmed")
+
+    result = await run_in_threadpool(
+        _apply_reply_sync, catalog, filename, comment_id, reply_text, work_id, page_number, user
+    )
+    background_tasks.add_task(sync_work_to_meilisearch_async, catalog)
+    return result
+
+
 @router.get("/notifications")
-async def get_notifications(request: Request, user=Depends(get_user)):
+def get_notifications(request: Request, user=Depends(get_user)):
     """Kasutaja enda teavitused. ``?unread=true`` filtreerib loetud teatised välja."""
     unread_only = request.query_params.get('unread') == 'true'
     with _notifications_lock:
@@ -219,44 +267,15 @@ async def send_notification(request: Request, user=Depends(require_role("editor"
         recipients = [recipient_username]
         notification_type = "review_request"
 
-    created = [
-        create_notification(
-            recipient,
-            notification_type,
-            title,
-            body,
-            link,
-            actor=user,
-            metadata={"sent_by_role": user.get("role", "")},
-        )
-        for recipient in recipients
-    ]
-    recipient_names = [
-        users_by_username[recipient].get("name") or recipient
-        for recipient in recipients
-        if recipient in users_by_username
-    ]
-    if user.get("username"):
-        create_notification(
-            user["username"],
-            "sent_notification",
-            title,
-            body,
-            link,
-            actor=user,
-            metadata={
-                "sent_by_role": user.get("role", ""),
-                "recipient_mode": recipient_mode,
-                "recipient_usernames": recipients,
-                "recipient_names": recipient_names,
-                "delivered_count": len(created),
-            },
-        )
-    return {"status": "success", "created": len(created)}
+    delivered = await run_in_threadpool(
+        _deliver_notifications_sync,
+        recipients, notification_type, title, body, link, user, users_by_username, recipient_mode
+    )
+    return {"status": "success", "created": delivered}
 
 
 @router.post("/notifications/{notification_id}/read")
-async def mark_notification_read(notification_id: str, user=Depends(get_user)):
+def mark_notification_read(notification_id: str, user=Depends(get_user)):
     """Märgib teatise loetuks (idempotentne: juba loetud teatis jääb loetuks)."""
     with _notifications_lock:
         notifications = load_notifications(user['username'])

--- a/server/routers/pages.py
+++ b/server/routers/pages.py
@@ -1,11 +1,10 @@
-import asyncio
 import json
 import os
 import shutil
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
-from fastapi.datastructures import FormData
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
+from starlette.concurrency import run_in_threadpool
 
 from ..admin_page_ops import (
     clear_original_backup,
@@ -35,7 +34,7 @@ router = APIRouter()
 
 
 @router.get("/admin/work/{work_id}/pages")
-async def admin_work_pages(work_id: str, user=Depends(require_role("admin"))):
+def admin_work_pages(work_id: str, user=Depends(require_role("admin"))):
     """Tagastab teose lehekülgede nimekirja halduseks (sequence järgi sorditud)."""
     path = find_directory_by_id(work_id)
     if not path:
@@ -77,7 +76,7 @@ async def admin_work_pages(work_id: str, user=Depends(require_role("admin"))):
 
 
 @router.delete("/admin/work/{work_id}/page/{page_num}")
-async def admin_delete_page(work_id: str, page_num: int, user=Depends(require_role("admin"))):
+def admin_delete_page(work_id: str, page_num: int, user=Depends(require_role("admin"))):
     """Kustutab teose lehekülje: liigutab .jpg prügikasti, kustutab .txt ja .json gitist."""
     path = find_directory_by_id(work_id)
     if not path:
@@ -121,7 +120,7 @@ async def admin_delete_pages(work_id: str, request: Request, user=Depends(requir
     except Exception:
         raise HTTPException(status_code=400, detail="Vigane päring")
 
-    result = delete_pages(work_id, base_names, username=user["username"])
+    result = await run_in_threadpool(delete_pages, work_id, base_names, username=user["username"])
     if result["status"] == "not_found":
         raise HTTPException(status_code=404, detail={"missing": result["missing"]})
     if result["status"] == "conflict":
@@ -130,7 +129,12 @@ async def admin_delete_pages(work_id: str, request: Request, user=Depends(requir
 
 
 @router.post("/admin/work/{work_id}/page/{page_num}/replace-image")
-async def admin_replace_page_image(work_id: str, page_num: int, request: Request, user=Depends(require_role("admin"))):
+def admin_replace_page_image(
+    work_id: str,
+    page_num: int,
+    file: UploadFile = File(...),
+    user=Depends(require_role("admin")),
+):
     """
     Asendab lehekülje pildi uuega. Vana pilt säilitatakse prügikastis 90 päeva.
     Body: multipart — file (JPG/PNG)
@@ -140,19 +144,8 @@ async def admin_replace_page_image(work_id: str, page_num: int, request: Request
         raise HTTPException(status_code=404, detail="Teost ei leitud")
     folder_name = os.path.basename(path)
 
-    # Parse multipart (async — enne luku võtmist)
-    try:
-        form: FormData = await request.form()
-        file: UploadFile = form.get("file")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
-
-    if not file:
-        raise HTTPException(status_code=400, detail="Fail puudub")
-
-    # Kontrolli failitüüpi + teisenda (jagatud helper: magic-byte, mõõtmekaitse,
-    # PNG→JPG valgele taustale). Enne luku võtmist.
-    content = await file.read()
+    # Kogu endpoint on sync def: FastAPI käitab Pillow/fail/git/Meili tee threadpoolis.
+    content = file.file.read()
     try:
         content, _ext = detect_and_convert_image(content, file.filename or "")
     except ValueError as e:
@@ -204,7 +197,12 @@ async def admin_replace_page_image(work_id: str, page_num: int, request: Request
 
 
 @router.post("/admin/work/{work_id}/add-page")
-async def admin_add_page(work_id: str, request: Request, user=Depends(require_role("admin"))):
+def admin_add_page(
+    work_id: str,
+    file: UploadFile = File(...),
+    after_page_num: int = Form(-1),
+    user=Depends(require_role("admin")),
+):
     """
     Lisab teosele uue lehekülje (JPG/PNG).
     Body: multipart — file (JPG/PNG), after_page_num (int, 0=algusesse, -1=lõppu)
@@ -215,19 +213,8 @@ async def admin_add_page(work_id: str, request: Request, user=Depends(require_ro
         raise HTTPException(status_code=404, detail="Teost ei leitud")
     folder_name = os.path.basename(path)
 
-    # Parse multipart (async — enne luku võtmist)
-    try:
-        form: FormData = await request.form()
-        file: UploadFile = form.get("file")
-        after_page_num = int(form.get("after_page_num", -1))
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
-
-    if not file:
-        raise HTTPException(status_code=400, detail="Fail puudub")
-
-    # Kontrolli failitüüpi + teisenda (enne luku võtmist)
-    content = await file.read()
+    # Kogu endpoint on sync def: FastAPI käitab Pillow/fail/git/Meili tee threadpoolis.
+    content = file.file.read()
     try:
         content, ext = detect_and_convert_image(content, file.filename or "")
     except ValueError as e:
@@ -309,32 +296,19 @@ async def admin_add_page(work_id: str, request: Request, user=Depends(require_ro
 
 
 @router.post("/admin/work/{work_id}/add-pages")
-async def admin_add_pages(work_id: str, request: Request, user=Depends(require_role("admin"))):
+def admin_add_pages(
+    work_id: str,
+    files: list[UploadFile] = File(..., alias="file"),
+    after_page_num: int = Form(-1),
+    user=Depends(require_role("admin")),
+):
     """Lisab teosele mitu lehekülge korraga (JPG/PNG), nimejärgi sorteeritud.
     Body: multipart — mitu `file`-välja + after_page_num (int, 0=algusesse, -1=lõppu).
     """
-    try:
-        form: FormData = await request.form()
-        after_page_num = int(form.get("after_page_num", -1))
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Vigane vorm: {e}")
-
-    uploads = form.getlist("file")
-    if not uploads:
-        raise HTTPException(status_code=400, detail="Faile pole")
-
-    files = []
-    for up in uploads:
-        if not hasattr(up, "read"):
-            continue
-        content = await up.read()
-        files.append((up.filename or "", content))
+    upload_data = [(up.filename or "", up.file.read()) for up in files]
 
     try:
-        # add_pages on blokeeriv (Pillow-teisendus, failikirjutus, flock, git commit) —
-        # offload threadpooli, et mitte külmutada single-worker event-loopi (vt OCR-SSH outage)
-        loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, add_pages, work_id, files, after_page_num, user["username"])
+        result = add_pages(work_id, upload_data, after_page_num, user["username"])
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if not result.get("found", True):
@@ -350,7 +324,9 @@ async def admin_split_page(work_id: str, page_num: int, request: Request, user=D
     if split_x is None:
         raise HTTPException(status_code=400, detail="split_x on kohustuslik")
     try:
-        result = split_page(work_id, page_num, float(split_x), user["username"])
+        result = await run_in_threadpool(
+            split_page, work_id, page_num, float(split_x), user["username"]
+        )
     except (ValueError, TypeError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     if not result.get("found", True):
@@ -366,7 +342,15 @@ async def admin_transform_page_image(work_id: str, filename: str, request: Reque
     crop = data.get("crop")
     quad = data.get("quad")
     try:
-        result = transform_page_image(work_id, filename, angle=angle, crop=crop, quad=quad, username=user["username"])
+        result = await run_in_threadpool(
+            transform_page_image,
+            work_id,
+            filename,
+            angle=angle,
+            crop=crop,
+            quad=quad,
+            username=user["username"],
+        )
     except (ValueError, TypeError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     if not result.get("found", True):
@@ -375,7 +359,7 @@ async def admin_transform_page_image(work_id: str, filename: str, request: Reque
 
 
 @router.post("/admin/work/{work_id}/page-image/{filename}/restore-original")
-async def admin_restore_original_page_image(work_id: str, filename: str, user=Depends(require_role("admin"))):
+def admin_restore_original_page_image(work_id: str, filename: str, user=Depends(require_role("admin"))):
     """Taastab lehe pildi ._originals pristine versiooni."""
     try:
         result = restore_original_page_image(work_id, filename, username=user["username"])
@@ -394,9 +378,11 @@ async def admin_reorder_pages(work_id: str, request: Request, user=Depends(requi
         raise HTTPException(status_code=404, detail="Teost ei leitud")
     data = await request.json()
     new_order = data.get("order", [])
-    result = reorder_pages(path, new_order, user.get("username", "admin"))
+    result = await run_in_threadpool(
+        reorder_pages, path, new_order, user.get("username", "admin")
+    )
     if result.get("error"):
         raise HTTPException(status_code=400, detail=result["error"])
     folder_name = os.path.basename(path)
-    sync_work_to_meilisearch(folder_name)
+    await run_in_threadpool(sync_work_to_meilisearch, folder_name)
     return {"status": "success"}

--- a/server/routers/public.py
+++ b/server/routers/public.py
@@ -3,6 +3,7 @@ import os
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response, StreamingResponse
+from starlette.concurrency import run_in_threadpool
 
 from ..access_ops import can_read_work, can_write_work, is_work_public
 from ..admin_page_ops import get_sorted_images
@@ -39,7 +40,8 @@ async def toggle_shareable(work_id: str, request: Request, background_tasks: Bac
     if not can_write_work(_cur_meta, user):
         raise HTTPException(status_code=403, detail="Puudub õigus selle teose jagamist muuta")
     slug = os.path.basename(folder)
-    save_work_metadata(
+    await run_in_threadpool(
+        save_work_metadata,
         meta_path,
         {"shareable": shareable},
         user["username"],
@@ -52,7 +54,7 @@ async def toggle_shareable(work_id: str, request: Request, background_tasks: Bac
 
 
 @router.get("/work/{work_id}/viewer-token")
-async def get_viewer_token(work_id: str, request: Request):
+def get_viewer_token(work_id: str, request: Request):
     """Tagastab Meilisearch tokeni + pildi HMAC andmed juurdepääsuks ühele teosele.
     Kasutatakse shareable ja restricted teoste otselinkide jaoks."""
     import hashlib as _hashlib
@@ -78,7 +80,7 @@ async def get_viewer_token(work_id: str, request: Request):
 
 
 @router.get("/download/{work_id}")
-async def download_work(request: Request, work_id: str, content: str = "both"):
+def download_work(request: Request, work_id: str, content: str = "both"):
     """Laeb alla teose failid.
     content:
       'text'   → üks kokku liidetud .txt fail (sequence järjekorras)
@@ -207,7 +209,7 @@ async def download_work(request: Request, work_id: str, content: str = "both"):
         raise
 
 @router.get("/meta/home")
-async def home_meta(request: Request):
+def home_meta(request: Request):
     """Bot-koduleht: kollektsioonide kaupa grupeeritud teosed + isikute-hub.
     Linkgraafi peamine jaotuspunkt (iga avalik teos 1 hüppe kaugusel /-st)."""
     import time
@@ -230,7 +232,7 @@ async def home_meta(request: Request):
 
 
 @router.get("/meta/persons")
-async def persons_meta(request: Request):
+def persons_meta(request: Request):
     client_ip = get_client_ip(request)
     allowed, retry_after = check_rate_limit(client_ip, '/meta/persons')
     if not allowed:
@@ -240,7 +242,7 @@ async def persons_meta(request: Request):
 
 
 @router.get("/meta/person/{person_id:path}")
-async def person_meta(person_id: str, request: Request):
+def person_meta(person_id: str, request: Request):
     client_ip = get_client_ip(request)
     allowed, retry_after = check_rate_limit(client_ip, '/meta/person')
     if not allowed:
@@ -266,7 +268,7 @@ async def person_meta(person_id: str, request: Request):
 
 
 @router.get("/meta/work/{work_id}")
-async def work_meta(work_id: str, request: Request):
+def work_meta(work_id: str, request: Request):
     client_ip = get_client_ip(request)
     allowed, retry_after = check_rate_limit(client_ip, '/meta/work')
     if not allowed:
@@ -290,7 +292,7 @@ async def work_meta(work_id: str, request: Request):
     return HTMLResponse(content=build_meta_html(work_id, creator_persons=get_persons_for_work(work_id), include_text=False))
 
 @router.get("/sitemap.xml")
-async def sitemap_xml():
+def sitemap_xml():
     import time
     from .. import utils as utils_module
     now = time.time()

--- a/server/routers/public_registries.py
+++ b/server/routers/public_registries.py
@@ -26,20 +26,23 @@ async def people_register():
     return {"status": "success", "people": get_cached_people_register()}
 
 
+# sync def → threadpool: labels.json faililugemine ei blokeeri event-loopi
 @router.get("/entity-labels")
-async def entity_labels():
+def entity_labels():
     return load_entity_labels()
 
 
+# sync def → threadpool: Wikidata võrgupäringud + failikirjutused ei blokeeri event-loopi
 @router.post("/admin/refresh-entity-labels")
-async def admin_refresh_entity_labels(user=Depends(require_role("admin"))):
+def admin_refresh_entity_labels(user=Depends(require_role("admin"))):
     """Värskendab kõik labels.json Q-koodid Wikidatast (admin)."""
     count = refresh_all_entity_labels()
     return {"updated": count}
 
 
+# sync def → threadpool: skannib kõiki lehekülje-JSON-e (raske faililugemine)
 @router.post("/admin/enrich-page-tag-labels")
-async def admin_enrich_page_tag_labels(background_tasks: BackgroundTasks, user=Depends(require_role("admin"))):
+def admin_enrich_page_tag_labels(background_tasks: BackgroundTasks, user=Depends(require_role("admin"))):
     """Rikastab kõik lehekülje-tagide Q-koodid labels.json-i (retroaktiivselt).
 
     Skannib kõik lehekülje JSON-failid, kogub Q-koodid page_tags väljalt

--- a/server/routers/reocr.py
+++ b/server/routers/reocr.py
@@ -22,12 +22,42 @@ from ..utils import find_directory_by_id, generate_nanoid
 router = APIRouter()
 
 
+def _prepare_reocr_page(path: str, page_filename: str):
+    """Loeb mudeli meta ja kopeerib pildi temp-kausta blokeeriva I/O-na."""
+    img_path = os.path.join(path, page_filename)
+    if not os.path.isfile(img_path):
+        raise HTTPException(status_code=404, detail="Pilti ei leitud")
+    meta_path = os.path.join(path, "_metadata.json")
+    ocr_model = "print"
+    if os.path.isfile(meta_path):
+        with open(meta_path, "r", encoding="utf-8") as meta_file:
+            meta = json.load(meta_file)
+        if isinstance(meta.get("type"), dict) and meta["type"].get("id") == "Q87167":
+            ocr_model = "hand"
+    tmp_path = f"/tmp/vutt-reocr-{generate_nanoid()}.jpg"
+    shutil.copy2(img_path, tmp_path)
+    return tmp_path, ocr_model
+
+
+def _validate_batch_pages(path: str, page_filenames):
+    """Kontrollib iga faili olemasolu (blokeeriv stat per fail); jookseb threadpool'is."""
+    pages = []
+    for fn in page_filenames:
+        # Turvalisus: ainult bare failinimi — väldi path traversal'i (nt ../../state/users.json)
+        if not isinstance(fn, str) or fn != os.path.basename(fn):
+            raise HTTPException(status_code=400, detail=f"Vigane failinimi: {fn}")
+        if not os.path.isfile(os.path.join(path, fn)):
+            raise HTTPException(status_code=400, detail=f"Pilti ei leitud: {fn}")
+        pages.append((fn, None))
+    return pages
+
+
 @router.post("/admin/work/{work_id}/reocr-page")
 async def admin_reocr_page(work_id: str, request: Request, user=Depends(require_role("admin"))):
     """Alustab lehekülje pildi re-OCR tööd. Tagastab job_id pollimiseks."""
     if get_active_reocr_count() >= REOCR_MAX_CONCURRENT:
         raise HTTPException(status_code=429, detail=f"Liiga palju korraga ({REOCR_MAX_CONCURRENT} max). Proovi hetke pärast uuesti.")
-    path = find_directory_by_id(work_id)
+    path = await run_in_threadpool(find_directory_by_id, work_id)
     if not path:
         raise HTTPException(status_code=404, detail="Teos ei leitud")
     slug = os.path.basename(path)
@@ -38,20 +68,20 @@ async def admin_reocr_page(work_id: str, request: Request, user=Depends(require_
     # Turvalisus: ainult bare failinimi — väldi path traversal'i (nt ../../state/users.json)
     if not isinstance(page_filename, str) or page_filename != os.path.basename(page_filename):
         raise HTTPException(status_code=400, detail="Vigane failinimi")
-    img_path = os.path.join(path, page_filename)
-    if not os.path.isfile(img_path):
-        raise HTTPException(status_code=404, detail="Pilti ei leitud")
     page_number = data.get("page_number")
-    meta_path = os.path.join(path, "_metadata.json")
-    ocr_model = "print"
-    if os.path.isfile(meta_path):
-        with open(meta_path, "r", encoding="utf-8") as _mf:
-            _meta = json.load(_mf)
-        if isinstance(_meta.get("type"), dict) and _meta["type"].get("id") == "Q87167":
-            ocr_model = "hand"
-    tmp_path = f"/tmp/vutt-reocr-{generate_nanoid()}.jpg"
-    shutil.copy2(img_path, tmp_path)
-    job_id = start_reocr_job(work_id, slug, tmp_path, page_filename=page_filename, page_number=page_number, username=user["username"], material_type=ocr_model)
+    tmp_path, ocr_model = await run_in_threadpool(
+        _prepare_reocr_page, path, page_filename
+    )
+    job_id = await run_in_threadpool(
+        start_reocr_job,
+        work_id,
+        slug,
+        tmp_path,
+        page_filename=page_filename,
+        page_number=page_number,
+        username=user["username"],
+        material_type=ocr_model,
+    )
     return {"status": "accepted", "job_id": job_id}
 
 
@@ -88,13 +118,13 @@ def _enrich_titles(items: list) -> list:
 
 
 @router.get("/admin/reocr/jobs")
-async def admin_reocr_jobs(user=Depends(require_role("admin"))):
+def admin_reocr_jobs(user=Depends(require_role("admin"))):
     """Tagastab kõigi aktiivsete ja hiljutiste re-OCR tööde loendi."""
     return {"status": "success", "jobs": _enrich_titles(list_reocr_jobs())}
 
 
 @router.get("/admin/reocr/log")
-async def admin_reocr_log(offset: int = 0, limit: int = 50, user=Depends(require_role("admin"))):
+def admin_reocr_log(offset: int = 0, limit: int = 50, user=Depends(require_role("admin"))):
     """Tagastab re-OCR ajalogi (püsiv, uuemad ees)."""
     log = get_reocr_log(offset, limit)
     log["entries"] = _enrich_titles(log["entries"])
@@ -102,7 +132,7 @@ async def admin_reocr_log(offset: int = 0, limit: int = 50, user=Depends(require
 
 
 @router.get("/admin/work/{work_id}/page-ocr")
-async def get_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
+def get_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
     """Tagastab lehekülje .ocr faili sisu, kui see eksisteerib."""
     path = find_directory_by_id(work_id)
     if not path:
@@ -117,7 +147,7 @@ async def get_page_ocr(work_id: str, filename: str, user=Depends(require_role("a
 
 
 @router.delete("/admin/work/{work_id}/page-ocr")
-async def delete_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
+def delete_page_ocr(work_id: str, filename: str, user=Depends(require_role("admin"))):
     """Kustutab lehekülje .ocr faili (tulemus rakendatud või tagasi lükatud)."""
     path = find_directory_by_id(work_id)
     if not path:
@@ -132,7 +162,7 @@ async def delete_page_ocr(work_id: str, filename: str, user=Depends(require_role
 @router.post("/admin/work/{work_id}/reocr-batch")
 async def admin_reocr_batch(work_id: str, request: Request, user=Depends(require_role("admin"))):
     """Alustab mitme lehe batch re-OCR tööd. Tagastab job_id."""
-    path = find_directory_by_id(work_id)
+    path = await run_in_threadpool(find_directory_by_id, work_id)
     if not path:
         raise HTTPException(status_code=404, detail="Teost ei leitud")
     if get_active_batch_for_work(work_id):
@@ -143,20 +173,22 @@ async def admin_reocr_batch(work_id: str, request: Request, user=Depends(require
     if not isinstance(page_filenames, list) or not page_filenames:
         raise HTTPException(status_code=400, detail="page_filenames puudub või tühi")
     material_type = data.get("material_type") if data.get("material_type") in ("print", "hand") else "print"
-    pages = []
-    for fn in page_filenames:
-        # Turvalisus: ainult bare failinimi — väldi path traversal'i (nt ../../state/users.json)
-        if not isinstance(fn, str) or fn != os.path.basename(fn):
-            raise HTTPException(status_code=400, detail=f"Vigane failinimi: {fn}")
-        if not os.path.isfile(os.path.join(path, fn)):
-            raise HTTPException(status_code=400, detail=f"Pilti ei leitud: {fn}")
-        pages.append((fn, None))
-    job_id = start_reocr_batch(work_id, slug, path, pages, material_type=material_type, username=user["username"])
+    # Failide olemasolu-kontroll (kuni terve teose jagu stat-e) threadpool'is
+    pages = await run_in_threadpool(_validate_batch_pages, path, page_filenames)
+    job_id = await run_in_threadpool(
+        start_reocr_batch,
+        work_id,
+        slug,
+        path,
+        pages,
+        material_type=material_type,
+        username=user["username"],
+    )
     return {"status": "accepted", "job_id": job_id}
 
 
 @router.get("/admin/work/{work_id}/reocr-status")
-async def admin_reocr_status_for_work(work_id: str, user=Depends(require_role("admin"))):
+def admin_reocr_status_for_work(work_id: str, user=Depends(require_role("admin"))):
     """Teose re-OCR koondstaatus manage-lehele (active/ocr_ready/errors/progress)."""
     path = find_directory_by_id(work_id)
     if not path:

--- a/server/routers/upload.py
+++ b/server/routers/upload.py
@@ -42,7 +42,8 @@ async def admin_upload_create(request: Request, user=Depends(require_role("admin
     # sanitize_slug on idempotentne, seega juba korrektne slug ei muutu.
     slug = sanitize_slug(data.get("slug") or data.get("title", ""))
     data["slug"] = slug
-    return {"status": "success", "upload": create_upload(data, username=user["username"])}
+    upload = await run_in_threadpool(create_upload, data, username=user["username"])
+    return {"status": "success", "upload": upload}
 
 
 @router.get("/admin/upload/{upload_id}/status")
@@ -135,7 +136,7 @@ async def admin_upload_replace_work(
 
 @router.get("/admin/upload/{upload_id}/meta")
 async def admin_upload_get_meta(upload_id: str, user=Depends(require_role("admin"))):
-    state = get_upload(upload_id)
+    state = await run_in_threadpool(get_upload, upload_id)
     if not state:
         raise HTTPException(status_code=404, detail="Upload ei leitud")
     return {"status": "success", "meta": state.get("meta", {})}
@@ -144,7 +145,7 @@ async def admin_upload_get_meta(upload_id: str, user=Depends(require_role("admin
 @router.patch("/admin/upload/{upload_id}/meta")
 async def admin_upload_update_meta(upload_id: str, request: Request, user=Depends(require_role("admin"))):
     data = await get_json_data(request)
-    if not update_upload_meta(upload_id, data):
+    if not await run_in_threadpool(update_upload_meta, upload_id, data):
         raise HTTPException(status_code=404, detail="Upload ei leitud")
     return {"status": "success"}
 

--- a/server/routers/user_settings.py
+++ b/server/routers/user_settings.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Request
+from starlette.concurrency import run_in_threadpool
 
 from ..deps import get_json_data, get_user
 from ..user_settings_ops import load_user_settings, save_user_settings
@@ -6,8 +7,9 @@ from ..user_settings_ops import load_user_settings, save_user_settings
 router = APIRouter()
 
 
+# sync def → threadpool: kasutaja seadete faililugemine ei blokeeri event-loopi
 @router.get("/user-settings")
-async def get_user_settings(request: Request, user=Depends(get_user)):
+def get_user_settings(request: Request, user=Depends(get_user)):
     """Tagastab kasutaja kõik seaded."""
     settings = load_user_settings(user["username"])
     return {"status": "success", "settings": settings}
@@ -17,18 +19,18 @@ async def get_user_settings(request: Request, user=Depends(get_user)):
 async def save_user_settings_endpoint(request: Request, user=Depends(get_user)):
     """Salvestab kasutaja seaded (keel, vaiketab, erimärgid jne)."""
     data = await get_json_data(request)
-    settings = load_user_settings(user["username"])
+    settings = await run_in_threadpool(load_user_settings, user["username"])
     # Uuenda ainult lubatud väljad
     allowed_fields = ["language", "default_tab", "characters"]
     for field in allowed_fields:
         if field in data:
             settings[field] = data[field]
-    save_user_settings(user["username"], settings)
+    await run_in_threadpool(save_user_settings, user["username"], settings)
     return {"status": "success", "settings": settings}
 
 
 @router.get("/user-chars")
-async def get_user_chars(request: Request, user=Depends(get_user)):
+def get_user_chars(request: Request, user=Depends(get_user)):
     """Tagastab kasutaja kohandatud erimärgid."""
     settings = load_user_settings(user["username"])
     chars = settings.get("characters", [])
@@ -40,10 +42,10 @@ async def get_user_chars(request: Request, user=Depends(get_user)):
 async def save_user_chars(request: Request, user=Depends(get_user)):
     """Salvestab kasutaja kohandatud erimärgid."""
     data = await get_json_data(request)
-    settings = load_user_settings(user["username"])
+    settings = await run_in_threadpool(load_user_settings, user["username"])
     if data.get("reset"):
         settings.pop("characters", None)
     else:
         settings["characters"] = data.get("characters", [])
-    save_user_settings(user["username"], settings)
+    await run_in_threadpool(save_user_settings, user["username"], settings)
     return {"status": "success", "reset": bool(data.get("reset"))}

--- a/tests/test_async_endpoint_offload.py
+++ b/tests/test_async_endpoint_offload.py
@@ -5,7 +5,21 @@ import threading
 from fastapi import BackgroundTasks
 from starlette.requests import Request
 
-from server.routers import ocr_jobs, reocr, upload
+from server.prosopography import router as prosopography
+from server.routers import (
+    admin,
+    auth,
+    collections,
+    editing,
+    notifications,
+    ocr_jobs,
+    pages,
+    public,
+    public_registries,
+    reocr,
+    upload,
+    user_settings,
+)
 
 
 MAIN_THREAD = threading.current_thread().name
@@ -101,6 +115,177 @@ def test_upload_cancel_jookseb_threadpoolis(monkeypatch):
 
     assert result == {"status": "success"}
     assert seen["upload_id"] == "up-1"
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_save_git_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    monkeypatch.setattr(editing, "_require_catalog_access", lambda *_a, **_k: {})
+
+    def fake_save(*_args, **_kwargs):
+        seen["thread"] = _worker_thread_name()
+        return {"success": True, "commit_hash": "abc12345"}
+
+    monkeypatch.setattr(editing, "save_with_git", fake_save)
+    result = asyncio.run(editing.save(
+        _json_request(b'{"original_path":"work","file_name":"page.txt","text_content":"x"}'),
+        BackgroundTasks(),
+        user={"username": "editor", "role": "editor"},
+    ))
+
+    assert result["status"] == "success"
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_metadata_save_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(editing, "find_directory_by_id", lambda _wid: "/tmp/work")
+
+    def fake_save(*_args, **_kwargs):
+        seen["thread"] = _worker_thread_name()
+        return {"id": "w1"}
+
+    monkeypatch.setattr(editing, "save_work_metadata", fake_save)
+    monkeypatch.setattr(editing, "process_person_fields_metadata", lambda *_a: None)
+    monkeypatch.setattr(editing, "enrich_entity_labels_async", lambda *_a: None)
+    monkeypatch.setattr(editing, "_invalidate_all_caches", lambda: None)
+
+    result = asyncio.run(editing.update_work_metadata(
+        _json_request(b'{"work_id":"w1","metadata":{"title":"T"}}'),
+        BackgroundTasks(),
+        user={"username": "admin", "role": "admin"},
+    ))
+
+    assert result == {"status": "success"}
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_prosopography_create_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_create(data, username):
+        seen["args"] = (data, username)
+        seen["thread"] = _worker_thread_name()
+        return {"id": "vutt:P1"}
+
+    monkeypatch.setattr(prosopography, "create_person", fake_create)
+    monkeypatch.setattr(prosopography, "enrich_entity_labels_from_person_async", lambda *_a: None)
+    result = asyncio.run(prosopography.prosopography_create(
+        _json_request(b'{"name":"Test"}'), user={"username": "editor"}
+    ))
+
+    assert result == {"id": "vutt:P1"}
+    assert seen["args"] == ({"name": "Test"}, "editor")
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_prosopography_rebuild_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_rebuild():
+        seen["thread"] = _worker_thread_name()
+
+    monkeypatch.setattr(prosopography, "rebuild_indices", fake_rebuild)
+    result = asyncio.run(prosopography.prosopography_rebuild(user={"username": "admin"}))
+
+    assert result["status"] == "ok"
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_rasked_sync_endpointid_on_fastapi_threadpooli_jaoks_sync_def():
+    """Request-bodyta rasked endpointid peavad olema sync def, mitte event-loop coroutine."""
+    assert not asyncio.iscoroutinefunction(pages.admin_delete_page)
+    assert not asyncio.iscoroutinefunction(pages.admin_restore_original_page_image)
+    assert not asyncio.iscoroutinefunction(public.download_work)
+    assert not asyncio.iscoroutinefunction(public.sitemap_xml)
+    assert not asyncio.iscoroutinefunction(prosopography.person_history)
+    assert not asyncio.iscoroutinefunction(prosopography.places_wikidata_search)
+    # admin: prügikast, git fsck, teose kustutus (raske fs + git)
+    assert not asyncio.iscoroutinefunction(admin.admin_registrations)
+    assert not asyncio.iscoroutinefunction(admin.admin_trash)
+    assert not asyncio.iscoroutinefunction(admin.admin_trash_restore)
+    assert not asyncio.iscoroutinefunction(admin.admin_work_metadata)
+    assert not asyncio.iscoroutinefunction(admin.admin_trash_pages)
+    assert not asyncio.iscoroutinefunction(admin.admin_restore_page)
+    assert not asyncio.iscoroutinefunction(admin.admin_git_health)
+    assert not asyncio.iscoroutinefunction(admin.admin_work_delete)
+    # collections: arhiivi/kollektsiooni kustutus skannib kõiki teoseid
+    assert not asyncio.iscoroutinefunction(collections.delete_archive)
+    assert not asyncio.iscoroutinefunction(collections.admin_collection_users)
+    assert not asyncio.iscoroutinefunction(collections.admin_delete_collection)
+    # notifications: faili luge/kirjuta
+    assert not asyncio.iscoroutinefunction(notifications.get_notifications)
+    assert not asyncio.iscoroutinefunction(notifications.mark_notification_read)
+    # user_settings: faililugemine
+    assert not asyncio.iscoroutinefunction(user_settings.get_user_settings)
+    assert not asyncio.iscoroutinefunction(user_settings.get_user_chars)
+    # public_registries: labels.json + Wikidata refresh + kõigi lehtede skann
+    assert not asyncio.iscoroutinefunction(public_registries.entity_labels)
+    assert not asyncio.iscoroutinefunction(public_registries.admin_refresh_entity_labels)
+    assert not asyncio.iscoroutinefunction(public_registries.admin_enrich_page_tag_labels)
+
+
+def test_login_verify_user_jookseb_threadpoolis(monkeypatch):
+    """bcrypt on CPU-raske — verify_user peab jooksma threadpool'is, mitte event-loopis."""
+    seen = {}
+
+    monkeypatch.setattr(auth, "check_rate_limit", lambda *_a, **_k: (True, 0))
+    monkeypatch.setattr(auth, "check_account_lockout", lambda *_a, **_k: (False, 0))
+    monkeypatch.setattr(auth, "clear_login_failures", lambda *_a, **_k: None)
+    monkeypatch.setattr(auth, "create_session", lambda user: "tok")
+
+    def fake_verify(username, password):
+        seen["args"] = (username, password)
+        seen["thread"] = _worker_thread_name()
+        return {"username": username, "role": "editor"}
+
+    monkeypatch.setattr(auth, "verify_user", fake_verify)
+
+    result = asyncio.run(auth.login(_json_request(b'{"username":"bob","password":"pw"}')))
+
+    assert result["status"] == "success"
+    assert seen["args"] == ("bob", "pw")
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_notifications_reply_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_apply(catalog, filename, comment_id, reply_text, work_id, page_number, user):
+        seen["args"] = (catalog, filename, comment_id, reply_text)
+        seen["thread"] = _worker_thread_name()
+        return {"status": "success", "comments": [], "reply": {}, "commit_hash": "abc"}
+
+    monkeypatch.setattr(notifications, "_apply_reply_sync", fake_apply)
+
+    result = asyncio.run(notifications.reply_to_page_comment(
+        _json_request(b'{"original_path":"w","file_name":"p.txt","comment_id":"c1","text":"hi"}'),
+        BackgroundTasks(),
+        user={"username": "editor", "name": "Ed"},
+    ))
+
+    assert result["status"] == "success"
+    assert seen["args"] == ("w", "p.txt", "c1", "hi")
+    assert seen["thread"] != MAIN_THREAD
+
+
+def test_prosopography_work_titles_jookseb_threadpoolis(monkeypatch):
+    seen = {}
+
+    def fake_collect(work_ids):
+        seen["work_ids"] = work_ids
+        seen["thread"] = _worker_thread_name()
+        return {"w1": {"title": "T", "year": None, "restricted": False}}
+
+    monkeypatch.setattr(prosopography, "_collect_work_titles", fake_collect)
+
+    result = asyncio.run(prosopography.prosopography_work_titles(
+        _json_request(b'{"work_ids":["w1"]}')
+    ))
+
+    assert result == {"titles": {"w1": {"title": "T", "year": None, "restricted": False}}}
+    assert seen["work_ids"] == ["w1"]
     assert seen["thread"] != MAIN_THREAD
 
 

--- a/tests/test_prosopography_git.py
+++ b/tests/test_prosopography_git.py
@@ -254,7 +254,7 @@ def test_person_history_uses_correct_relative_path():
         from server.prosopography import router as prosopo_router
         import importlib; importlib.reload(prosopo_router)
         with patch("server.prosopography.router.get_file_git_history", return_value=mock_history) as mock_git2:
-            result = asyncio.run(prosopo_router.person_history("vutt:Pabc123", user={"username": "t", "role": "editor"}))
+            result = prosopo_router.person_history("vutt:Pabc123", user={"username": "t", "role": "editor"})
 
     assert result["status"] == "ok"
     called_path = mock_git2.call_args.args[0]
@@ -277,8 +277,8 @@ def test_compute_person_diff_used_in_diff_endpoint():
          patch("server.prosopography.router.get_or_init_repo") as mock_repo:
         mock_repo.return_value.commit.return_value = mock_commit
         from server.prosopography import router as prosopo_router
-        result = asyncio.run(prosopo_router.person_diff("vutt:Pabc123", commit="abc12345",
-                             user={"username": "t", "role": "editor"}))
+        result = prosopo_router.person_diff("vutt:Pabc123", commit="abc12345",
+                                            user={"username": "t", "role": "editor"})
 
     assert result["status"] == "ok"
     fields = {c["field"] for c in result["changes"]}

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -78,8 +78,7 @@ def test_sitemap_uses_snapshot_not_live_cache(monkeypatch):
 
     monkeypatch.setattr(utils_mod, "WORK_ID_CACHE", {"w1": "/data/w1", "w2": "/data/w2"})
 
-    import asyncio
-    asyncio.run(public_router.sitemap_xml())
+    public_router.sitemap_xml()
 
     assert captured_args, "build_sitemap_xml ei kutsutud"
     passed_cache = captured_args[0]


### PR DESCRIPTION
Sulgeb #111.

## Miks

Async route ei tohi kutsuda blokeerivat I/O-d otse event-loopis — üks aeglane
operatsioon (bcrypt, git commit, faili luge/kirjuta, kataloogi-skann, Wikidata
päring) külmutab kõik samaaegsed päringud. Sama muster põhjustas varasema
OCR-serveri SSH outage'i (a89e905).

See PR viib lõpuni event-loop offload töö, mis algas `editing.py`, `pages.py`,
`prosopography/router.py`, `reocr.py`, `public.py`, `upload.py` moodulites, ja
katab ülejäänud router-moodulid.

## Muudatused

**auth.py** — bcrypt on THE kriitiline offender:
- `login`: `verify_user` (bcrypt ~100ms) → `run_in_threadpool`
- registreerimine / parooli-reset / kutse: failioperatsioonid offload

**admin.py**
- prügikast / work-metadata / git-fsck / **work-delete** (rmtree+move+git) → sync `def`
- registration approve/reject, user role/collections/delete, reset-password → `run_in_threadpool`

**collections.py**
- **delete-archive / delete-collection** (skannib KÕIKI teoseid + git commit) → sync `def`
- archive/collection loe-muuda-kirjuta → `run_in_threadpool`

**notifications.py**
- `reply_to_page_comment` → `_apply_reply_sync` (git commit + teavitus) offload
- `send_notification` → `_deliver_notifications_sync` (file write per saaja) offload
- GET-id → sync `def`

**user_settings.py / public_registries.py** — settings I/O, labels.json, Wikidata refresh,
kõigi lehtede skann offload / sync `def`.

**editing.py / reocr.py / prosopography/router.py** — jäägid: `/save` sequence-read,
batch-lehtede stat-loop, `work-titles` kuni 200 metadata-faili lugemine.

## Verifikatsioon

- AST-inventuur: async route'idesse ei jää rasket sünkroonset I/O-d. Alles jäävad
  vaid cache-soe `load_users()` (populeeritud impordil) ja üksikud triviaalsed
  `os.path.exists` guard-stat'id ning standardne streaming-upload muster.
- `pytest -q` → **897 passed** (lisatud login/reply/work-titles threadpool
  regressioonid + sync-def invariandi kontroll uutele endpointidele)
- `git diff --check` puhas
- Frontend puutumata (ainult server/ Python)

## Käsitsi kontrollida enne merge't (multipart route'id)

`pages.py` pildi-route'id on sync `def` (`file.file.read()`, mitte `await file.read()`):
- ühe pildi asendamine
- ühe / mitme lehe lisamine

🤖 Generated with [Claude Code](https://claude.com/claude-code)