### PR TITLE
Fix prosopography side-write auditing and enrichment leak

### DIFF
--- a/server/prosopography/locks.py
+++ b/server/prosopography/locks.py
@@ -6,13 +6,16 @@ või bulk + edit) loevad-muudavad-kirjutavad sama faili paralleelselt. Uvicorn o
 single-worker, AGA BackgroundTasks ja daemon-thread'id jooksevad samas protsessis.
 
 Lukud on püsivad (ei puhastata) — ~2200 isikut → ~2200 Lock objekti, tühine.
-Iga kirjutaja haarab korraga AINULT ühe luku → deadlock pole võimalik.
+Tavaline kirjutaja haarab korraga ainult ühe isikuluku. Isiku- ja kohaliitmine võivad
+haarata mitu isikulukku, kuid need operatsioonid serialiseerib enne seda ühine
+``merge_operation_lock``; nii ei saa kaks liitmist tekitada ristlukustust.
 """
 import threading
 from typing import Dict
 
 _registry_guard = threading.Lock()
 _person_locks: Dict[str, threading.Lock] = {}
+merge_operation_lock = threading.Lock()
 
 
 def person_lock(person_id: str) -> threading.Lock:

--- a/server/prosopography/merge_ops.py
+++ b/server/prosopography/merge_ops.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import ExitStack
 from datetime import datetime, timezone
 
 from . import state
 from .indices import _load_index, _load_person_to_works, _remove_aliases_entry, rebuild_indices
 from .person_crud import _id_to_path, get_person
+from .locks import person_lock
 from ._compat import sync_from_facade
 
 
-def merge_person(source_id: str, target_id: str, username: str) -> dict:
-    """
-    Liidab source kirje target kirjesse ja sünkroniseerib read-modelid.
-    """
+def _merge_person_locked(source_id: str, target_id: str, username: str) -> dict:
+    """Liidab kirjed; kutsuja hoiab source- ja target-kaardi lukke."""
     sync_from_facade()
     if source_id == target_id:
         raise ValueError("Source ja target ei tohi olla samad.")
@@ -132,15 +132,29 @@ def merge_person(source_id: str, target_id: str, username: str) -> dict:
             continue
         if p.get("record_status") == "tombstone":
             continue
-        changed = False
-        for rel in p.get("relations", []):
-            if rel.get("target_id") == source_id:
-                rel["target_id"] = target_id
-                changed = True
-        if changed:
-            p["updated_at"] = now
-            p["updated_by"] = username
-            state.atomic_write_json(fpath, p)
+        person_id = p.get("id")
+        if not person_id:
+            continue
+        # Loe luku all uuesti: skannimise ja kirjutamise vahel võis kaart muutuda.
+        with person_lock(person_id):
+            p = get_person(person_id)
+            if p is None or p.get("record_status") == "tombstone":
+                continue
+            changed = False
+            for rel in p.get("relations", []):
+                if rel.get("target_id") == source_id:
+                    rel["target_id"] = target_id
+                    changed = True
+            if changed:
+                p["updated_at"] = now
+                p["updated_by"] = username
+                person_name = (p.get("name") or {}).get("label") or person_id
+                state.save_with_git(
+                    fpath,
+                    json.dumps(p, ensure_ascii=False, indent=2),
+                    username,
+                    message=f"Prosopo liitmise seoseuuendus: {person_name} [{person_id}]",
+                )
 
     target_label = (target.get("name") or {}).get("label") or source.get("name", {}).get("label", "")
     from ..config import BASE_DIR as data_dir
@@ -191,6 +205,17 @@ def merge_person(source_id: str, target_id: str, username: str) -> dict:
 
     rebuild_indices()
     return get_person(target_id)
+
+
+def merge_person(source_id: str, target_id: str, username: str) -> dict:
+    """Liidab source kirje target kirjesse ja sünkroniseerib read-modelid."""
+    if source_id == target_id:
+        raise ValueError("Source ja target ei tohi olla samad.")
+    # Fikseeritud järjekord väldib kahe samaaegse ristmerge'i deadlock'i.
+    with ExitStack() as stack:
+        for person_id in sorted((source_id, target_id)):
+            stack.enter_context(person_lock(person_id))
+        return _merge_person_locked(source_id, target_id, username)
 
 
 def delete_person(person_id: str, username: str) -> dict:

--- a/server/prosopography/merge_ops.py
+++ b/server/prosopography/merge_ops.py
@@ -9,12 +9,12 @@ from datetime import datetime, timezone
 from . import state
 from .indices import _load_index, _load_person_to_works, _remove_aliases_entry, rebuild_indices
 from .person_crud import _id_to_path, get_person
-from .locks import person_lock
+from .locks import merge_operation_lock, person_lock
 from ._compat import sync_from_facade
 
 
 def _merge_person_locked(source_id: str, target_id: str, username: str) -> dict:
-    """Liidab kirjed; kutsuja hoiab source- ja target-kaardi lukke."""
+    """Liidab kirjed; kutsuja hoiab liitmis- ning source/target isikulukke."""
     sync_from_facade()
     if source_id == target_id:
         raise ValueError("Source ja target ei tohi olla samad.")
@@ -211,11 +211,13 @@ def merge_person(source_id: str, target_id: str, username: str) -> dict:
     """Liidab source kirje target kirjesse ja sünkroniseerib read-modelid."""
     if source_id == target_id:
         raise ValueError("Source ja target ei tohi olla samad.")
-    # Fikseeritud järjekord väldib kahe samaaegse ristmerge'i deadlock'i.
-    with ExitStack() as stack:
-        for person_id in sorted((source_id, target_id)):
-            stack.enter_context(person_lock(person_id))
-        return _merge_person_locked(source_id, target_id, username)
+    # Globaalne lukk serialiseerib ka relation-loop'is ja kohaliitmisel võetavad
+    # lisalukud; järjestus väldib source/target paaris ebavajalikku ristootamist.
+    with merge_operation_lock:
+        with ExitStack() as stack:
+            for person_id in sorted((source_id, target_id)):
+                stack.enter_context(person_lock(person_id))
+            return _merge_person_locked(source_id, target_id, username)
 
 
 def delete_person(person_id: str, username: str) -> dict:

--- a/server/prosopography/person_crud.py
+++ b/server/prosopography/person_crud.py
@@ -418,8 +418,10 @@ def apply_enrichment(person_id: str, approved: dict, username: str) -> dict:
             raise KeyError(person_id)
 
         # Tehniline võti juhib checked_at uuendust, kuid ei kuulu isikukaardile.
-        scheme = approved.pop("_enrichment_scheme", None)
-        for field_path, value in approved.items():
+        # Koopia väldib kutsuja request-dict'i muteerimist.
+        approved_fields = dict(approved)
+        scheme = approved_fields.pop("_enrichment_scheme", None)
+        for field_path, value in approved_fields.items():
             _deep_set(person, field_path, value)
 
         if scheme:

--- a/server/prosopography/person_crud.py
+++ b/server/prosopography/person_crud.py
@@ -311,9 +311,6 @@ def _person_image_path(person_id: str, ext: str) -> str:
 def upload_person_image(person_id: str, file_bytes: bytes, content_type: str, username: str) -> dict:
     """Salvestab isiku pildi ja uuendab image_url kirjes."""
     sync_from_facade()
-    person = get_person(person_id)
-    if person is None:
-        raise KeyError(person_id)
 
     if content_type not in ("image/jpeg", "image/png", "image/webp"):
         raise ValueError("Toetatud formaadid: JPEG, PNG, WebP")
@@ -332,25 +329,34 @@ def upload_person_image(person_id: str, file_bytes: bytes, content_type: str, us
 
     ext = ".jpg" if content_type in ("image/jpeg",) else ".webp"
 
-    for old_ext in (".jpg", ".webp"):
-        old_path = _person_image_path(person_id, old_ext)
-        if old_path.endswith(ext):
-            continue
-        if os.path.exists(old_path):
-            os.remove(old_path)
+    with person_lock(person_id):
+        person = get_person(person_id)
+        if person is None:
+            raise KeyError(person_id)
 
-    os.makedirs(state.PROSOPOGRAPHY_IMAGES_DIR, exist_ok=True)
-    img_path = _person_image_path(person_id, ext)
-    with open(img_path, "wb") as f:
-        f.write(file_bytes)
+        for old_ext in (".jpg", ".webp"):
+            old_path = _person_image_path(person_id, old_ext)
+            if old_path.endswith(ext):
+                continue
+            if os.path.exists(old_path):
+                os.remove(old_path)
 
-    encoded_id = person_id.replace(":", "%3A")
-    person["image_url"] = f"/api/files/prosopography/{encoded_id}/image"
+        os.makedirs(state.PROSOPOGRAPHY_IMAGES_DIR, exist_ok=True)
+        img_path = _person_image_path(person_id, ext)
+        with open(img_path, "wb") as f:
+            f.write(file_bytes)
 
-    now = datetime.now(timezone.utc).isoformat()
-    person["updated_at"] = now
-    person["updated_by"] = username
-    state.atomic_write_json(_id_to_path(person_id), person)
+        encoded_id = person_id.replace(":", "%3A")
+        person["image_url"] = f"/api/files/prosopography/{encoded_id}/image"
+        person["updated_at"] = datetime.now(timezone.utc).isoformat()
+        person["updated_by"] = username
+        name = (person.get("name") or {}).get("label") or person_id
+        state.save_with_git(
+            _id_to_path(person_id),
+            json.dumps(person, ensure_ascii=False, indent=2),
+            username,
+            message=f"Prosopo pildi lisamine: {name} [{person_id}]",
+        )
     _indices()._update_index_entry(person)
     return person
 
@@ -370,20 +376,26 @@ def get_person_image_path(person_id: str) -> Optional[str]:
 def delete_person_image(person_id: str, username: str) -> dict:
     """Kustutab isiku pildi ja tühjendab image_url. Tagastab uuendatud kirje."""
     sync_from_facade()
-    person = get_person(person_id)
-    if person is None:
-        raise KeyError(person_id)
+    with person_lock(person_id):
+        person = get_person(person_id)
+        if person is None:
+            raise KeyError(person_id)
 
-    for ext in (".jpg", ".webp"):
-        path = _person_image_path(person_id, ext)
-        if os.path.exists(path):
-            os.remove(path)
+        for ext in (".jpg", ".webp"):
+            path = _person_image_path(person_id, ext)
+            if os.path.exists(path):
+                os.remove(path)
 
-    person["image_url"] = None
-    now = datetime.now(timezone.utc).isoformat()
-    person["updated_at"] = now
-    person["updated_by"] = username
-    state.atomic_write_json(_id_to_path(person_id), person)
+        person["image_url"] = None
+        person["updated_at"] = datetime.now(timezone.utc).isoformat()
+        person["updated_by"] = username
+        name = (person.get("name") or {}).get("label") or person_id
+        state.save_with_git(
+            _id_to_path(person_id),
+            json.dumps(person, ensure_ascii=False, indent=2),
+            username,
+            message=f"Prosopo pildi kustutamine: {name} [{person_id}]",
+        )
     _indices()._update_index_entry(person)
     return person
 
@@ -405,10 +417,11 @@ def apply_enrichment(person_id: str, approved: dict, username: str) -> dict:
         if person is None:
             raise KeyError(person_id)
 
+        # Tehniline võti juhib checked_at uuendust, kuid ei kuulu isikukaardile.
+        scheme = approved.pop("_enrichment_scheme", None)
         for field_path, value in approved.items():
             _deep_set(person, field_path, value)
 
-        scheme = approved.get("_enrichment_scheme")
         if scheme:
             for ident in person.get("identifiers") or []:
                 if ident.get("scheme") == scheme:

--- a/server/prosopography/places_ops.py
+++ b/server/prosopography/places_ops.py
@@ -16,7 +16,7 @@ from typing import Optional
 from ..config import PLACES_FILE, ORIGIN_GROUPS_FILE, PROSOPOGRAPHY_DIR, get_logger
 from ..utils import atomic_write_json
 from ..git_ops import save_with_git
-from .locks import person_lock
+from .locks import merge_operation_lock, person_lock
 
 logger = get_logger(__name__)
 
@@ -616,7 +616,7 @@ def refresh_all_place_labels() -> int:
     return updated
 
 
-def merge_places(source_key: str, target_key: str, username: str = "system") -> dict:
+def _merge_places_locked(source_key: str, target_key: str, username: str) -> dict:
     """
     Ühendab source_key sihtkoha target_key alla.
     1. Uuendab kõik isikud kelle origin.place == source_key → target_key.
@@ -694,6 +694,12 @@ def merge_places(source_key: str, target_key: str, username: str = "system") -> 
 
     logger.info("merge_places: %s → %s, %d isikut ümber suunatud", source_key, target_key, redirected)
     return {"redirected": redirected, "target_key": target_key}
+
+
+def merge_places(source_key: str, target_key: str, username: str = "system") -> dict:
+    """Serialiseerib kohaliitmise teiste isiku- ja kohaliitmiste suhtes."""
+    with merge_operation_lock:
+        return _merge_places_locked(source_key, target_key, username)
 
 
 def delete_place(key: str) -> None:

--- a/server/prosopography/places_ops.py
+++ b/server/prosopography/places_ops.py
@@ -10,10 +10,13 @@ import time
 import threading
 import urllib.request
 import urllib.parse
+from datetime import datetime, timezone
 from typing import Optional
 
 from ..config import PLACES_FILE, ORIGIN_GROUPS_FILE, PROSOPOGRAPHY_DIR, get_logger
 from ..utils import atomic_write_json
+from ..git_ops import save_with_git
+from .locks import person_lock
 
 logger = get_logger(__name__)
 
@@ -613,7 +616,7 @@ def refresh_all_place_labels() -> int:
     return updated
 
 
-def merge_places(source_key: str, target_key: str) -> dict:
+def merge_places(source_key: str, target_key: str, username: str = "system") -> dict:
     """
     Ühendab source_key sihtkoha target_key alla.
     1. Uuendab kõik isikud kelle origin.place == source_key → target_key.
@@ -648,14 +651,32 @@ def merge_places(source_key: str, target_key: str) -> dict:
         except Exception as exc:
             logger.warning("merge_places: skipping %s: %s", fpath, exc)
             continue
-        origin = person.get("origin")
-        if not isinstance(origin, dict):
+        person_id = person.get("id")
+        if not person_id:
             continue
-        if origin.get("place") != source_key:
-            continue
-        origin["place"] = target_key
-        atomic_write_json(fpath, person)
-        redirected += 1
+        with person_lock(person_id):
+            # Loe luku all uuesti, et paralleelne isikukaardi salvestus ei kaoks.
+            try:
+                with open(fpath, "r", encoding="utf-8") as f:
+                    person = json.load(f)
+            except Exception as exc:
+                logger.warning("merge_places: skipping %s after lock: %s", fpath, exc)
+                continue
+            origin = person.get("origin")
+            if not isinstance(origin, dict) or origin.get("place") != source_key:
+                continue
+            origin["place"] = target_key
+            person["updated_at"] = datetime.now(timezone.utc).isoformat()
+            person["updated_by"] = username
+            raw_name = person.get("name")
+            person_name = (raw_name.get("label") if isinstance(raw_name, dict) else raw_name) or person_id
+            save_with_git(
+                fpath,
+                json.dumps(person, ensure_ascii=False, indent=2),
+                username,
+                message=f"Prosopo kohaliitmine: {person_name} [{person_id}]",
+            )
+            redirected += 1
 
     # 2. Lisa source_key sihtkoha historical_names-i
     target = dict(places[target_key])

--- a/server/prosopography/reciprocal_ops.py
+++ b/server/prosopography/reciprocal_ops.py
@@ -2,7 +2,8 @@
 """
 Vastastikuste seoste sünkroniseerimine.
 Kutsutakse router.py PUT endpointist pärast isiku salvestamist.
-Kasutab atomic_write_json otse — EI kasuta update_person() — vältimaks lõputut tsüklit.
+Ei kasuta update_person() — see väldib lõputut sünkroniseerimistsüklit —,
+kuid salvestab muudatuse git-ajalooga.
 """
 import json
 import os
@@ -10,7 +11,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 from ..config import PROSOPOGRAPHY_DIR, get_logger
-from ..utils import atomic_write_json
+from ..git_ops import save_with_git
 from .locks import person_lock
 
 logger = get_logger(__name__)
@@ -82,7 +83,13 @@ def sync_reciprocals(
             })
             b["updated_at"] = now
             b["updated_by"] = username
-            atomic_write_json(_id_to_path(b_id), b)
+            b_name = (b.get("name") or {}).get("label") or b_id
+            save_with_git(
+                _id_to_path(b_id),
+                json.dumps(b, ensure_ascii=False, indent=2),
+                username,
+                message=f"Prosopo vastastikune seos: {b_name} [{b_id}]",
+            )
             synced.append(b_id)
 
     for b_id in removed:
@@ -101,7 +108,13 @@ def sync_reciprocals(
             b["relations"] = after
             b["updated_at"] = now
             b["updated_by"] = username
-            atomic_write_json(_id_to_path(b_id), b)
+            b_name = (b.get("name") or {}).get("label") or b_id
+            save_with_git(
+                _id_to_path(b_id),
+                json.dumps(b, ensure_ascii=False, indent=2),
+                username,
+                message=f"Prosopo vastastikune seos: {b_name} [{b_id}]",
+            )
             synced.append(b_id)
 
     return synced

--- a/server/prosopography/router.py
+++ b/server/prosopography/router.py
@@ -478,7 +478,9 @@ async def places_merge(
     if not target_key:
         raise HTTPException(status_code=400, detail="target_key on kohustuslik")
     try:
-        result = await run_in_threadpool(merge_places, source_key, target_key)
+        result = await run_in_threadpool(
+            merge_places, source_key, target_key, username=user["username"]
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/tests/test_prosopography_git.py
+++ b/tests/test_prosopography_git.py
@@ -202,8 +202,11 @@ def test_merge_person_commits_source_and_target(tmp_path):
                "import_batch_ids": [], "statuses": [], "occupations": [], "education": [],
                "sources": [], "confessions": [], "birth": None, "death": None,
                "origin": {}, "gender": None, "biography": None, "notes": None, "image_url": None}
+    # Targeti viide source'ile katab source/target kaartide relation-loop'is
+    # vahelejätmise: neid ei tohi tavalise Lock-iga teist korda lukustada.
     target = {"id": "vutt:Ptgt", "name": {"label": "Sihtmärk"}, "record_status": "draft",
-               "updated_at": "2024-01-01T00:00:00+00:00", "relations": [], "identifiers": [],
+               "updated_at": "2024-01-01T00:00:00+00:00",
+               "relations": [{"target_id": "vutt:Psrc", "type": "kolleeg"}], "identifiers": [],
                "import_batch_ids": [], "statuses": [], "occupations": [], "education": [],
                "sources": [], "confessions": [], "birth": None, "death": None,
                "origin": {}, "gender": None, "biography": None, "notes": None, "image_url": None}

--- a/tests/test_prosopography_side_writes.py
+++ b/tests/test_prosopography_side_writes.py
@@ -1,0 +1,74 @@
+"""Prosopograafia kõrvalkirjutuste git- ja tehniliste väljade regressioonitestid."""
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+def _person(person_id="vutt:Pabc123"):
+    return {
+        "id": person_id,
+        "name": {"label": "Test Isik"},
+        "identifiers": [{"scheme": "wikidata", "id": "Q1", "checked_at": None}],
+        "image_url": None,
+        "updated_at": "2026-01-01T00:00:00+00:00",
+    }
+
+
+def _configure_crud(monkeypatch, tmp_path, person):
+    from server.prosopography import person_crud
+
+    prosopo_dir = tmp_path / "prosopography"
+    images_dir = tmp_path / "state-images"
+    prosopo_dir.mkdir()
+    path = prosopo_dir / "abc123.json"
+    path.write_text(json.dumps(person), encoding="utf-8")
+
+    monkeypatch.setattr(person_crud.state, "PROSOPOGRAPHY_DIR", str(prosopo_dir))
+    monkeypatch.setattr(person_crud.state, "PROSOPOGRAPHY_IMAGES_DIR", str(images_dir))
+    monkeypatch.setattr(person_crud, "sync_from_facade", lambda: None)
+    monkeypatch.setattr(person_crud, "get_person", lambda _pid: json.loads(path.read_text()))
+    monkeypatch.setattr(person_crud, "_indices", lambda: type("I", (), {
+        "_update_index_entry": staticmethod(lambda _p: None),
+        "_update_aliases_entry": staticmethod(lambda _p: None),
+    })())
+    return person_crud, path
+
+
+def _saving_mock(path):
+    def save(filepath, content, *_args, **_kwargs):
+        Path(filepath).write_text(content, encoding="utf-8")
+        return {"success": True, "commit_hash": "test"}
+    return MagicMock(side_effect=save)
+
+
+def test_image_metadata_changes_use_git(monkeypatch, tmp_path):
+    crud, path = _configure_crud(monkeypatch, tmp_path, _person())
+    save = _saving_mock(path)
+    monkeypatch.setattr(crud.state, "save_with_git", save)
+
+    result = crud.upload_person_image("vutt:Pabc123", b"jpeg", "image/jpeg", "editor")
+    assert result["image_url"]
+    assert save.call_count == 1
+    assert "pildi lisamine" in save.call_args.kwargs["message"]
+
+    result = crud.delete_person_image("vutt:Pabc123", "editor")
+    assert result["image_url"] is None
+    assert save.call_count == 2
+    assert "pildi kustutamine" in save.call_args.kwargs["message"]
+
+
+def test_enrichment_scheme_is_not_persisted(monkeypatch, tmp_path):
+    crud, path = _configure_crud(monkeypatch, tmp_path, _person())
+    save = _saving_mock(path)
+    monkeypatch.setattr(crud.state, "save_with_git", save)
+
+    result = crud.apply_enrichment(
+        "vutt:Pabc123",
+        {"biography": "Uus elulugu", "_enrichment_scheme": "wikidata"},
+        "editor",
+    )
+
+    saved = json.loads(path.read_text())
+    assert result["identifiers"][0]["checked_at"] is not None
+    assert saved["biography"] == "Uus elulugu"
+    assert "_enrichment_scheme" not in saved

--- a/tests/test_reciprocal_ops.py
+++ b/tests/test_reciprocal_ops.py
@@ -41,7 +41,12 @@ def _read_person(prosopo_dir: Path, person_id: str) -> dict:
 
 
 def _run(prosopo_dir: Path, old_relations: list, new_relations: list) -> list[str]:
-    with patch("server.prosopography.reciprocal_ops.PROSOPOGRAPHY_DIR", str(prosopo_dir)):
+    def fake_save(path, content, *_args, **_kwargs):
+        Path(path).write_text(content, encoding="utf-8")
+        return {"success": True, "commit_hash": "test"}
+
+    with patch("server.prosopography.reciprocal_ops.PROSOPOGRAPHY_DIR", str(prosopo_dir)), \
+         patch("server.prosopography.reciprocal_ops.save_with_git", side_effect=fake_save):
         return sync_reciprocals(A_ID, old_relations, new_relations, A_LABEL, "testuser")
 
 


### PR DESCRIPTION
## Kokkuvõte

- suunab isikupildi, vastastikuste seoste, merge’i kõrvalkirjete ja kohaliitmise isikumuudatused git-versioonihaldusse
- lisab puuduvad `person_lock`-id ning merge’i lukkude deterministliku järjekorra
- eemaldab tehnilise `_enrichment_scheme` võtme enne rikastusväljade salvestamist
- lisab regressioonitestid pildimetaandmete git-salvestusele ja rikastuse tehnilise välja lekkimisele

## Testid

- `.venv/bin/pytest -q` — 899 passed
- `git diff --check`

Closes #160
Closes #163