### PR TITLE
Add optional privacy-scrubbed error reporting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       # VUTT_ENV=production aktiveerib startup-kontrolli vaikimisi saladuste vastu (Leid 1).
       # Sea .env failis VUTT_ENV=production tootmises; arenduses jäta määramata (dev).
       - VUTT_ENV=${VUTT_ENV:-dev}
+      # Sentry või GlitchTip DSN; tühjana on vea-aggregatsioon välja lülitatud.
+      - ERROR_REPORTING_DSN=${ERROR_REPORTING_DSN:-}
+      - ERROR_REPORTING_ENVIRONMENT=${ERROR_REPORTING_ENVIRONMENT:-}
+      - ERROR_REPORTING_RELEASE=${ERROR_REPORTING_RELEASE:-}
       - VUTT_DATA_DIR=/data
       - MEILISEARCH_URL=http://meilisearch:7700
       - MEILISEARCH_MASTER_KEY=${MEILI_MASTER_KEY:-vutt_master_key}

--- a/docs/error-reporting.md
+++ b/docs/error-reporting.md
@@ -1,0 +1,49 @@
+# Vea-aggregatsioon (Sentry / GlitchTip)
+
+Integratsioon on vaikimisi välja lülitatud ja töötab nii Sentry kui ka Sentry API-ga
+ühilduva GlitchTipiga. Tootmises on privaatsuse tõttu eelistatud self-hosted GlitchTip;
+Sentry SaaS-i kasutamine vajab eraldi andmekaitseotsust.
+
+## Konfiguratsioon
+
+Backend (`.env`, Docker Compose loeb automaatselt):
+
+```env
+ERROR_REPORTING_DSN=https://.../project-id
+ERROR_REPORTING_ENVIRONMENT=production
+ERROR_REPORTING_RELEASE=vutt-2026-07-11
+```
+
+Frontend (väärtused kompileeritakse `npm run build` ajal):
+
+```env
+VITE_SENTRY_DSN=https://.../project-id
+VITE_SENTRY_ENVIRONMENT=production
+VITE_SENTRY_RELEASE=vutt-2026-07-11
+```
+
+Frontend ja backend peaksid kasutama eri projekte/DSN-e. Tühja DSN-i korral SDK-d ei
+käivitata. Pärast backend-muutust tuleb konteiner uuesti ehitada; pärast frontend-muutust
+teha uus build ja kopeerida `dist/` serverisse.
+
+## Privaatsus
+
+Mõlemad integratsioonid kasutavad `sendDefaultPii=false` ning `beforeSend` filtrit.
+Enne saatmist eemaldatakse:
+
+- kasutaja identifikaator;
+- päringukeha, küpsised ja päised (sh autentimistoken);
+- URL-i query parameetrid;
+- breadcrumb'ide `data` sisu.
+
+Performance tracing on backendis välja lülitatud. DSN-i ei tohi lisada lähtekoodi.
+
+## Kaetus
+
+- Reacti globaalne error boundary ja React Routeri vead;
+- brauseri käsitlemata erindid ja promise rejection'id;
+- FastAPI/Starlette käsitlemata erindid;
+- Python `threading.Thread` käsitlemata erindid, sh daemon-thread'id.
+
+Health/heartbeat jälgimine on sellest eraldi: aggregatsioon teatab erindist, heartbeat
+näitab, kas taustaloop jätkab töötamist.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/search": "^6.6.0",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.37.2",
+        "@sentry/react": "^10.65.0",
         "@types/leaflet": "^1.9.21",
         "i18next": "^25.7.4",
         "i18next-browser-languagedetector": "^8.2.0",
@@ -1522,6 +1523,112 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.65.0.tgz",
+      "integrity": "sha512-XUDDsx0qxzeIlcOu1fDEqTcDl0eiOqghsgV+ReuuNP4jYjZ9kUQxE3rXWM5mlT1pBi4VaQ4FHqvQZZrRXy+oDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0",
+        "@sentry/feedback": "10.65.0",
+        "@sentry/replay": "10.65.0",
+        "@sentry/replay-canvas": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.65.0.tgz",
+      "integrity": "sha512-4J0mkfNJAGUOkpg1ZggizyftFTn9N20b+Jl87UnWsDUkNG0Ic1l/FIzMPTVxXrAnhBGu0ULO0TFWMoQ5s3QtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.15.1.tgz",
+      "integrity": "sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.65.0.tgz",
+      "integrity": "sha512-3aqtmM5NgNGo45BNaaBzi0LPQZAw//NEL4HKS5fXm12pJMa4KEkze8DEKnkTEIrGnWaOJKamecHKlnNg/Mqf/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.65.0.tgz",
+      "integrity": "sha512-ck8h7wgd3F3bYNk0v1OgohmyLBeXcKxqlfBJRtQq4k6KZUq+pXimOG7ckNguVMYjCo3PEfuG+ckKc21yqotKug==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.65.0.tgz",
+      "integrity": "sha512-fvHxpuvid0wt9/1N3itcKDyKOjqmYHw3MBSt5Pki3Iz4CL2CmgQp9ZFv/CA7UhMnEvn2Gd+Qc2UKxujZWd8FLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.65.0",
+        "@sentry/conventions": "^0.15.1",
+        "@sentry/core": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.65.0.tgz",
+      "integrity": "sha512-aW988CcQBNArbOMzOFOziipHz6uQyXSa4i5CPWsu+nhVPTJHafosi5Lv9n6NM/icDX5e23VdnX6mZd8SyJuo8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.65.0",
+        "@sentry/core": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.65.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.65.0.tgz",
+      "integrity": "sha512-A7X3RVk1Gk+knK8Ip/2EjejckNCLgCfRZo6eGlsy6qyz904KBpYmys1a0o7QkzFRjhIndjHAfcVxwt6jSLJlrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.65.0",
+        "@sentry/replay": "10.65.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.37.2",
+    "@sentry/react": "^10.65.0",
     "@types/leaflet": "^1.9.21",
     "i18next": "^25.7.4",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ tqdm>=4.66.0
 paramiko>=3.0.0
 fastapi>=0.115.0
 uvicorn>=0.30.0
+sentry-sdk[fastapi]>=2.0,<3.0
 python-multipart>=0.0.9
 PyJWT>=2.0
 bcrypt>=4.0.0

--- a/server/error_reporting.py
+++ b/server/error_reporting.py
@@ -1,0 +1,53 @@
+"""Valikuline Sentry/GlitchTip vea-aggregatsioon ilma kasutajaandmeteta."""
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+
+def scrub_event(event: dict[str, Any], _hint: dict[str, Any]) -> dict[str, Any]:
+    """Eemaldab päringukehad, päised, kasutaja ja URL-i query parameetrid."""
+    event.pop("user", None)
+    request = event.get("request")
+    if isinstance(request, dict):
+        url = request.get("url")
+        clean_request: dict[str, Any] = {}
+        if isinstance(url, str):
+            try:
+                parts = urlsplit(url)
+                clean_request["url"] = urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+            except ValueError:
+                pass
+        method = request.get("method")
+        if isinstance(method, str):
+            clean_request["method"] = method
+        event["request"] = clean_request
+
+    for breadcrumb in (event.get("breadcrumbs") or {}).get("values", []):
+        if isinstance(breadcrumb, dict):
+            breadcrumb.pop("data", None)
+    return event
+
+
+def init_error_reporting() -> bool:
+    """Käivitab SDK ainult ERROR_REPORTING_DSN olemasolul.
+
+    Sentry vaikeintegratsioonid hõlmavad FastAPI/Starlette'i ning uncaught
+    ``threading.Thread`` erindeid, sealhulgas daemon-thread'e.
+    """
+    dsn = os.getenv("ERROR_REPORTING_DSN", "").strip()
+    if not dsn:
+        return False
+
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.getenv("ERROR_REPORTING_ENVIRONMENT") or os.getenv("VUTT_ENV", "dev"),
+        release=os.getenv("ERROR_REPORTING_RELEASE") or None,
+        send_default_pii=False,
+        before_send=scrub_event,
+        traces_sample_rate=0.0,
+    )
+    return True

--- a/server/main.py
+++ b/server/main.py
@@ -4,8 +4,10 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import PORT, ALLOWED_ORIGINS, BASE_DIR, UPLOAD_ENABLED, UPLOADS_DIR, get_logger
+from .error_reporting import init_error_reporting
 from .utils import build_work_id_cache
 
+init_error_reporting()
 logger = get_logger(__name__)
 from .meilisearch_ops import metadata_watcher_loop, _keepwarm_loop, _ensure_filterable_attributes, get_meilisearch_sync_status
 from .upload_ops import start_upload_sync_loop

--- a/src/components/GlobalErrorBoundary.tsx
+++ b/src/components/GlobalErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import i18n from '../i18n';
+import { reportError } from '../services/errorReporting';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/** Püüab kinni ka väljaspool React Routerit tekkinud renderdusvead. */
+export default class GlobalErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    reportError(error, { boundary: 'global-react' });
+    console.error('Globaalne Reacti renderdusviga', error, info);
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-white rounded-lg shadow-sm border border-gray-200 p-8 text-center">
+          <div className="w-12 h-12 bg-red-50 rounded-full flex items-center justify-center mx-auto mb-4">
+            <AlertTriangle className="w-6 h-6 text-red-500" />
+          </div>
+          <h1 className="text-lg font-bold text-gray-900 mb-2">{i18n.t('common:errors.boundaryTitle')}</h1>
+          <p className="text-sm text-gray-500 mb-6">{i18n.t('common:errors.boundaryDescription')}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700"
+          >
+            <RefreshCw size={14} />
+            {i18n.t('common:errors.boundaryReload')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/RouteErrorBoundary.tsx
+++ b/src/components/RouteErrorBoundary.tsx
@@ -1,7 +1,8 @@
 import { useRouteError, isRouteErrorResponse, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, RefreshCw, Home, ChevronDown } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { reportError } from '../services/errorReporting';
 
 // React Routeri errorElement — näitab kasutajasõbralikku veateadet marsruudi vigade korral
 export default function RouteErrorBoundary() {
@@ -9,6 +10,10 @@ export default function RouteErrorBoundary() {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
   const [showDetails, setShowDetails] = useState(false);
+
+  useEffect(() => {
+    reportError(error, { boundary: 'react-router' });
+  }, [error]);
 
   // Veateade
   let errorMessage = t('errors.unknownError');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,13 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import GlobalErrorBoundary from './components/GlobalErrorBoundary';
+import { initErrorReporting } from './services/errorReporting';
 import 'leaflet/dist/leaflet.css';
 import './index.css';
 import './i18n';
+
+initErrorReporting();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -13,8 +17,10 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <Suspense fallback={<div className="h-screen flex items-center justify-center">Laadin...</div>}>
-      <App />
-    </Suspense>
+    <GlobalErrorBoundary>
+      <Suspense fallback={<div className="h-screen flex items-center justify-center">Laadin...</div>}>
+        <App />
+      </Suspense>
+    </GlobalErrorBoundary>
   </React.StrictMode>
 );

--- a/src/services/__tests__/errorReporting.test.ts
+++ b/src/services/__tests__/errorReporting.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { scrubErrorEvent } from '../errorReporting';
+
+
+describe('scrubErrorEvent', () => {
+  it('eemaldab kasutaja, päringu sisu, query ja breadcrumb data', () => {
+    const event = scrubErrorEvent({
+      user: { username: 'editor' },
+      request: {
+        url: 'https://vutt.ut.ee/api/files/save?token=secret',
+        method: 'POST',
+        headers: { authorization: 'Bearer secret' },
+        data: 'transkriptsioon',
+      },
+      breadcrumbs: [{ category: 'fetch', data: { url: '?token=secret' } }],
+    } as unknown as Parameters<typeof scrubErrorEvent>[0]);
+
+    expect(event.user).toBeUndefined();
+    expect(event.request).toEqual({ url: 'https://vutt.ut.ee/api/files/save' });
+    expect(event.breadcrumbs).toEqual([{ category: 'fetch' }]);
+  });
+});

--- a/src/services/errorReporting.ts
+++ b/src/services/errorReporting.ts
@@ -1,0 +1,46 @@
+import * as Sentry from '@sentry/react';
+
+const dsn = import.meta.env.VITE_SENTRY_DSN?.trim();
+
+/** Eemaldab sündmusest kasutajaandmed ja päringute tundliku sisu. */
+export function scrubErrorEvent(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
+  delete event.user;
+
+  if (event.request) {
+    const url = event.request.url;
+    event.request = {};
+    if (url) {
+      try {
+        const parsed = new URL(url);
+        event.request.url = `${parsed.origin}${parsed.pathname}`;
+      } catch {
+        // Vigast URL-i ei edastata.
+      }
+    }
+  }
+
+  if (event.breadcrumbs) {
+    event.breadcrumbs = event.breadcrumbs.map(({ data: _data, ...breadcrumb }) => breadcrumb);
+  }
+  return event;
+}
+
+/** Käivitab Sentry/GlitchTip integratsiooni ainult seadistatud DSN-i korral. */
+export function initErrorReporting(): void {
+  if (!dsn) return;
+  Sentry.init({
+    dsn,
+    environment: import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE,
+    release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
+    sendDefaultPii: false,
+    beforeSend: scrubErrorEvent,
+  });
+}
+
+export function reportError(error: unknown, context?: Record<string, string>): void {
+  if (!dsn) return;
+  Sentry.withScope((scope) => {
+    if (context) scope.setTags(context);
+    Sentry.captureException(error);
+  });
+}

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -1,0 +1,30 @@
+"""Vea-aggregatsiooni privaatsusfiltri testid."""
+from server.error_reporting import init_error_reporting, scrub_event
+
+
+def test_scrub_event_removes_sensitive_request_data():
+    event = {
+        "user": {"username": "editor"},
+        "request": {
+            "url": "https://vutt.ut.ee/api/files/save?token=secret",
+            "method": "POST",
+            "headers": {"authorization": "Bearer secret"},
+            "data": {"text": "transkriptsioon"},
+            "cookies": {"session": "secret"},
+        },
+        "breadcrumbs": {"values": [{"category": "fetch", "data": {"url": "?token=secret"}}]},
+    }
+
+    result = scrub_event(event, {})
+
+    assert "user" not in result
+    assert result["request"] == {
+        "url": "https://vutt.ut.ee/api/files/save",
+        "method": "POST",
+    }
+    assert "data" not in result["breadcrumbs"]["values"][0]
+
+
+def test_error_reporting_is_disabled_without_dsn(monkeypatch):
+    monkeypatch.delenv("ERROR_REPORTING_DSN", raising=False)
+    assert init_error_reporting() is False


### PR DESCRIPTION
## Kokkuvõte

- lisab globaalse React error boundary ja React Routeri vigade raporteerimise
- lisab valikulise Sentry/GlitchTip integratsiooni frontendile ja FastAPI backendile
- katab käsitlemata brauseri-, FastAPI- ja daemon-thread’ide erindid
- eemaldab enne saatmist kasutajaandmed, päringukehad, päised, küpsised, query-parameetrid ja breadcrumb `data` sisu
- hoiab integratsiooni DSN-i puudumisel täielikult väljas
- lisab Docker Compose env-muutujad ja seadistusjuhendi `docs/error-reporting.md`

## Teadlik otsus

Tootmises on privaatsuse tõttu eelistatud self-hosted GlitchTip. Sentry SaaS vajab eraldi andmekaitseotsust. See PR valmistab integratsioonikihi ette; GlitchTipi infrastruktuur ja DSN-ide seadistamine jäävad eraldi deploy-sammuks.

## Kontrollid

- `.venv/bin/pytest -q` — 901 passed
- `npm test` — 543 passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`

Refs #133