### PR TITLE
Render annotations (<annN>) in marginalia overlay and mobile view

### DIFF
--- a/src/utils/__tests__/renderVuttMarkup.test.ts
+++ b/src/utils/__tests__/renderVuttMarkup.test.ts
@@ -34,6 +34,49 @@ describe('renderVuttMarkup — VUTT-tägide renderdamine', () => {
   });
 });
 
+describe('renderVuttMarkup — annotatsioonid (<annN>)', () => {
+  it('renderdab <ann1> sisu highlight-märgendina, tägid peidetud', () => {
+    const out = renderVuttMarkup('<ann1>tekst</ann1>');
+    expect(out).not.toContain('ann1');
+    expect(out).not.toContain('&lt;ann');
+    expect(out).toContain('tekst');
+    expect(out).toMatch(/<mark[^>]*>tekst<\/mark>/);
+  });
+
+  it('annotatsioon marginaalia sees (overlay stsenaarium)', () => {
+    const out = renderVuttMarkup('<m>Vide <ann2>Picrium</ann2></m>');
+    expect(out).not.toContain('ann2');
+    expect(out).toContain('Picrium');
+    expect(out).toMatch(/<mark[^>]*>Picrium<\/mark>/);
+  });
+
+  it('mitmekohaline ID ja mitu annotatsiooni', () => {
+    const out = renderVuttMarkup('<ann12>a</ann12> ja <ann3>b</ann3>');
+    expect(out).not.toContain('ann12');
+    expect(out).not.toContain('ann3');
+    expect(out).toContain('a');
+    expect(out).toContain('b');
+  });
+
+  it('orv (paarita) ann-täg eemaldatakse, sisu säilib', () => {
+    const out = renderVuttMarkup('enne <ann5>sisu järel');
+    expect(out).not.toContain('ann5');
+    expect(out).toContain('enne sisu järel');
+  });
+
+  it('valepaar (ID-d ei klapi) ei renderdu markina, tägid eemaldatakse', () => {
+    const out = renderVuttMarkup('<ann1>tekst</ann2>');
+    expect(out).not.toContain('ann1');
+    expect(out).not.toContain('ann2');
+    expect(out).toContain('tekst');
+  });
+
+  it('ann-tägi ei saa kuritarvitada atribuutidega (XSS)', () => {
+    const out = renderVuttMarkup('<ann1 onclick="alert(1)">x</ann1>');
+    expect(out).not.toContain('onclick');
+  });
+});
+
 describe('renderVuttMarkup — XSS kaitse (Leid A)', () => {
   it('span onclick — ei teki aktiivset elementi (< on escape\'itud)', () => {
     const out = renderVuttMarkup('<span onclick="alert(1)">kliki</span>');

--- a/src/utils/renderVuttMarkup.ts
+++ b/src/utils/renderVuttMarkup.ts
@@ -6,8 +6,8 @@ export function renderVuttMarkup(text: string): string {
     .replace(/&/g, '&amp;')
     // Escape kõik < mis EI alusta lubatud VUTT-tägi (avav/sulgev) → kaitse HTML-injektsiooni
     // eest (security_review Leid A). Kasutaja sisestatud <span onclick=...>, <img onerror=...>
-    // jne muutuvad &lt;-ks; ainult VUTT-tägid (b,i,cs,m,hi,fn,pb) jäävad töötlemiseks alles.
-    .replace(/<(?!\/?(?:b|i|cs|m|hi|fn|pb)\b)/g, '&lt;')
+    // jne muutuvad &lt;-ks; ainult VUTT-tägid (b,i,cs,m,hi,fn,pb,annN) jäävad töötlemiseks alles.
+    .replace(/<(?!\/?(?:b|i|cs|m|hi|fn|pb|ann\d+)\b)/g, '&lt;')
     // <pb/> — leheküljevahetus
     .replace(/<pb\/>/g, '<span class="block text-center text-gray-300 text-xs my-1 select-none">── lk ──</span>')
     // <fn>n</fn> — joonealune viide superscriptina
@@ -19,7 +19,11 @@ export function renderVuttMarkup(text: string): string {
     // <m>...</m> — marginaalia plokk-kaardina: taane, väiksem kiri, vasak ääris.
     // Sisemine märgendus (<i>, <cs> jne) renderdub tavaliste reeglitega.
     .replace(/<m>([\s\S]*?)<\/m>/g, '<span class="block text-[0.85em] leading-snug text-stone-600 border-l-2 border-stone-300 pl-2 my-1">$1</span>')
-    .replace(/<hi>([\s\S]*?)<\/hi>/g, '<mark class="bg-yellow-100">$1</mark>');
+    .replace(/<hi>([\s\S]*?)<\/hi>/g, '<mark class="bg-yellow-100">$1</mark>')
+    // <annN>...</annN> — tekstiannotatsioon: sama visuaal mis editoris (.vutt-ann),
+    // ilma interaktiivsuseta. ID-d peavad klappima (\1); orvud/valepaarid koristab
+    // allolev tundmatute tägide strip (sisu säilib).
+    .replace(/<ann(\d+)>([\s\S]*?)<\/ann\1>/g, '<mark class="bg-yellow-100 border-b-2 border-yellow-500 rounded-sm">$2</mark>');
 
   // Eemaldame ülejäänud tundmatud VUTT-tägid; meie sisestatud HTML-elemendid (strong, em, span,
   // mark, sup) on whitelistis ja jäävad puutumatuks.


### PR DESCRIPTION
## Probleem

https://vutt.utlib.ut.ee/work/pgvzuy/8 — kui annotatsioon on marginaalia sees ja marginaalia kuvatakse külje-overlay's (suletud plokk), jäi näha toores `<ann1>tekst</ann1>`. Sama probleem mobiilivaates.

## Juurpõhjus

Overlay (`MarginaliaExtension.ts`) ja mobiilivaade renderdavad sisu `renderVuttMarkup()` kaudu, mille XSS-kaitse escape'ib kõik `<`-märgid, mis ei alusta lubatud VUTT-tägi. `ann\d+` polnud allowlist'is → tägid jäid toorena nähtavale.

## Lahendus

- `ann\d+` lisatud escape-allowlist'i
- Paaris `<annN>...</annN>` renderdub sama visuaaliga mis editoris (kollane taust + allajoon), ilma interaktiivsuseta
- Orvud ja valepaarid (ID-d ei klapi) koristab olemasolev tundmatute tägide strip — sisu säilib

**Ohutus:** ainult kuva-renderdaja muudatus. `VuttMarkupExtension`, `annUtils`, kaitsefiltrid ja dokumendi tekst puutumata — annotatsioonide positsioneerimine/salvestus ei muutu.

## Testid

6 uut testi (annotatsioon marginaalia sees, mitu annotatsiooni, orvud, valepaarid, atribuudiga XSS-katse). Kogu komplekt 549/549 läbib, typecheck puhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)