### PR TITLE
security: eemalda CSP-st kasutamata Tailwind CDN ja rehype-raw sõltuvus

### DIFF
--- a/nginx.host.conf
+++ b/nginx.host.conf
@@ -47,8 +47,8 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
 
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://*.openhistoricalmap.org; connect-src 'self' https://www.wikidata.org https://viaf.org https://lobid.org https://*.openhistoricalmap.org; font-src 'self'; worker-src 'self' blob:; frame-ancestors 'self';" always;
-    more_set_headers "Content-Security-Policy: default-src 'self'; script-src 'self' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://*.openhistoricalmap.org; connect-src 'self' https://www.wikidata.org https://viaf.org https://lobid.org https://*.openhistoricalmap.org; font-src 'self'; worker-src 'self' blob:; frame-ancestors 'self';";
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://*.openhistoricalmap.org; connect-src 'self' https://www.wikidata.org https://viaf.org https://lobid.org https://*.openhistoricalmap.org; font-src 'self'; worker-src 'self' blob:; frame-ancestors 'self';" always;
+    more_set_headers "Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org https://*.openhistoricalmap.org; connect-src 'self' https://www.wikidata.org https://viaf.org https://lobid.org https://*.openhistoricalmap.org; font-src 'self'; worker-src 'self' blob:; frame-ancestors 'self';";
 
     # Jõudlus: Gzip pakkimine
     gzip on;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "react-router-dom": "^7.9.6",
         "react-zoom-pan-pinch": "^3.7.0",
         "recharts": "^3.5.0",
-        "rehype-raw": "^7.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1"
       },
@@ -3085,18 +3084,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -3640,64 +3627,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-from-parse5": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
-      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "devlop": "^1.0.0",
-        "hastscript": "^9.0.0",
-        "property-information": "^7.0.0",
-        "vfile": "^6.0.0",
-        "vfile-location": "^5.0.0",
-        "web-namespaces": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
-      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-raw": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
-      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "hast-util-from-parse5": "^8.0.0",
-        "hast-util-to-parse5": "^8.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "parse5": "^7.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3725,25 +3654,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-to-parse5": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
-      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "devlop": "^1.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -3751,23 +3661,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hastscript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
-      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-parse-selector": "^4.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3791,16 +3684,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/i18next": {
@@ -5667,18 +5550,6 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
-    "node_modules/parse5": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6258,21 +6129,6 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
-      }
-    },
-    "node_modules/rehype-raw": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
-      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-raw": "^9.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-breaks": {
@@ -7044,20 +6900,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vfile-location": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
-      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -7265,16 +7107,6 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
-    },
-    "node_modules/web-namespaces": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
-      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-router-dom": "^7.9.6",
     "react-zoom-pan-pinch": "^3.7.0",
     "recharts": "^3.5.0",
-    "rehype-raw": "^7.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1"
   },

--- a/src/components/__tests__/markdownViewSafety.test.ts
+++ b/src/components/__tests__/markdownViewSafety.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Lukustab `MarkdownView`-i turvainvariandi (vt CLAUDE.md, #189).
+ *
+ * `MarkdownView` renderdab kasutaja kirjutatud vabateksti (prosopograafia
+ * Märkmed / Elulugu, lehekülje kommentaarid). Turvalisus tugineb sellele, et
+ * toores HTML jääb escape'ituks — see kehtib ainult seni, kuni `rehype-raw`
+ * pole kasutusel. Üks import teeks kogu allow-listi mõttetuks ja avaks XSS-i.
+ *
+ * Sõltuvus on `package.json`-ist eemaldatud, aga see test hoiab invariandi
+ * kehtivana ka siis, kui keegi paketi hiljem tagasi lisab.
+ */
+const repoRoot = resolve(__dirname, '../../..');
+const read = (p: string) => readFileSync(resolve(repoRoot, p), 'utf8');
+
+describe('MarkdownView turvainvariant', () => {
+  it('ei impordi rehype-raw-d', () => {
+    const source = read('src/components/MarkdownView.tsx');
+    expect(source).not.toMatch(/from\s+['"]rehype-raw['"]/);
+    expect(source).not.toMatch(/\brehypeRaw\b/);
+  });
+
+  it('ei kasuta rehypePlugins propi', () => {
+    // Ka muu rehype-plugin võib tooret HTML-i läbi lasta — kui seda on
+    // päriselt vaja, tuleb see teadlik otsus siin üle vaadata.
+    const source = read('src/components/MarkdownView.tsx');
+    expect(source).not.toMatch(/rehypePlugins/);
+  });
+
+  it('rehype-raw ei ole projekti sõltuvustes', () => {
+    const pkg = JSON.parse(read('package.json'));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    expect(deps['rehype-raw']).toBeUndefined();
+  });
+
+  it('hoiab allow-listi ja unwrapDisallowed kasutusel', () => {
+    const source = read('src/components/MarkdownView.tsx');
+    expect(source).toMatch(/allowedElements/);
+    expect(source).toMatch(/unwrapDisallowed/);
+  });
+});


### PR DESCRIPTION
## CSP: `script-src 'self' https://cdn.tailwindcss.com` → `script-src 'self'`

Tailwindi CDN-i ei kasuta ükski leht. Kontrollitud enne muutmist:

- `index.html` ei viita sellele
- ehitatud `dist/` ei sisalda seda (ka serveris deploy'tud oma)
- Tailwind ehitatakse lokaalselt (`tailwindcss` + `@tailwindcss/postcss`)
- kõik `public/*.html` staatilised lehed (about, about_en, transcription_guide) puhtad
- **ainus viide kogu repos oli CSP ise**

Aegunud luba andis kolmandale domeenile õiguse serveerida käivitatavat JS-i meie
päritolu kontekstis.

CSP oli määratud kahel real (`add_header` real 50 ja `more_set_headers` real 51 —
headers-more kirjutab esimese üle). Uuendasin mõlemad, et need ei läheks lahku.

**Serveris juba rakendatud:** varukoopia tehtud, `nginx -t` ok, reload tehtud.
Kontrollitud, et `/`, `/about.html`, `/about_en.html`, `/transcription_guide.html`
ja `/sitemap.xml` vastavad 200-ga ning päis on nüüd `script-src 'self'`.
Repo `nginx.host.conf` on live-konfiguratsiooniga sünkroonis.

## `rehype-raw` eemaldatud sõltuvustest

`MarkdownView` ei kasutanud seda kunagi (CLAUDE.md invariant: toores HTML peab
jääma escape'ituks, allow-list ei tohi mööda minna). Paketi olemasolu tegi
taaskasutuselevõtu ühe impordi kaugusel olevaks.

Entry chunk'i hash ei muutunud (`index-laZHeimE.js`) — pakett polnud kunagi
bundle'is, seega frontend deploy'd pole vaja korrata.

## Invariant testiga lukustatud

`markdownViewSafety.test.ts` kontrollib, et `MarkdownView` ei impordi
`rehype-raw`-d, ei kasuta `rehypePlugins` propi, et pakett pole `package.json`-is
ja et allow-list + `unwrapDisallowed` on alles.

588 testi läbivad, typecheck puhas, build õnnestub.

Closes #189