### PR TITLE
perf: Workspace lehe-vahetus — üks Meili päring, eellaadimine ja lehe algusest alustamine

### DIFF
--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -3,6 +3,9 @@ import { ZoomIn, ZoomOut, Maximize2, Download, LayoutGrid, Scissors } from 'luci
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 import { panOffsetForTop } from '../utils/imageViewerGeometry';
 
+/** Hingamisruum juhtnuppude riba ja skaneeringu ülaserva vahel. */
+const CONTROLS_GAP_PX = 8;
+
 interface ImageViewerProps {
   src: string;
   pageNum?: number;
@@ -20,6 +23,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
   const containerRef = useRef<HTMLDivElement>(null);
   const isHoveredRef = useRef(false);
   const imgRef = useRef<HTMLImageElement>(null);
+  const controlsRef = useRef<HTMLDivElement>(null);
 
   // Lehe vahetusel hoiab brauser <img>-is eelmise lehe dekodeeritud pilti kuni
   // uus on laetud. Tekst vahetub aga kohe, nii et vana skaneering jääks hetkeks
@@ -40,7 +44,12 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
       setPosition({ x: 0, y: 0 });
       return;
     }
-    setPosition({ x: 0, y: panOffsetForTop(img.clientHeight, scale, container.clientHeight) });
+    // Juhtnupud on pildi peal `absolute` ribana ja kataksid muidu skaneeringu
+    // esimesed tekstiread. Mõõdame riba päris kõrguse, et nuppude lisandumine
+    // ei jätaks arvutust vaikselt valeks.
+    const controls = controlsRef.current;
+    const topInset = controls ? controls.offsetTop + controls.offsetHeight + CONTROLS_GAP_PX : 0;
+    setPosition({ x: 0, y: panOffsetForTop(img.clientHeight, scale, container.clientHeight, topInset) });
   }, [scale]);
 
   // Iga src saab ülaserva-nihke täpselt ühe korra, et suurendamine või
@@ -220,7 +229,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
       onMouseLeave={() => { isHoveredRef.current = false; }}
     >
       {/* Controls */}
-      <div className="absolute top-4 left-4 z-10 flex gap-2">
+      <div ref={controlsRef} className="absolute top-4 left-4 z-10 flex gap-2">
         <div className="bg-black/50 backdrop-blur-md rounded-lg p-1 flex gap-1 shadow-lg border border-white/10">
           <button
             onClick={() => handleZoom(0.25)}

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { ZoomIn, ZoomOut, Maximize2, Download, LayoutGrid, Scissors } from 'lucide-react';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
+import { panOffsetForTop } from '../utils/imageViewerGeometry';
 
 interface ImageViewerProps {
   src: string;
@@ -28,11 +29,39 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
   const isImageLoading = !!src && src !== loadedSrc;
   const [showImageSpinner, setShowImageSpinner] = useState(false);
 
+  // Lehe vahetusel algab lugemine uue lehe algusest. Suurendustase jääb püsima
+  // (sama suurendus järgmisel lehel on lappamisel kasulik), aga asend viiakse
+  // ülaserva — muidu peaks kasutaja iga lehe alguses käsitsi üles kerima, sest
+  // eelmisel lehel jäi ta lehe lõppu.
+  const resetPanToTop = useCallback(() => {
+    const img = imgRef.current;
+    const container = containerRef.current;
+    if (!img || !container) {
+      setPosition({ x: 0, y: 0 });
+      return;
+    }
+    setPosition({ x: 0, y: panOffsetForTop(img.clientHeight, scale, container.clientHeight) });
+  }, [scale]);
+
+  // Iga src saab ülaserva-nihke täpselt ühe korra, et suurendamine või
+  // uuesti-renderdus ei viskaks kasutajat lehe algusesse tagasi.
+  const resetForSrcRef = useRef<string | null>(null);
+  const handleImageLoaded = useCallback(() => {
+    setLoadedSrc(src);
+    if (resetForSrcRef.current === src) return;
+    resetForSrcRef.current = src;
+    // rAF: paigutus peab olema arvutatud, enne kui clientHeight't loeme.
+    requestAnimationFrame(resetPanToTop);
+  }, [src, resetPanToTop]);
+
+  const handleImageLoadedRef = useRef(handleImageLoaded);
+  handleImageLoadedRef.current = handleImageLoaded;
+
   // Vahemälust (nt eellaetud kõrvalleht) tulev pilt võib olla valmis juba enne
   // kui React onLoad-i külge jõuab panna — siis onLoad ei käivituks kunagi.
   useEffect(() => {
     const el = imgRef.current;
-    if (el?.complete && el.naturalWidth > 0) setLoadedSrc(src);
+    if (el?.complete && el.naturalWidth > 0) handleImageLoadedRef.current();
   }, [src]);
 
   // Väike viivitus: eellaetud pilt jõuab kohale enne, nii et spinner ei vilgu
@@ -277,7 +306,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
             }`}
             style={{ maxHeight: '85vh', maxWidth: '85vw' }}
             onDragStart={preventDrag}
-            onLoad={() => setLoadedSrc(src)}
+            onLoad={handleImageLoaded}
             // Vea korral lõpetame ootamise — muidu jääks spinner igaveseks
             // keerlema. Katkise pildi käsitleb <img> ise (alt-tekst).
             onError={() => setLoadedSrc(src)}

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -18,6 +18,33 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
   const isHoveredRef = useRef(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  // Lehe vahetusel hoiab brauser <img>-is eelmise lehe dekodeeritud pilti kuni
+  // uus on laetud. Tekst vahetub aga kohe, nii et vana skaneering jääks hetkeks
+  // uue teksti kõrvale — segadusseajav. Seetõttu peidame pildi laadimise ajaks
+  // ja näitame spinnerit.
+  const [loadedSrc, setLoadedSrc] = useState<string | null>(null);
+  const isImageLoading = !!src && src !== loadedSrc;
+  const [showImageSpinner, setShowImageSpinner] = useState(false);
+
+  // Vahemälust (nt eellaetud kõrvalleht) tulev pilt võib olla valmis juba enne
+  // kui React onLoad-i külge jõuab panna — siis onLoad ei käivituks kunagi.
+  useEffect(() => {
+    const el = imgRef.current;
+    if (el?.complete && el.naturalWidth > 0) setLoadedSrc(src);
+  }, [src]);
+
+  // Väike viivitus: eellaetud pilt jõuab kohale enne, nii et spinner ei vilgu
+  // ühe kaadri jagu iga pöörde peal.
+  useEffect(() => {
+    if (!isImageLoading) {
+      setShowImageSpinner(false);
+      return;
+    }
+    const timer = setTimeout(() => setShowImageSpinner(true), 150);
+    return () => clearTimeout(timer);
+  }, [isImageLoading]);
 
   // Puuteekraani pinch-to-zoom ja drag tugi
   const touchStateRef = useRef<{
@@ -242,14 +269,27 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, onGridView, onN
           className="will-change-transform"
         >
           <img
+            ref={imgRef}
             src={src}
             alt="Faksiimile"
-            className="max-w-none shadow-2xl sepia-[0.3] pointer-events-none"
+            className={`max-w-none shadow-2xl sepia-[0.3] pointer-events-none transition-opacity duration-150 ${
+              isImageLoading ? 'opacity-0' : 'opacity-100'
+            }`}
             style={{ maxHeight: '85vh', maxWidth: '85vw' }}
             onDragStart={preventDrag}
+            onLoad={() => setLoadedSrc(src)}
+            // Vea korral lõpetame ootamise — muidu jääks spinner igaveseks
+            // keerlema. Katkise pildi käsitleb <img> ise (alt-tekst).
+            onError={() => setLoadedSrc(src)}
           />
         </div>
       </div>
+
+      {showImageSpinner && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-white/70" />
+        </div>
+      )}
 
       <div className="absolute bottom-4 right-4 text-white/50 text-xs pointer-events-none bg-black/20 px-2 py-1 rounded">
         {Math.round(scale * 100)}%

--- a/src/components/editor/__tests__/editorAnnotations.test.ts
+++ b/src/components/editor/__tests__/editorAnnotations.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { EditorState, Transaction } from '@codemirror/state';
+import { isPageSwapUpdate, pageSwapAnnotation } from '../editorAnnotations';
+
+/**
+ * Regressioonitest #185-st tulnud vea vastu: lehe vahetusel asendatakse kogu
+ * dokument ühe dispatch'iga, mis on `docChanged`. Ilma märgistuseta luges
+ * updateListener selle kasutaja muudatuseks ja lahkumisel küsiti salvestamist,
+ * kuigi kasutaja polnud midagi teinud.
+ */
+describe('isPageSwapUpdate', () => {
+  const state = EditorState.create({ doc: 'vana leht' });
+
+  const pageSwap = () =>
+    state.update({
+      changes: { from: 0, to: state.doc.length, insert: 'uus leht' },
+      annotations: pageSwapAnnotation.of(true),
+    });
+
+  it('tunneb lehe vahetuse tehingu ära', () => {
+    expect(isPageSwapUpdate([pageSwap()])).toBe(true);
+  });
+
+  it('kasutaja tippimist ei loeta lehe vahetuseks', () => {
+    const typing = state.update({
+      changes: { from: 0, insert: 'x' },
+      annotations: Transaction.userEvent.of('input.type'),
+    });
+    expect(isPageSwapUpdate([typing])).toBe(false);
+  });
+
+  it('märgistuseta programmaatiline muudatus ei ole lehe vahetus', () => {
+    const plain = state.update({ changes: { from: 0, insert: 'x' } });
+    expect(isPageSwapUpdate([plain])).toBe(false);
+  });
+
+  it('tühi tehingute nimekiri ei ole lehe vahetus', () => {
+    expect(isPageSwapUpdate([])).toBe(false);
+  });
+
+  it('lehe vahetuse tehing EI kanna userEvent märgistust', () => {
+    // Kriitiline: marginaliaProtectionFilter ja vuttAutoSanitizer tegutsevad
+    // ainult userEvent-tehingutel. Kui lehe vahetus saaks userEvent'i, hakkaks
+    // sanitiseerija kettalt laetud teksti muutma.
+    expect(pageSwap().annotation(Transaction.userEvent)).toBeUndefined();
+  });
+});

--- a/src/components/editor/editorAnnotations.ts
+++ b/src/components/editor/editorAnnotations.ts
@@ -1,0 +1,30 @@
+import { Annotation, type Transaction } from '@codemirror/state';
+
+/**
+ * Märgistab tehingu, mis vahetab editori sisu lehe vahetusel (programmaatiline
+ * dokumendi asendus), mitte kasutaja muudatuse.
+ *
+ * **Miks vaja:** `useCodeMirrorLifecycle` updateListener seab iga `docChanged`
+ * peale `isDirty = true`. Lehe vahetusel asendab `useEditorState` kogu
+ * dokumendi ühe dispatch'iga — see on samuti `docChanged` ja märgiks lehe
+ * ekslikult muudetuks, mille peale küsitakse lahkumisel salvestamist, kuigi
+ * kasutaja pole midagi teinud.
+ *
+ * Varem seda ei juhtunud ainult seetõttu, et lehe vahetus monteeris terve
+ * editori maha. Alates #185-st jääb editor püsima, seega peab programmaatiline
+ * asendus olema selgelt eristatav.
+ *
+ * NB: see ei ole `Transaction.userEvent`. `marginaliaProtectionFilter`
+ * (MarginaliaExtension.ts) ja `vuttAutoSanitizer` (VuttMarkupExtension.ts)
+ * mõlemad tegutsevad ainult userEvent-tehingutel, seega jäävad nad lehe
+ * vahetuse asendusest puutumata — nagu peabki.
+ */
+export const pageSwapAnnotation = Annotation.define<boolean>();
+
+/**
+ * Kas see update pärineb lehe vahetusest? Kasutab `useCodeMirrorLifecycle`
+ * updateListener, et mitte märkida lehte muudetuks.
+ */
+export function isPageSwapUpdate(transactions: readonly Transaction[]): boolean {
+  return transactions.some(tr => tr.annotation(pageSwapAnnotation) === true);
+}

--- a/src/components/editor/useCodeMirrorLifecycle.ts
+++ b/src/components/editor/useCodeMirrorLifecycle.ts
@@ -9,6 +9,7 @@ import { closeAllMarginalia, marginaliaExtension, marginaliaField } from './Marg
 import type { MarginaliaMode } from './MarginaliaExtension';
 import { vuttTheme } from './VuttTheme';
 import { createVuttSearchPanel } from './VuttSearchPanel';
+import { isPageSwapUpdate } from './editorAnnotations';
 
 interface UseCodeMirrorLifecycleParams {
   page: Page;
@@ -90,7 +91,10 @@ export function useCodeMirrorLifecycle({
           ),
           vuttTheme,
           EditorView.updateListener.of((update) => {
-            if (update.docChanged) setIsDirty(true);
+            // Lehe vahetuse programmaatiline dokumendi-asendus ei ole kasutaja
+            // muudatus — muidu küsitaks lahkumisel salvestamist ilma et kasutaja
+            // oleks midagi teinud (vt editorAnnotations.ts).
+            if (update.docChanged && !isPageSwapUpdate(update.transactions)) setIsDirty(true);
             const count = update.state.field(marginaliaField).blocks.length;
             setMarginaliaCount(prev => (prev === count ? prev : count));
           }),

--- a/src/components/editor/useEditorState.ts
+++ b/src/components/editor/useEditorState.ts
@@ -3,6 +3,7 @@ import type { EditorView } from '@codemirror/view';
 import type { Annotation, Page, TextAnnotation } from '../../types';
 import type { LinkedEntity } from '../../types/LinkedEntity';
 import { closeAllMarginalia } from './MarginaliaExtension';
+import { pageSwapAnnotation } from './editorAnnotations';
 import type { EditorSavedState } from './useEditorSave';
 
 interface UseEditorStateParams {
@@ -54,6 +55,11 @@ export function useEditorState({ page, viewRef, onUnsavedChanges }: UseEditorSta
     setPageTags(page.page_tags || []);
     setSavedState({ status: page.status, comments: page.comments, page_tags: page.page_tags || [], text_annotations: page.text_annotations || [] });
     setIsDirty(false);
+    // Salvestamata kommentaarimustand kuulub eelmisele lehele — muidu jääks
+    // hoiatus "salvestamata muudatused" uuel lehel ekslikult püsima.
+    setAnnotationDraftDirty(false);
+    // Sama põhjus: eelmise lehe salvestusviga ei ole uuel lehel enam asjakohane.
+    setSaveError(null);
 
     const view = viewRef.current;
     if (view) {
@@ -64,6 +70,9 @@ export function useEditorState({ page, viewRef, onUnsavedChanges }: UseEditorSta
           // Lehevahetusel tühjendame openMarks — vana positsioon kukuks nulli ja
           // avaks võõra ploki uuel lehel
           effects: closeAllMarginalia.of(null),
+          // Programmaatiline asendus, mitte kasutaja muudatus — updateListener
+          // ei tohi seda dirty-ks lugeda (vt editorAnnotations.ts).
+          annotations: pageSwapAnnotation.of(true),
         });
       }
     }

--- a/src/components/editor/useEditorState.ts
+++ b/src/components/editor/useEditorState.ts
@@ -67,6 +67,9 @@ export function useEditorState({ page, viewRef, onUnsavedChanges }: UseEditorSta
       if (currentText !== page.text_content) {
         view.dispatch({
           changes: { from: 0, to: currentText.length, insert: page.text_content || '' },
+          // Uus leht algab algusest — muidu jääks kursor eelmise lehe pealt
+          // suvalisse kohta uues tekstis.
+          selection: { anchor: 0 },
           // Lehevahetusel tühjendame openMarks — vana positsioon kukuks nulli ja
           // avaks võõra ploki uuel lehel
           effects: closeAllMarginalia.of(null),
@@ -75,6 +78,11 @@ export function useEditorState({ page, viewRef, onUnsavedChanges }: UseEditorSta
           annotations: pageSwapAnnotation.of(true),
         });
       }
+      // Kerimine lehe algusesse. Tingimusest väljaspool, sest kaks järjestikust
+      // lehte võivad olla identse tekstiga (nt tühjad) — ka siis peab uus leht
+      // algama ülevalt. Alates #185-st ei monteerita editorit lehe vahetusel
+      // maha, seega kerimispositsioon jääks muidu eelmise lehe lõppu.
+      view.scrollDOM.scrollTop = 0;
     }
   }, [page, viewRef]);
 

--- a/src/hooks/__tests__/adjacentPageTargets.test.ts
+++ b/src/hooks/__tests__/adjacentPageTargets.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { adjacentPageTargets } from '../useAdjacentPagePrefetch';
+
+describe('adjacentPageTargets', () => {
+  it('eellaeb järgmise enne eelmist', () => {
+    expect(adjacentPageTargets(5, 100)).toEqual([6, 4]);
+  });
+
+  it('esimesel lehel ainult järgmine', () => {
+    expect(adjacentPageTargets(1, 100)).toEqual([2]);
+  });
+
+  it('viimasel lehel ainult eelmine', () => {
+    expect(adjacentPageTargets(100, 100)).toEqual([99]);
+  });
+
+  it('üheleheline teos ei eellaadi midagi', () => {
+    expect(adjacentPageTargets(1, 1)).toEqual([]);
+  });
+
+  it('teadmata lehearvu korral piirab ainult alt', () => {
+    expect(adjacentPageTargets(1, undefined)).toEqual([2]);
+    expect(adjacentPageTargets(7, undefined)).toEqual([8, 6]);
+  });
+
+  it('lehearv 0 (veel indekseerimata) käitub nagu teadmata', () => {
+    expect(adjacentPageTargets(3, 0)).toEqual([4, 2]);
+  });
+
+  it('vigane lehenumber ei tekita päringuid', () => {
+    expect(adjacentPageTargets(0, 100)).toEqual([]);
+    expect(adjacentPageTargets(-2, 100)).toEqual([]);
+    expect(adjacentPageTargets(NaN, 100)).toEqual([]);
+  });
+});

--- a/src/hooks/useAdjacentPagePrefetch.ts
+++ b/src/hooks/useAdjacentPagePrefetch.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from 'react';
+import type { Index } from 'meilisearch';
+import { getPage } from '../services/pageService';
+
+interface UseAdjacentPagePrefetchParams {
+  index: Index | null | undefined;
+  workId: string | undefined;
+  currentPageNum: number;
+  pageCount: number | undefined;
+  /** Lisab piiratud teose pildi-URL-ile HMAC tokeni. */
+  appendImageToken: (url: string) => string;
+  /** Eellaadimine ainult siis, kui praegune leht on kohal ja viga puudub. */
+  enabled: boolean;
+}
+
+/**
+ * Eellaeb kõrvallehtede skaneeringud brauseri vahemällu, et järjest lappamine
+ * oleks hetkeline.
+ *
+ * **Ainult pilt, mitte lehe kirje.** Meili päring lehe kohta on niigi ~10 ms,
+ * skaneering aga sadu kilobaite — kogu tajutav viivitus tuleb pildist. Teksti
+ * teadlikult ei cache'ita: vahemälust serveeritud vananenud transkriptsioon
+ * oleks transkribeerimistööriistas korrektsusviga, mitte jõudlusvõit.
+ *
+ * Pildid on pika cache-elueaga (image server `max-age=86400`, nginx 30 p), seega
+ * eellaetud pilt on tegeliku pöörde ajaks brauseri vahemälus.
+ */
+export function useAdjacentPagePrefetch({
+  index,
+  workId,
+  currentPageNum,
+  pageCount,
+  appendImageToken,
+  enabled,
+}: UseAdjacentPagePrefetchParams): void {
+  // Juba soojendatud URL-id — väldib sama pildi korduvat päringut edasi-tagasi
+  // lappamisel. Puhastatakse teose vahetusel.
+  const warmedRef = useRef<{ workId: string | undefined; urls: Set<string> }>({
+    workId: undefined,
+    urls: new Set(),
+  });
+
+  useEffect(() => {
+    if (!enabled || !index || !workId) return;
+    if (shouldSkipPrefetch()) return;
+
+    if (warmedRef.current.workId !== workId) {
+      warmedRef.current = { workId, urls: new Set() };
+    }
+
+    const targets = adjacentPageTargets(currentPageNum, pageCount);
+    if (targets.length === 0) return;
+
+    let cancelled = false;
+
+    const warm = async () => {
+      for (const pageNum of targets) {
+        if (cancelled) return;
+        try {
+          const pageData = await getPage(index, workId, pageNum);
+          if (cancelled || !pageData?.image_url) continue;
+
+          const url = appendImageToken(pageData.image_url);
+          if (warmedRef.current.urls.has(url)) continue;
+          warmedRef.current.urls.add(url);
+
+          // `new Image()` tõmbab pildi vahemällu ilma DOM-i puutumata. Vead
+          // ignoreeritakse vaikselt — eellaadimine ei tohi kunagi UI-d mõjutada.
+          const img = new Image();
+          img.decoding = 'async';
+          img.src = url;
+        } catch {
+          /* eellaadimine on parim-pingutus */
+        }
+      }
+    };
+
+    // Ootame jõudeoleku ära, et eellaadimine ei võistleks praeguse lehe
+    // renderdusega ega selle pildiga.
+    const idle = scheduleWhenIdle(warm);
+
+    return () => {
+      // `cancelled` peatab uute päringute alustamise. Juba lennus olevat pilti
+      // ei katkestata teadlikult: see on suure tõenäosusega just see leht, kuhu
+      // kasutaja liikus, ja `img.src = ''` võib mõnes brauseris hoopis
+      // dokumendi-URL-i pärida.
+      cancelled = true;
+      idle.cancel();
+    };
+  }, [index, workId, currentPageNum, pageCount, appendImageToken, enabled]);
+}
+
+/**
+ * Eellaetavad lehenumbrid, järjekorras. Edasi enne tagasi — järjest lappamine on
+ * tavalisem kui tagasi kerimine. Piirid: leht 1 ja teose viimane leht.
+ *
+ * `pageCount === undefined` tähendab "veel teadmata" (teose metaandmed pole
+ * jõudnud laadida) — siis piirame ainult alt, et esimene pööre ei jääks ootama.
+ */
+export function adjacentPageTargets(currentPageNum: number, pageCount: number | undefined): number[] {
+  if (!Number.isFinite(currentPageNum) || currentPageNum < 1) return [];
+  return [currentPageNum + 1, currentPageNum - 1].filter(
+    n => n >= 1 && (pageCount === undefined || pageCount <= 0 || n <= pageCount),
+  );
+}
+
+/** Andmesäästurežiim või aeglane ühendus — ära raiska kasutaja mahtu. */
+function shouldSkipPrefetch(): boolean {
+  const conn = (navigator as any)?.connection;
+  if (!conn) return false;
+  if (conn.saveData) return true;
+  return ['slow-2g', '2g'].includes(conn.effectiveType);
+}
+
+function scheduleWhenIdle(fn: () => void): { cancel: () => void } {
+  const ric = (window as any).requestIdleCallback;
+  if (typeof ric === 'function') {
+    const id = ric(fn, { timeout: 2000 });
+    return { cancel: () => (window as any).cancelIdleCallback?.(id) };
+  }
+  const id = window.setTimeout(fn, 300);
+  return { cancel: () => window.clearTimeout(id) };
+}

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { MeiliSearch } from 'meilisearch';
 import { useUnsavedChangesGuard } from '../hooks/useUnsavedChangesGuard';
+import { useAdjacentPagePrefetch } from '../hooks/useAdjacentPagePrefetch';
 import { getPage, savePage } from '../services/pageService';
 import { getWorkMetadata, getWorkPageImages } from '../services/workService';
 import type { Page, Work } from '../types';
@@ -339,6 +340,17 @@ const Workspace: React.FC = () => {
     } catch { /* ignore */ }
     return appendImageToken(page.image_url);
   }, [appendImageToken, page?.image_url, page?.page_number, workId]);
+
+  // Kõrvallehtede skaneeringute eellaadimine (#186) — peab olema pärast
+  // appendImageToken'i definitsiooni.
+  useAdjacentPagePrefetch({
+    index: effectiveIndex,
+    workId,
+    currentPageNum,
+    pageCount: work?.page_count,
+    appendImageToken,
+    enabled: !loading && !error && !!page,
+  });
 
   const handleOpenGridView = useCallback(async () => {
     if (!work || !effectiveIndex) return;

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -42,6 +42,11 @@ const Workspace: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const [loading, setLoading] = useState(true);
+  // Lehe laadimine sama teose sees — ei võta editorit maha, näitab ainult riba.
+  const [pageLoading, setPageLoading] = useState(false);
+  // Viimati laetud teos. Eristab "teose vahetus" (spinner) ja "lehe vahetus
+  // samas teoses" (raam jääb püsima).
+  const loadedWorkIdRef = useRef<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [errorRequiresLogin, setErrorRequiresLogin] = useState(false);
   const [page, setPage] = useState<Page | null>(null);
@@ -162,14 +167,17 @@ const Workspace: React.FC = () => {
         setLoading(false);
         return;
       }
-      setLoading(true);
+      // Spinner ainult teose vahetusel või esmalaadimisel. Sama teose sees lehte
+      // vahetades jääb raam püsima — TextEditor sünkroniseerib sisu ise
+      // (useEditorState `page`-effect), muidu monteeriks CodeMirror end iga
+      // pöörde peal maha ja uuesti.
+      const isWorkSwitch = loadedWorkIdRef.current !== workId;
+      if (isWorkSwitch) setLoading(true);
+      setPageLoading(true);
       setError(null);
       setErrorRequiresLogin(false);
       try {
-        let [pageData, workData] = await Promise.all([
-          getPage(effectiveIndex, workId, currentPageNum),
-          getWorkMetadata(effectiveIndex, workId)
-        ]);
+        const pageData = await getPage(effectiveIndex, workId, currentPageNum);
 
         // Shareable fallback: teos on piiratud kollektsioonis aga võib olla jagatud.
         // Saadame ka Authorization päise — kui Meili indeks on (veel/taas) anonüümses
@@ -208,23 +216,7 @@ const Workspace: React.FC = () => {
         } else {
           setPage(pageData);
           setCurrentStatus(pageData.status);
-          if (workData) {
-            let freshWorkData = workData;
-            if (authToken) {
-              try {
-                const metaResponse = await fetch(`${FILE_API_URL}/get-work-metadata`, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
-                  body: JSON.stringify({ work_id: workId, original_path: pageData.original_path }),
-                });
-                const metaData = await metaResponse.json();
-                if (metaData.status === 'success' && metaData.metadata && typeof metaData.metadata.shareable === 'boolean') {
-                  freshWorkData = { ...workData, shareable: metaData.metadata.shareable };
-                }
-              } catch { /* Meili väärtus jääb fallbackiks */ }
-            }
-            setWork(freshWorkData);
-          }
+          loadedWorkIdRef.current = workId;
           // Redirect logic: If we asked for page 1, but got page 5 (because book starts there),
           // update the URL to reflect reality.
           if (pageData.page_number !== currentPageNum) {
@@ -236,10 +228,55 @@ const Workspace: React.FC = () => {
         setError(e.message || "Viga andmete laadimisel. Palun kontrolli Meilisearchi ühendust.");
       } finally {
         setLoading(false);
+        setPageLoading(false);
       }
     };
     loadData();
   }, [effectiveIndex, workId, currentPageNum, navigate, viewerToken, authToken, sessionExpired, user, authInitializing, t]);
+
+  // Teose metaandmed — sõltuvad ainult teosest, mitte lehenumbrist. Eraldi
+  // effect, et lehe vahetus samas teoses ei tooks kaasa uut Meili päringut ega
+  // /get-work-metadata edasi-tagasi-käiku (#185). `effectiveIndex` on deps-listis,
+  // sest piiratud teose puhul saab metaandmed kätte alles viewer-tokeniga.
+  useEffect(() => {
+    if (!effectiveIndex) return;
+    if (authInitializing) return;
+    if (!workId) return;
+    let cancelled = false;
+
+    // Teost vahetades ei tohi eelmise teose metaandmed hetkeks alles jääda —
+    // lehe effect võib lõpetada enne seda ja renderdaks vale pealkirja/lehearvu.
+    setWork(prev => (prev && prev.work_id !== workId ? undefined : prev));
+
+    const loadWork = async () => {
+      try {
+        const workData = await getWorkMetadata(effectiveIndex, workId);
+        if (cancelled || !workData) return;
+        setWork(workData);
+
+        // `shareable` on autoriteetne ainult failisüsteemist — Meili väärtus võib
+        // olla vananenud. Endpoint nõuab editor-rolli, seega ülejäänutel jääb
+        // kehtima Meili väärtus. Ei blokeeri lehe renderdust.
+        if (!authToken) return;
+        const metaResponse = await fetch(`${FILE_API_URL}/get-work-metadata`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${authToken}` },
+          // original_path on endpointis ainult varuvariant (work_id on esmane) ja
+          // pärineb samast Meili väljast mis lehe oma (originaal_kataloog).
+          body: JSON.stringify({ work_id: workId, original_path: workData.catalog_name }),
+        });
+        const metaData = await metaResponse.json();
+        if (cancelled) return;
+        if (metaData.status === 'success' && metaData.metadata && typeof metaData.metadata.shareable === 'boolean') {
+          const { shareable } = metaData.metadata;
+          setWork(prev => (prev ? { ...prev, shareable } : prev));
+        }
+      } catch { /* Meili väärtus jääb fallbackiks */ }
+    };
+
+    loadWork();
+    return () => { cancelled = true; };
+  }, [effectiveIndex, workId, authToken, authInitializing]);
 
   // Metaandmete modaali avamine
   const openMetaModal = () => {
@@ -514,6 +551,16 @@ const Workspace: React.FC = () => {
     <div className="workspace-container h-screen flex flex-col bg-gray-100 overflow-hidden">
       {/* COinS for Zotero - peidetud span bibliograafiliste andmetega */}
       {page && <span className="Z3988" title={generateCoins() || ''} />}
+
+      {/* Lehe vahetus samas teoses ei võta editorit maha (vt loadData) — õhuke
+          riba annab tagasiside, ilma et raam vahepeal kaoks. */}
+      {pageLoading && (
+        <div
+          className="fixed top-0 left-0 right-0 h-0.5 bg-primary-500/70 animate-pulse z-[60]"
+          role="status"
+          aria-label={t('common:labels.loading')}
+        />
+      )}
 
       {/* Top Navigation Bar (desktop only) */}
       <div className="hidden md:flex h-12 bg-white border-b border-gray-200 items-center justify-between px-4 shrink-0 shadow-sm relative z-50">

--- a/src/utils/__tests__/imageViewerGeometry.test.ts
+++ b/src/utils/__tests__/imageViewerGeometry.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { panOffsetForTop } from '../imageViewerGeometry';
+
+describe('panOffsetForTop', () => {
+  it('mahtuv pilt jääb tsentreerituks', () => {
+    // 600px pilt 800px konteineris, suurendus 1 → ülejääki pole
+    expect(panOffsetForTop(600, 1, 800)).toBe(0);
+  });
+
+  it('täpselt mahtuv pilt jääb tsentreerituks', () => {
+    expect(panOffsetForTop(800, 1, 800)).toBe(0);
+  });
+
+  it('suurendatud pilt nihutatakse poole ülejäägi võrra alla', () => {
+    // 800px pilt suurendusega 2 = 1600px; konteiner 800px → ülejääk 800px.
+    // Tsentreerituna ulatub pilt -400..1200, ülaserva toomiseks nihe +400.
+    expect(panOffsetForTop(800, 2, 800)).toBe(400);
+  });
+
+  it('murdosaline suurendus', () => {
+    expect(panOffsetForTop(1000, 1.5, 900)).toBe(300);
+  });
+
+  it('pikk pilt ilma suurenduseta vajab samuti nihet', () => {
+    // Skaneeringud on sageli konteinerist kõrgemad ka suurenduseta
+    expect(panOffsetForTop(2000, 1, 800)).toBe(600);
+  });
+
+  it('nullmõõtmed ei tekita NaN-i', () => {
+    expect(panOffsetForTop(0, 1, 0)).toBe(0);
+    expect(panOffsetForTop(0, 1, 800)).toBe(0);
+  });
+
+  it('mõõtmata element (NaN) annab tsentreeritud asendi', () => {
+    expect(panOffsetForTop(NaN, 1, 800)).toBe(0);
+  });
+});

--- a/src/utils/__tests__/imageViewerGeometry.test.ts
+++ b/src/utils/__tests__/imageViewerGeometry.test.ts
@@ -34,4 +34,28 @@ describe('panOffsetForTop', () => {
   it('mõõtmata element (NaN) annab tsentreeritud asendi', () => {
     expect(panOffsetForTop(NaN, 1, 800)).toBe(0);
   });
+
+  describe('topInset — varu pildi peal olevatele juhtnuppudele', () => {
+    it('nihutab suurendatud pilti veel varu võrra allapoole', () => {
+      // Ilma varuta 400; 62px riba alt algamiseks 462
+      expect(panOffsetForTop(800, 2, 800, 62)).toBe(462);
+    });
+
+    it('täpselt mahtuv pilt nihkub varu võrra, et ülaserv jääks riba alla', () => {
+      expect(panOffsetForTop(800, 1, 800, 62)).toBe(62);
+    });
+
+    it('väike pilt jääb tsentreerituks — varu ei tohi teda alla lükata', () => {
+      // Pilt on poole konteineri kõrgusest: ülaserv on niigi ribast allpool
+      expect(panOffsetForTop(400, 1, 800, 62)).toBe(0);
+    });
+
+    it('varu ei muuda tulemust negatiivseks', () => {
+      expect(panOffsetForTop(100, 1, 800, 20)).toBe(0);
+    });
+
+    it('mõõtmata riba (NaN) käitub nagu varu puuduks', () => {
+      expect(panOffsetForTop(800, 2, 800, NaN)).toBe(400);
+    });
+  });
 });

--- a/src/utils/imageViewerGeometry.ts
+++ b/src/utils/imageViewerGeometry.ts
@@ -9,20 +9,31 @@
  */
 
 /**
- * Vertikaalne nihe, mis toob skaleeritud pildi ülaserva konteineri ülaserva.
+ * Vertikaalne nihe, mis toob skaleeritud pildi ülaserva nähtavale.
  *
  * Tsentreeritud pilt ulatub `C/2 - H*s/2` kuni `C/2 + H*s/2`. Ülaserva
  * nulli viimiseks on vaja `ty = (H*s - C) / 2`.
  *
- * Kui pilt mahub konteinerisse tervikuna (ülejääk ≤ 0), on õige asend
- * tsentreeritud ehk 0 — ülaserva "kleepimine" jätaks alla tühja ala.
+ * `topInset` nihutab veel allapoole, et pildi ülaserv ei jääks pealkattuvate
+ * juhtnuppude (suum / kärpimine / allalaadimine) alla — need on pildi peal
+ * `absolute` ribana ja kataksid muidu skaneeringu esimesed tekstiread.
+ *
+ * Kunagi ei nihutata tsentreeritud asendist ülespoole (tulem ≥ 0): väike pilt,
+ * mis mahub tervikuna ära, jääb keskele, mitte ei kleepu ülaserva tühja alaga.
  *
  * @param imageHeight Pildi paigutuslik kõrgus (skaleerimata, `clientHeight`)
  * @param scale Praegune suurendustegur
  * @param containerHeight Nähtava ala kõrgus
+ * @param topInset Ülaserva varu juhtnuppude jaoks (px)
  */
-export function panOffsetForTop(imageHeight: number, scale: number, containerHeight: number): number {
+export function panOffsetForTop(
+  imageHeight: number,
+  scale: number,
+  containerHeight: number,
+  topInset = 0,
+): number {
   const overflowY = imageHeight * scale - containerHeight;
-  if (!Number.isFinite(overflowY) || overflowY <= 0) return 0;
-  return overflowY / 2;
+  const inset = Number.isFinite(topInset) ? topInset : 0;
+  if (!Number.isFinite(overflowY)) return 0;
+  return Math.max(0, overflowY / 2 + inset);
 }

--- a/src/utils/imageViewerGeometry.ts
+++ b/src/utils/imageViewerGeometry.ts
@@ -1,0 +1,28 @@
+/**
+ * Pildivaaturi panimise geomeetria.
+ *
+ * Vaatur kasutab `transform: translate(tx, ty) scale(s)` koos
+ * `transformOrigin: center center`-iga ja pilt on konteineris flex-iga
+ * tsentreeritud. CSS-i transform-loend rakendub paremalt vasakule: kõigepealt
+ * skaleeritakse element ümber oma keskme, seejärel nihutatakse. Seega on
+ * `translate` **skaleerimata** konteineri pikslites — mitte pildi omades.
+ */
+
+/**
+ * Vertikaalne nihe, mis toob skaleeritud pildi ülaserva konteineri ülaserva.
+ *
+ * Tsentreeritud pilt ulatub `C/2 - H*s/2` kuni `C/2 + H*s/2`. Ülaserva
+ * nulli viimiseks on vaja `ty = (H*s - C) / 2`.
+ *
+ * Kui pilt mahub konteinerisse tervikuna (ülejääk ≤ 0), on õige asend
+ * tsentreeritud ehk 0 — ülaserva "kleepimine" jätaks alla tühja ala.
+ *
+ * @param imageHeight Pildi paigutuslik kõrgus (skaleerimata, `clientHeight`)
+ * @param scale Praegune suurendustegur
+ * @param containerHeight Nähtava ala kõrgus
+ */
+export function panOffsetForTop(imageHeight: number, scale: number, containerHeight: number): number {
+  const overflowY = imageHeight * scale - containerHeight;
+  if (!Number.isFinite(overflowY) || overflowY <= 0) return 0;
+  return overflowY / 2;
+}


### PR DESCRIPTION
Lehe-vahetuse jõudlus Workspace'is: kaks issue'd ja neli neist välja tulnud lihvi.

## #185 — teose metaandmed lahus lehe laadimisest

Lehepööre laadis seni terve teose konteksti uuesti: `getWorkMetadata` (täismahus
Meili päring ~25 väljaga) ja sellele järgnenud `/get-work-metadata` POST jooksid
iga pöörde peal, kuigi teose metaandmed on kõigil sama teose lehtedel identsed.
Põhjus oli `currentPageNum` effecti dep-listis.

`shareable` värskenduse sai teose-tasandile viia, kuna see polnud tegelikult
lehest sõltuv: endpoint eelistab `find_directory_by_id(work_id)`-t ja
`original_path` on ainult varuvariant, mis pärineb samast Meili väljast
(`originaal_kataloog`) mis lehe oma.

Spinner tuleb nüüd ainult teose vahetusel. Sama teose sees jääb raam püsima —
see oli ohutu, sest `useEditorState` sisaldas juba lehe vahetuse
sünkroniseerimist (CM6 dokumendi asendus + marginaalia oleku tühjendus); varem
lihtsalt maskeeris remount selle tee.

**Tulem: lehepööre teeb ühe Meili päringu senise kahe päringu + HTTP POST-i asemel.**

## #186 — kõrvallehtede eellaadimine

`useAdjacentPagePrefetch` soojendab järgmise ja eelmise lehe skaneeringu
brauseri vahemällu, `requestIdleCallback`-i taga.

Teadlik kitsendus: eellaetakse ainult pilt, mitte lehe kirje. Meili päring on
~10 ms, skaneering sadu kilobaite. Teksti cache'imine tooks riski, et
transkribeerimistööriist serveerib vananenud teksti — korrektsusrisk, mitte
jõudlusvõit. Vt kommentaari #186 all.

## Neli parandust, mis tulid remounti kadumisest

Kuna editorit ja pildivaaturit enam lehe vahetusel maha ei monteerita, tulid
välja kohad, kus olek vaikselt remountiga lähtestus:

1. **Vale "salvestamata muudatused" hoiatus.** `updateListener` seab iga
   `docChanged` peale `isDirty = true`, aga lehe vahetus asendab kogu dokumendi
   — see on samuti `docChanged`. Lahendus: `pageSwapAnnotation` märgistab
   programmaatilise asenduse. Märgistus EI ole `Transaction.userEvent`, sest
   `marginaliaProtectionFilter` ja `vuttAutoSanitizer` tegutsevad ainult
   userEvent-tehingutel ja peavad kettalt laetud teksti puutumata jätma.
   Sama juurpõhjusega said parandatud `annotationDraftDirty` (salvestamata
   kommentaarimustand hoidis hoiatust elus järgmisel lehel) ja `saveError`
   (eelmise lehe viga jäi uue lehe peale ekraanile).

2. **Vana skaneering uue teksti kõrval.** Tekst tuli Meilist ~10 ms-ga, pilt
   sadu kilobaite hiljem, ja brauser hoidis vahepeal eelmise lehe pilti. Nüüd
   peidetakse pilt laadimise ajaks ja näidatakse spinnerit — 150 ms viivitusega,
   et eellaetud leht ei tekitaks vilkumist.

3. **Iga leht algab algusest.** Suurendustase jääb püsima (lappamisel kasulik),
   aga asend viiakse lehe ülaserva — nii pildil kui tekstis. Muidu pidi kasutaja
   iga lehe alguses mõlemad käsitsi üles kerima.

4. **Nupuriba ei kata enam esimesi tekstiridu.** Riba kõrgus mõõdetakse DOM-ist,
   mitte ei kodeerita konstandina.

## Käitumismuutused, mis on teadlikud ja soovitud

Redaktori sakk, suurendustase, otsingupaneel ja marginaaliavaate režiim püsivad
nüüd üle lehepöörete. Varem lähtestas remount need iga kord. Testitud ja
kinnitatud kasutuses.

## Testid

584 testi läbivad, neist 19 uut:

- `adjacentPageTargets` — eellaadimise piirid (7)
- `isPageSwapUpdate` — sh invariant, et lehe vahetus ei kanna userEvent
  märgistust (5)
- `panOffsetForTop` — transform-geomeetria ja nupuriba varu (12)

`npm run typecheck` puhas, `npm run build` õnnestub.

Deploy'tud ja töös testitud enne merge'i.

Closes #185
Closes #186
