### PR TITLE
perf: keelepakid laisalt ja pisichunkide koondamine (#187, #188)

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,87 +1,83 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
+import type { BackendModule, ReadCallback } from 'i18next';
+import {
+  detectInitialLanguageFromBrowser,
+  LANGUAGE_STORAGE_KEY,
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from './utils/detectLanguage';
+import { NAMESPACES } from './locales/namespaces';
 
-// Tõlked
-import etCommon from './locales/et/common.json';
-import etAuth from './locales/et/auth.json';
-import etDashboard from './locales/et/dashboard.json';
-import etWorkspace from './locales/et/workspace.json';
-import etSearch from './locales/et/search.json';
-import etStatistics from './locales/et/statistics.json';
-import etAdmin from './locales/et/admin.json';
-import etRegister from './locales/et/register.json';
-import etReview from './locales/et/review.json';
-import etUpload from './locales/et/upload.json';
-import etProsopography from './locales/et/prosopography.json';
-import etSettings from './locales/et/settings.json';
+// Dünaamiline import → üks chunk keele kohta. `import()` vahemälustab lubaduse,
+// seega 12 nimeruumi päringut ühe keele kohta toovad ikkagi ainult ühe chunki.
+const LOADERS: Record<SupportedLanguage, () => Promise<{ default: Record<string, object> }>> = {
+  et: () => import('./locales/et'),
+  en: () => import('./locales/en'),
+};
 
-import enCommon from './locales/en/common.json';
-import enAuth from './locales/en/auth.json';
-import enDashboard from './locales/en/dashboard.json';
-import enWorkspace from './locales/en/workspace.json';
-import enSearch from './locales/en/search.json';
-import enStatistics from './locales/en/statistics.json';
-import enAdmin from './locales/en/admin.json';
-import enRegister from './locales/en/register.json';
-import enReview from './locales/en/review.json';
-import enUpload from './locales/en/upload.json';
-import enProsopography from './locales/en/prosopography.json';
-import enSettings from './locales/en/settings.json';
-
-const resources = {
-  et: {
-    common: etCommon,
-    auth: etAuth,
-    dashboard: etDashboard,
-    workspace: etWorkspace,
-    search: etSearch,
-    statistics: etStatistics,
-    admin: etAdmin,
-    register: etRegister,
-    review: etReview,
-    upload: etUpload,
-    prosopography: etProsopography,
-    settings: etSettings,
-  },
-  en: {
-    common: enCommon,
-    auth: enAuth,
-    dashboard: enDashboard,
-    workspace: enWorkspace,
-    search: enSearch,
-    statistics: enStatistics,
-    admin: enAdmin,
-    register: enRegister,
-    review: enReview,
-    upload: enUpload,
-    prosopography: enProsopography,
-    settings: enSettings,
+/**
+ * Laisk backend: i18next küsib nimeruume vajaduse hetkel. Nii laeb esmasel
+ * laadimisel ainult kasutaja keel ja teine keel alles keelevahetusel.
+ *
+ * Varem olid mõlema keele kõik 12 nimeruumi staatiliselt entry chunk'is —
+ * 34,6 kB gzip, millest pool oli alati kasutu (#187).
+ */
+const lazyBackend: BackendModule = {
+  type: 'backend',
+  init: () => {},
+  read(language: string, namespace: string, callback: ReadCallback) {
+    const loader = LOADERS[language as SupportedLanguage];
+    if (!loader) {
+      callback(null, {});
+      return;
+    }
+    loader()
+      .then(module => callback(null, module.default[namespace] ?? {}))
+      .catch(error => callback(error, false));
   },
 };
 
-i18n
-  .use(LanguageDetector)
+const initialLanguage = detectInitialLanguageFromBrowser();
+
+export const i18nReady = i18n
+  .use(lazyBackend)
   .use(initReactI18next)
   .init({
-    resources,
-    // Mitte-eesti brauser → inglise (rahvusvaheline publik). Eesti brauser saab
-    // eesti keele (navigator tuvastab 'et'); tundmatu/muu keel langeb 'en' peale.
-    // Teine fallback 'et' = turvavõrk, kui mõni 'en' võti peaks puuduma.
-    // localStorage 'vutt_language' (käsitsi valik) on tuvastusjärjekorras esimene.
-    fallbackLng: ['en', 'et'],
+    lng: initialLanguage,
+    supportedLngs: [...SUPPORTED_LANGUAGES],
+    // Keeltevahelist varunduskeelt EI kasutata: see sunniks i18nexti laadima ka
+    // teise keele paki ja võit kaoks. Võtmete kattuvust hoiab selle asemel
+    // `localeParity.test.ts`, mis on rangem kui vaikne fallback.
+    fallbackLng: false,
     defaultNS: 'common',
-    ns: ['common', 'auth', 'dashboard', 'workspace', 'search', 'statistics', 'admin', 'register', 'review', 'upload', 'prosopography', 'settings'],
-
-    detection: {
-      order: ['localStorage', 'navigator'],
-      lookupLocalStorage: 'vutt_language',
-      caches: ['localStorage'],
-    },
-
+    ns: [...NAMESPACES],
     interpolation: {
       escapeValue: false, // React juba escapib
     },
   });
+
+// Käsitsi valik püsib üle seansside. Varem tegi seda LanguageDetectori
+// `caches: ['localStorage']`; detektor on nüüd asendatud oma tuvastusega.
+i18n.on('languageChanged', lng => {
+  try {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, lng);
+  } catch {
+    /* privaatrežiim — valik ei püsi, aga rakendus töötab */
+  }
+});
+
+/**
+ * Soojendab teise keele paki jõudeajal, et keelevahetus oleks kohene ega
+ * peataks rakendust Suspense'i taha.
+ */
+export function preloadOtherLanguage(): void {
+  const other = SUPPORTED_LANGUAGES.find(l => l !== i18n.language);
+  if (!other) return;
+  const run = () => { void LOADERS[other]().catch(() => { /* parim-pingutus */ }); };
+  const ric = (window as any).requestIdleCallback;
+  if (typeof ric === 'function') ric(run, { timeout: 5000 });
+  else window.setTimeout(run, 2000);
+}
 
 export default i18n;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import App from './App';
 import 'leaflet/dist/leaflet.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import './index.css';
-import './i18n';
+import { i18nReady, preloadOtherLanguage } from './i18n';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -12,10 +12,23 @@ if (!rootElement) {
 }
 
 const root = ReactDOM.createRoot(rootElement);
-root.render(
-  <React.StrictMode>
-    <Suspense fallback={<div className="h-screen flex items-center justify-center">Laadin...</div>}>
-      <App />
-    </Suspense>
-  </React.StrictMode>
-);
+
+const render = () => {
+  root.render(
+    <React.StrictMode>
+      <Suspense fallback={<div className="h-screen flex items-center justify-center">Laadin...</div>}>
+        <App />
+      </Suspense>
+    </React.StrictMode>
+  );
+  // Teine keel jõudeajal vahemällu — keelevahetus ei jää siis chunki ootama.
+  preloadOtherLanguage();
+};
+
+// Tõlked laetakse nüüd laisalt (#187), seega ootame esimese keele paki ära.
+// Muidu vilguks rakendus hetkeks tõlkevõtmetega. Vea korral renderdame ikkagi —
+// katkine tõlgete laadimine ei tohi jätta tühja lehte.
+i18nReady.then(render).catch(error => {
+  console.error('i18n init failed', error);
+  render();
+});

--- a/src/locales/__tests__/i18nBootstrap.test.ts
+++ b/src/locales/__tests__/i18nBootstrap.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+/**
+ * Otsast-otsani kontroll i18n käivitusteele (#187).
+ *
+ * See on muudatuse riskantseim osa: staatiliste `resources`-ite asemel laeb
+ * i18next nimeruume nüüd laisa backendi kaudu ja `fallbackLng` on välja
+ * lülitatud. Kui backend midagi valesti tagastab, ei visata viga — kasutaja
+ * lihtsalt näeb tõlkevõtmeid. Seetõttu kontrollime päris initsialiseerimist.
+ */
+
+const store = new Map<string, string>();
+
+beforeAll(() => {
+  // i18n.ts loeb brauseri API-sid; node-keskkonnas anname minimaalse topelti.
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  });
+  vi.stubGlobal('navigator', { languages: ['et-EE', 'et'], language: 'et-EE' });
+});
+
+describe('i18n käivitus laisa backendiga', () => {
+  it('laeb tuvastatud keele ja lahendab võtmed', async () => {
+    const { i18nReady, default: i18n } = await import('../../i18n');
+    await i18nReady;
+
+    expect(i18n.language).toBe('et');
+    expect(i18n.t('app.subtitle')).toBe('Varauusaegsete tekstide töölaud');
+    expect(i18n.t('buttons.search')).toBe('Otsi');
+  });
+
+  it('lahendab võtmeid ka mujalt kui vaikimisi nimeruumist', async () => {
+    const { i18nReady, default: i18n } = await import('../../i18n');
+    await i18nReady;
+
+    // `workspace` nimeruum peab olema samast pakist kaasa tulnud
+    expect(i18n.t('workspace:tabs.edit')).not.toBe('tabs.edit');
+  });
+
+  it('keelevahetus laeb teise paki ja tõlked muutuvad', async () => {
+    const { i18nReady, default: i18n } = await import('../../i18n');
+    await i18nReady;
+
+    await i18n.changeLanguage('en');
+    expect(i18n.language).toBe('en');
+    expect(i18n.t('app.subtitle')).toBe('Early Modern Text Workbench');
+    expect(i18n.t('buttons.search')).toBe('Search');
+  });
+
+  it('keelevalik salvestatakse localStorage-isse', async () => {
+    const { i18nReady, default: i18n } = await import('../../i18n');
+    await i18nReady;
+
+    await i18n.changeLanguage('en');
+    expect(store.get('vutt_language')).toBe('en');
+  });
+});

--- a/src/locales/__tests__/lazyLoading.test.ts
+++ b/src/locales/__tests__/lazyLoading.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { NAMESPACES } from '../namespaces';
+import etBundle from '../et';
+import enBundle from '../en';
+
+/**
+ * Laisa laadimise ehitusplokid (#187).
+ *
+ * `src/i18n.ts` ise käivitab importimisel initsialiseerimise ja sõltub
+ * brauseri API-dest, seega kontrollime siin seda, mille peal laisk backend
+ * seisab: keelepakid peavad sisaldama täpselt neid nimeruume, mida i18next
+ * küsib. Kui pakist puuduks nimeruum, tagastaks backend vaikselt `{}` ja
+ * kasutaja näeks tõlkevõtmeid — ilma `fallbackLng`-ta ei püüaks seda enam
+ * miski kinni.
+ */
+describe('keelepakid laisa laadimise jaoks', () => {
+  const bundles = { et: etBundle, en: enBundle } as const;
+
+  it.each(Object.keys(bundles) as (keyof typeof bundles)[])(
+    'pakk "%s" sisaldab kõiki nimeruume',
+    lang => {
+      expect(Object.keys(bundles[lang]).sort()).toEqual([...NAMESPACES].sort());
+    },
+  );
+
+  it.each(Object.keys(bundles) as (keyof typeof bundles)[])(
+    'pakk "%s" ei sisalda tühje nimeruume',
+    lang => {
+      for (const ns of NAMESPACES) {
+        const bundle = bundles[lang][ns] as Record<string, unknown>;
+        expect(bundle, `${lang}/${ns}`).toBeTypeOf('object');
+        expect(Object.keys(bundle).length, `${lang}/${ns} on tühi`).toBeGreaterThan(0);
+      }
+    },
+  );
+
+  it('paketid on eri keeltes tõesti erineva sisuga', () => {
+    // Kaitse selle vastu, et mõlemad laadijad osutaksid kogemata samale kaustale
+    expect(JSON.stringify(etBundle)).not.toEqual(JSON.stringify(enBundle));
+  });
+});

--- a/src/locales/__tests__/localeParity.test.ts
+++ b/src/locales/__tests__/localeParity.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { NAMESPACES } from '../namespaces';
+
+/**
+ * Hoiab eesti ja inglise tõlked võtmete poolest identsena.
+ *
+ * **Miks see test on kohustuslik (#187):** varem oli `fallbackLng: ['en', 'et']`
+ * — puuduv võti ühes keeles võeti vaikselt teisest. See varuvõrk sundis
+ * i18nexti laadima mõlema keele paki ja tegi laiska laadimist mõttetuks, seega
+ * eemaldati (`fallbackLng: false`). Ilma varuvõrguta ilmuks puuduv võti
+ * kasutajale toorel kujul.
+ *
+ * See test on vaiksest fallbackist rangem: lahknevus katkestab build'i, mitte
+ * ei kao märkamatult teise keele teksti taha.
+ */
+const localesDir = resolve(__dirname, '..');
+const LANGUAGES = ['et', 'en'] as const;
+
+function flatKeys(value: unknown, prefix = ''): string[] {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return [prefix];
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) =>
+    flatKeys(child, prefix ? `${prefix}.${key}` : key),
+  );
+}
+
+const load = (lang: string, ns: string): unknown =>
+  JSON.parse(readFileSync(resolve(localesDir, lang, `${ns}.json`), 'utf8'));
+
+describe('lokaatide võtmete pariteet', () => {
+  it('mõlemal keelel on samad nimeruumifailid', () => {
+    const files = (lang: string) =>
+      readdirSync(resolve(localesDir, lang)).filter(f => f.endsWith('.json')).sort();
+    expect(files('en')).toEqual(files('et'));
+  });
+
+  it('namespaces.ts NAMESPACES vastab failidele kettal', () => {
+    const onDisk = readdirSync(resolve(localesDir, 'et'))
+      .filter(f => f.endsWith('.json'))
+      .map(f => f.replace(/\.json$/, ''))
+      .sort();
+    expect([...NAMESPACES].sort()).toEqual(onDisk);
+  });
+
+  it.each(NAMESPACES)('nimeruumil "%s" on mõlemas keeles samad võtmed', ns => {
+    const [etKeys, enKeys] = LANGUAGES.map(lang => flatKeys(load(lang, ns)).sort());
+
+    const onlyEt = etKeys.filter(k => !enKeys.includes(k));
+    const onlyEn = enKeys.filter(k => !etKeys.includes(k));
+
+    expect({ onlyEt, onlyEn }).toEqual({ onlyEt: [], onlyEn: [] });
+  });
+});

--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -1,0 +1,30 @@
+// Ühe keele kõik nimeruumid ühes moodulis. Dünaamiline import loob siit
+// täpselt ühe chunki keele kohta — nimeruumide kaupa importimine annaks 12.
+// Laadimist juhib `src/i18n.ts` laisk backend.
+import admin from './admin.json';
+import auth from './auth.json';
+import common from './common.json';
+import dashboard from './dashboard.json';
+import prosopography from './prosopography.json';
+import register from './register.json';
+import review from './review.json';
+import search from './search.json';
+import settings from './settings.json';
+import statistics from './statistics.json';
+import upload from './upload.json';
+import workspace from './workspace.json';
+
+export default {
+  admin,
+  auth,
+  common,
+  dashboard,
+  prosopography,
+  register,
+  review,
+  search,
+  settings,
+  statistics,
+  upload,
+  workspace,
+};

--- a/src/locales/et/index.ts
+++ b/src/locales/et/index.ts
@@ -1,0 +1,30 @@
+// Ühe keele kõik nimeruumid ühes moodulis. Dünaamiline import loob siit
+// täpselt ühe chunki keele kohta — nimeruumide kaupa importimine annaks 12.
+// Laadimist juhib `src/i18n.ts` laisk backend.
+import admin from './admin.json';
+import auth from './auth.json';
+import common from './common.json';
+import dashboard from './dashboard.json';
+import prosopography from './prosopography.json';
+import register from './register.json';
+import review from './review.json';
+import search from './search.json';
+import settings from './settings.json';
+import statistics from './statistics.json';
+import upload from './upload.json';
+import workspace from './workspace.json';
+
+export default {
+  admin,
+  auth,
+  common,
+  dashboard,
+  prosopography,
+  register,
+  review,
+  search,
+  settings,
+  statistics,
+  upload,
+  workspace,
+};

--- a/src/locales/namespaces.ts
+++ b/src/locales/namespaces.ts
@@ -1,0 +1,13 @@
+/**
+ * i18n nimeruumid. Eraldi moodulis, et neid saaks importida ilma `src/i18n.ts`
+ * kõrvalmõjuta — selle importimine käivitab i18nexti initsialiseerimise.
+ *
+ * Peab vastama failidele `src/locales/{et,en}/*.json`; seda kontrollib
+ * `__tests__/localeParity.test.ts`.
+ */
+export const NAMESPACES = [
+  'common', 'auth', 'dashboard', 'workspace', 'search', 'statistics',
+  'admin', 'register', 'review', 'upload', 'prosopography', 'settings',
+] as const;
+
+export type Namespace = (typeof NAMESPACES)[number];

--- a/src/utils/__tests__/detectLanguage.test.ts
+++ b/src/utils/__tests__/detectLanguage.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { detectInitialLanguage } from '../detectLanguage';
+
+describe('detectInitialLanguage', () => {
+  it('käsitsi valik localStorage-is on kaalukaim', () => {
+    expect(detectInitialLanguage('et', ['en-US', 'en'])).toBe('et');
+    expect(detectInitialLanguage('en', ['et-EE', 'et'])).toBe('en');
+  });
+
+  it('ignoreerib toetamata salvestatud väärtust', () => {
+    expect(detectInitialLanguage('de', ['et-EE'])).toBe('et');
+    expect(detectInitialLanguage('', ['et'])).toBe('et');
+  });
+
+  it('eesti brauser saab eesti keele', () => {
+    expect(detectInitialLanguage(null, ['et-EE', 'et'])).toBe('et');
+    expect(detectInitialLanguage(null, ['et'])).toBe('et');
+  });
+
+  it('piirkonnakood eemaldatakse ja suurtähed ei sega', () => {
+    expect(detectInitialLanguage(null, ['ET-ee'])).toBe('et');
+    expect(detectInitialLanguage(null, ['en-GB'])).toBe('en');
+  });
+
+  it('muu keel langeb inglise peale', () => {
+    expect(detectInitialLanguage(null, ['de-DE', 'fr'])).toBe('en');
+    expect(detectInitialLanguage(null, ['ru'])).toBe('en');
+  });
+
+  it('võtab esimese toetatud vaste järjekorras', () => {
+    // Brauser eelistab saksa keelt, aga eesti on nimekirjas enne inglist
+    expect(detectInitialLanguage(null, ['de', 'et', 'en'])).toBe('et');
+    expect(detectInitialLanguage(null, ['de', 'en', 'et'])).toBe('en');
+  });
+
+  it('tühi või puuduv brauseri nimekiri annab inglise keele', () => {
+    expect(detectInitialLanguage(null, [])).toBe('en');
+    expect(detectInitialLanguage(null, undefined)).toBe('en');
+  });
+
+  it('ei komistata mitte-string kirjete otsa', () => {
+    expect(detectInitialLanguage(null, [undefined as any, null as any, 'et'])).toBe('et');
+  });
+});

--- a/src/utils/detectLanguage.ts
+++ b/src/utils/detectLanguage.ts
@@ -1,0 +1,55 @@
+export const SUPPORTED_LANGUAGES = ['et', 'en'] as const;
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const LANGUAGE_STORAGE_KEY = 'vutt_language';
+
+/** Vaikekeel: rahvusvaheline publik saab inglise keele. */
+const DEFAULT_LANGUAGE: SupportedLanguage = 'en';
+
+function isSupported(value: unknown): value is SupportedLanguage {
+  return typeof value === 'string' && (SUPPORTED_LANGUAGES as readonly string[]).includes(value);
+}
+
+/**
+ * Valib algkeele. Kordab senist `i18next-browser-languagedetector` käitumist
+ * (`order: ['localStorage', 'navigator']`), aga teeb seda **enne** i18n
+ * initsialiseerimist, et osata laadida ainult ühe keele pakk.
+ *
+ * Miks käsitsi: kui jätta tuvastus i18nexti hooleks koos `fallbackLng`-ga,
+ * laadib i18next ka varukeele paki. Eestikeelne kasutaja saaks siis ikka
+ * mõlemad ja kogu #187 võit kaoks.
+ *
+ * Järjekord:
+ * 1. Käsitsi valik localStorage'is (`vutt_language`) — kaalukaim.
+ * 2. Brauseri keeled: esimene toetatud vaste (`et-EE` → `et`).
+ * 3. Inglise keel.
+ */
+export function detectInitialLanguage(
+  stored: string | null | undefined,
+  navigatorLanguages: readonly string[] | undefined,
+): SupportedLanguage {
+  if (isSupported(stored)) return stored;
+
+  for (const raw of navigatorLanguages ?? []) {
+    if (typeof raw !== 'string') continue;
+    // Piirkonnakood maha: `et-EE` → `et`
+    const base = raw.toLowerCase().split('-')[0];
+    if (isSupported(base)) return base;
+  }
+
+  return DEFAULT_LANGUAGE;
+}
+
+/** Brauserist lugev variant. Testides kasuta puhast `detectInitialLanguage`-i. */
+export function detectInitialLanguageFromBrowser(): SupportedLanguage {
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  } catch {
+    /* privaatrežiim või blokeeritud salvestus — jätkame tuvastusega */
+  }
+  const langs = typeof navigator !== 'undefined'
+    ? navigator.languages ?? (navigator.language ? [navigator.language] : [])
+    : [];
+  return detectInitialLanguage(stored, langs);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,36 @@ export default defineConfig(({ mode }) => {
         alias: {
           '@': path.resolve(__dirname, 'src'),
         }
+      },
+      build: {
+        rollupOptions: {
+          output: {
+            // Automaatne chunk'imine jättis 26 faili alla 2 kB — peamiselt
+            // üksikud lucide ikoonid, mida jagavad mitu lazy marsruuti. Tootmine
+            // vastab HTTP/1.1-ga (vt #177), kus brauseril on ~6 paralleelset
+            // ühendust: kümnete pisifailide järjekord maksab rohkem kui nende
+            // kogumaht. Vt #188.
+            manualChunks(id: string) {
+              // Tõlked keele kaupa (#187). Nimetame selgelt, muidu tekivad
+              // `index-*.js` nimelised chunkid (kaustade index.ts järgi).
+              if (id.includes('/src/locales/et/')) return 'locale-et';
+              if (id.includes('/src/locales/en/')) return 'locale-en';
+
+              if (!id.includes('node_modules')) return undefined;
+
+              // Kõik ikoonid ühte chunki ühe päringu asemel kümnete asemel.
+              if (id.includes('/lucide-react/')) return 'icons';
+
+              // Raamistik muutub harva → püsib brauseri vahemälus üle deploy'de,
+              // samal ajal kui rakenduse kood uueneb.
+              if (/\/node_modules\/(react|react-dom|scheduler|react-router|react-router-dom)\//.test(id)) {
+                return 'vendor-react';
+              }
+
+              return undefined;
+            },
+          },
+        },
       }
     };
 });


### PR DESCRIPTION
## #187 — tõlked keele kaupa

Entry chunk sisaldas mõlema keele kõiki 12 nimeruumi — **34,6 kB gzip, millest
pool oli igal külastusel kasutu**. `src/i18n.ts` impordib nüüd keelepakid
dünaamiliselt laisa i18next backendi kaudu; `src/locales/{et,en}/index.ts`
koondab ühe keele üheks chunkiks (nimeruumide kaupa importimine annaks 12).

Keeletuvastus tehakse käsitsi enne i18n init'i. Põhjus: `fallbackLng`-ga
**sunnib i18next laadima ka varukeele paki**, mis oleks võidu täielikult ära
söönud. Tuvastus kordab senist LanguageDetectori käitumist (localStorage
`vutt_language` → brauseri keeled → inglise).

### Varuvõrgu asendamine, mitte lihtsalt eemaldamine

`fallbackLng: false` võtab ära vaikse keeltevahelise varunduse. Kontrollisin
**enne** eemaldamist, kas seda üldse kasutatakse: lokaadid on täpselt sünkroonis,
0 lahknevat võtit kummaski suunas. Varuvõrk ei rakendunud kunagi.

Asendasin selle millegi rangemaga: `localeParity` test katkestab build'i, kui
võtmed lahknevad. Vaikne fallback oleks lasknud puuduva tõlke märkamatult teise
keele teksti taha kaduda; test ei lase.

## #188 — chunk'ide koondamine

`manualChunks`: lucide ikoonid ühte chunki (26 chunki 55-st olid alla 2 kB),
react/react-dom/scheduler/router eraldi `vendor-react` chunki, keelepakid
selgete nimedega.

**Üks selle issue leidudest oli vale** ja on kommentaaris parandatud: väitsin,
et maandumisruudi chunk vajab modulepreload'i, aga Dashboard on `App.tsx:7`
staatiliselt imporditud, mitte lazy — ta oli juba entry chunk'is. Vite lisab nüüd
modulepreload'i ise `vendor-react` ja `icons` chunkidele, kuna need on entry
staatilised sõltuvused.

## Mõõdetud

| | enne | pärast |
|---|---|---|
| Entry chunk | 193,22 kB gzip | **59,13 kB gzip** |
| Esmane laadimine kokku (et) | ~221 kB gzip | **~202 kB gzip** |
| JS chunke | 55 | 36 |
| Alla 2 kB chunke | 26 | 3 |

### Aus kompromiss

Keelepakk laeb nüüd järjestikku pärast entry chunki. Mõõtsin RTT serverini:
**~100 ms**. See kulu tabab ainult **esimest külastust** — failinimi on hashitud
ja `/assets/` on `expires 1y`, seega edaspidi tuleb pakk vahemälust ilma
päringuta.

Vastu saab: 134 kB väiksem entry kriitilisel teel ja `vendor-react` (87 kB),
mis püsib nüüd vahemälus üle deploy'de. VUTT on korduvkasutatav tööriist, seega
korduvkülastuse profiil kaalub ühekordse RTT selgelt üles.

## Testid

619 läbivad, 19 uut:

- `detectLanguage` — tuvastuse järjekord, piirkonnakoodid, tundmatud keeled (9)
- `localeParity` — võtmete pariteet nimeruumide kaupa (asendab fallback'i)
- `lazyLoading` — keelepakkide terviklikkus, kaitse selle vastu et mõlemad
  laadijad osutaksid samale kaustale
- `i18nBootstrap` — **otsast otsani**: päris init, võtmete lahendamine üle
  nimeruumide, keelevahetus teise paki laadimisega, localStorage püsivus

Viimane on siin kõige olulisem: ilma `fallbackLng`-ta ei visata tõlkevea korral
enam viga — kasutaja lihtsalt näeks tõlkevõtmeid. Seetõttu on käivitustee
päris-init'iga kaetud, mitte mockidega.

Closes #187
Closes #188