### PR TITLE
fix: re-OCR olek on lehepõhine, mitte editori-instantsi põhine

### DIFF
--- a/docs/decisions/0010-lehe-vahetus-ei-monteeri-editorit-maha.md
+++ b/docs/decisions/0010-lehe-vahetus-ei-monteeri-editorit-maha.md
@@ -49,6 +49,17 @@ teinud.
   seni: `isDirty`, `annotationDraftDirty`, `saveError`, kerimispositsioon,
   pildi asend.
 
+- **Lehepõhine taustatöö olek vajab lehe-võtit, mitte mount-guardi.**
+  `useReOcr` hoidis re-OCR seisu (banner "Transkriptsioon käib", tulemuse
+  ülekate) ühekordse mount-kontrolliga (`didCheckStoredJobRef`) — see eeldas
+  remounti. Ilma remountita rippus eelmise lehe banner igal järgmisel lehel ja
+  valmiv töö kuvas võõra lehe teksti, mille "Rakenda" oleks kirjutanud
+  praegusesse dokumenti. Muster: identiteedivõti (`reocrPageIdentity` →
+  `work_id/failinimi`) effecti dep-listis, mis lähtestab oleku, + `pageKeyRef`
+  valve iga async-vastuse ees, et vana lehe poll ei kirjutaks uue lehe olekusse.
+  Sama põhjusel on `PageCommentsPanel`-il `key={page.id}` — mustandiväljad on
+  lehepõhised.
+
 - Teadlikult **säilivad** üle lehepöörete: redaktori sakk, suurendustase,
   otsingupaneeli olek, marginaaliavaate režiim. Need on lappamisel soovitud.
 

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -3,6 +3,7 @@ import { Page, PageStatus, Annotation, Work } from '../types';
 import type { Collections } from '../services/collectionService';
 import type { TextAnnotation } from '../types';
 import { useUser } from '../contexts/UserContext';
+import { isAtLeast } from '../utils/roleUtils';
 import EditorHeader from './editor/EditorHeader';
 import EditorEditTab from './editor/EditorEditTab';
 import EditorInfoHistoryTabs from './editor/EditorInfoHistoryTabs';
@@ -144,6 +145,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ page, work, onSave, onUnsavedCh
   const { reocrStatus, reocrText, reocrError, handleReOcr, applyReOcr, deleteOcrFile } = useReOcr({
     page,
     authToken,
+    isAdmin: isAtLeast(user?.role, 'admin'),
     viewRef,
     setIsDirty,
   });

--- a/src/components/editor/AnnotationsTab.tsx
+++ b/src/components/editor/AnnotationsTab.tsx
@@ -100,8 +100,11 @@ const AnnotationsTab: React.FC<AnnotationsTabProps> = ({
         lang={lang}
       />
 
-      {/* Comments */}
+      {/* Comments — key lähtestab mustandiväljad lehe vahetusel.
+          Editor ei monteeru enam lehe pöördel maha (ADR 0010), seega jääks
+          pooleli kirjutatud kommentaar muidu järgmisele lehele rippuma. */}
       <PageCommentsPanel
+        key={_page.id}
         comments={comments}
         setComments={setComments}
         onDraftChange={onDraftChange}

--- a/src/components/editor/__tests__/reocrPageIdentity.test.ts
+++ b/src/components/editor/__tests__/reocrPageIdentity.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { reocrPageIdentity } from '../reocrPageIdentity';
+
+describe('reocrPageIdentity', () => {
+  it('eristab sama teose leheküljed', () => {
+    const a = reocrPageIdentity('w1', 'http://x/images/w1/foo_pg_001.jpg');
+    const b = reocrPageIdentity('w1', 'http://x/images/w1/foo_pg_002.jpg');
+    expect(a.pageKey).not.toBe(b.pageKey);
+    expect(a.storageKey).not.toBe(b.storageKey);
+  });
+
+  it('sama leht annab sama võtme', () => {
+    const a = reocrPageIdentity('w1', 'http://x/images/w1/foo_pg_001.jpg');
+    const b = reocrPageIdentity('w1', 'http://x/images/w1/foo_pg_001.jpg');
+    expect(a.pageKey).toBe(b.pageKey);
+  });
+
+  it('eristab sama failinimega lehed eri teostes', () => {
+    const a = reocrPageIdentity('w1', 'http://x/images/w1/pg_001.jpg');
+    const b = reocrPageIdentity('w2', 'http://x/images/w2/pg_001.jpg');
+    expect(a.pageKey).not.toBe(b.pageKey);
+  });
+
+  it('säilitab ajaloolise localStorage võtme formaadi', () => {
+    // NB: pooleliolevad tööd on juba salvestatud selle võtmega — ära muuda.
+    expect(reocrPageIdentity('w1', '/img/foo_pg_001.jpg').storageKey)
+      .toBe('reocr_job_w1_foo_pg_001.jpg');
+  });
+
+  it('ilma pildi või teoseta võtit pole', () => {
+    expect(reocrPageIdentity('w1', null).pageKey).toBeNull();
+    expect(reocrPageIdentity(null, '/img/foo.jpg').pageKey).toBeNull();
+    expect(reocrPageIdentity('w1', null).storageKey).toBeNull();
+  });
+});

--- a/src/components/editor/reocrPageIdentity.ts
+++ b/src/components/editor/reocrPageIdentity.ts
@@ -1,0 +1,27 @@
+// Re-OCR lehe identiteet. Re-OCR olek (banner, tulemus, viga) kuulub LEHELE,
+// mitte editori instantsile — editor ei monteeru lehe vahetusel maha (ADR 0010),
+// seega peab olek lähtestuma siinse võtme muutumisel.
+
+export interface ReocrPageIdentity {
+  /** Pildifaili nimi (nt "foo_pg_001.jpg") või null, kui lehel pilti pole. */
+  pageFilename: string | null;
+  /** Lehe identiteedi võti — muutumine tähendab, et olek tuleb lähtestada. */
+  pageKey: string | null;
+  /** localStorage võti poolelioleva töö job_id jaoks (ajalooline formaat). */
+  storageKey: string | null;
+}
+
+export function reocrPageIdentity(
+  workId: string | null | undefined,
+  imageUrl: string | null | undefined,
+): ReocrPageIdentity {
+  const pageFilename = imageUrl ? (imageUrl.split('/').pop() || null) : null;
+  if (!workId || !pageFilename) {
+    return { pageFilename, pageKey: null, storageKey: null };
+  }
+  return {
+    pageFilename,
+    pageKey: `${workId}/${pageFilename}`,
+    storageKey: `reocr_job_${workId}_${pageFilename}`,
+  };
+}

--- a/src/components/editor/useReOcr.ts
+++ b/src/components/editor/useReOcr.ts
@@ -3,12 +3,15 @@ import { EditorView } from '@codemirror/view';
 import { fetchWithTimeout, getAuthHeaders } from '../../utils/fetchWithTimeout';
 import { FILE_API_URL } from '../../config';
 import { Page } from '../../types';
+import { reocrPageIdentity } from './reocrPageIdentity';
 
 export type ReocrStatus = 'idle' | 'uploading' | 'processing' | 'done' | 'error';
 
 interface UseReOcrProps {
   page: Page;
   authToken: string | null;
+  /** Re-OCR endpointid on admin-only — muul juhul ei tehta ühtki päringut. */
+  isAdmin: boolean;
   viewRef: MutableRefObject<EditorView | null>;
   setIsDirty: (v: boolean) => void;
 }
@@ -33,35 +36,50 @@ const parseJsonResponse = async (response: Response): Promise<any> => {
   }
 };
 
-export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps): UseReOcrReturn {
+export function useReOcr({ page, authToken, isAdmin, viewRef, setIsDirty }: UseReOcrProps): UseReOcrReturn {
   const [reocrStatus, setReocrStatus] = useState<ReocrStatus>('idle');
   const [reocrText, setReocrText] = useState<string | null>(null);
   const [reocrError, setReocrError] = useState<string | null>(null);
   const reocrPollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Lehekülje failinimi (piltide URL-ist) — kasutatakse .ocr faili ja localStorage võtme jaoks
-  const pageFilename = page.image_url ? (page.image_url.split('/').pop() ?? null) : null;
-  // localStorage võti poolelioleva re-OCR töö job_id säilitamiseks
-  const reocrStorageKey = page.work_id && pageFilename
-    ? `reocr_job_${page.work_id}_${pageFilename}`
-    : null;
-  const didCheckStoredJobRef = useRef(false);
+  const { pageFilename, pageKey, storageKey: reocrStorageKey } = reocrPageIdentity(page.work_id, page.image_url);
 
-  // Poll cleanup
+  // Editor EI monteeru lehe vahetusel maha (ADR 0010), seega on see olek
+  // "kleepuv": ilma selgesõnalise lähtestuseta ripuks eelmise lehe banner ja
+  // tulemus kaasa igale järgmisele lehele. pageKeyRef valvab ka pooleliolevate
+  // async-vastuste eest — vana lehe poll ei tohi kirjutada uue lehe olekusse.
+  const pageKeyRef = useRef<string | null>(pageKey);
+  pageKeyRef.current = pageKey;
+
+  // Poll cleanup komponendi mahavõtmisel
   useEffect(() => {
     return () => {
       if (reocrPollRef.current) clearTimeout(reocrPollRef.current);
     };
   }, []);
 
-  // Mountimisel: kontrolli esmalt .ocr faili (püsiv), siis localStorage (pooleliolev töö)
+  // Lehe vahetusel: lähtesta olek ja kontrolli UUE lehe seisu.
+  // 1. .ocr fail (püsiv, elab serveri restardi üle)
+  // 2. localStorage (pooleliolev töö)
   useEffect(() => {
-    if (didCheckStoredJobRef.current || !authToken || !page.work_id || !pageFilename) return;
-    didCheckStoredJobRef.current = true;
+    if (reocrPollRef.current) {
+      clearTimeout(reocrPollRef.current);
+      reocrPollRef.current = null;
+    }
+    setReocrStatus('idle');
+    setReocrText(null);
+    setReocrError(null);
+
+    if (!authToken || !isAdmin || !pageKey || !page.work_id || !pageFilename) return;
+
+    // Kõik hilisemad kirjutused käivad läbi selle valve — kui leht on vahepeal
+    // vahetunud, visatakse vastus lihtsalt ära.
+    const isCurrent = () => pageKeyRef.current === pageKey;
 
     const startPollingFromSaved = (jobId: string) => {
       setReocrStatus('processing');
       const poll = async () => {
+        if (!isCurrent()) return;
         try {
           const pr = await fetchWithTimeout(
             `${FILE_API_URL}/admin/reocr/${jobId}/status`,
@@ -69,38 +87,41 @@ export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps
           );
           if (!pr.ok) throw new Error('Polling ebaõnnestus');
           const pd = await parseJsonResponse(pr);
+          if (!isCurrent()) return;
           if (pd.status === 'done') {
             setReocrStatus('done');
             setReocrText(pd.text ?? '');
           } else if (pd.status === 'error') {
             setReocrStatus('error');
             setReocrError(pd.error || 'Tundmatu viga');
-            if (reocrStorageKey) localStorage.removeItem(reocrStorageKey);
+            localStorage.removeItem(reocrStorageKey!);
           } else if (pd.status === 'not_found') {
             setReocrStatus('idle');
-            if (reocrStorageKey) localStorage.removeItem(reocrStorageKey);
+            localStorage.removeItem(reocrStorageKey!);
           } else {
             reocrPollRef.current = setTimeout(poll, 3000);
           }
         } catch {
-          reocrPollRef.current = setTimeout(poll, 4000);
+          if (isCurrent()) reocrPollRef.current = setTimeout(poll, 4000);
         }
       };
       reocrPollRef.current = setTimeout(poll, 1000);
     };
 
     const checkAll = async () => {
-      // 1. Kontrolli .ocr faili (elab serverirestate üle)
+      // 1. Kontrolli .ocr faili (elab serveri restardi üle)
       try {
         const res = await fetchWithTimeout(
           `${FILE_API_URL}/admin/work/${page.work_id}/page-ocr?filename=${encodeURIComponent(pageFilename)}`,
           { headers: getAuthHeaders(authToken), timeout: 5000 }
         );
+        if (!isCurrent()) return;
         if (res.ok) {
           const data = await parseJsonResponse(res);
+          if (!isCurrent()) return;
           setReocrStatus('done');
           setReocrText(data.text ?? '');
-          if (reocrStorageKey) localStorage.removeItem(reocrStorageKey);
+          localStorage.removeItem(reocrStorageKey!);
           return;
         }
       } catch {
@@ -108,8 +129,8 @@ export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps
       }
 
       // 2. .ocr puudub — kontrolli localStorage (pooleliolev töö)
-      const savedJobId = reocrStorageKey ? localStorage.getItem(reocrStorageKey) : null;
-      if (!savedJobId) return;
+      const savedJobId = localStorage.getItem(reocrStorageKey!);
+      if (!savedJobId || !isCurrent()) return;
 
       try {
         const pr = await fetchWithTimeout(
@@ -117,13 +138,14 @@ export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps
           { headers: getAuthHeaders(authToken), timeout: 10000 }
         );
         const pd = await parseJsonResponse(pr);
+        if (!isCurrent()) return;
         if (pd.status === 'done') {
           setReocrStatus('done');
           setReocrText(pd.text ?? '');
         } else if (pd.status === 'uploading' || pd.status === 'processing') {
           startPollingFromSaved(savedJobId);
         } else {
-          if (reocrStorageKey) localStorage.removeItem(reocrStorageKey);
+          localStorage.removeItem(reocrStorageKey!);
         }
       } catch {
         // Eiramine
@@ -131,11 +153,23 @@ export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps
     };
 
     checkAll();
+
+    return () => {
+      if (reocrPollRef.current) {
+        clearTimeout(reocrPollRef.current);
+        reocrPollRef.current = null;
+      }
+    };
+  // pageKey katab work_id + failinime; ülejäänu on sellest tuletatud
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authToken]);
+  }, [authToken, isAdmin, pageKey]);
 
   const handleReOcr = useCallback(async () => {
-    if (!pageFilename || !authToken) return;
+    if (!pageFilename || !authToken || !pageKey) return;
+
+    // Töö kuulub sellele lehele — vastuseid ei tohi rakendada pärast lehe vahetust.
+    const jobPageKey = pageKey;
+    const isCurrent = () => pageKeyRef.current === jobPageKey;
 
     if (reocrPollRef.current) clearTimeout(reocrPollRef.current);
     setReocrStatus('uploading');
@@ -154,10 +188,14 @@ export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps
         throw new Error(d.detail || 'Re-OCR alustamine ebaõnnestus');
       }
       const { job_id } = await parseJsonResponse(res);
+      // job_id salvestatakse ALATI — töö jookseb serveris ka siis, kui kasutaja
+      // on vahepeal lehte vahetanud; tagasi tulles leitakse see üles.
       if (reocrStorageKey) localStorage.setItem(reocrStorageKey, job_id);
+      if (!isCurrent()) return;
       setReocrStatus('processing');
 
       const poll = async () => {
+        if (!isCurrent()) return;
         try {
           const pr = await fetchWithTimeout(
             `${FILE_API_URL}/admin/reocr/${job_id}/status`,
@@ -165,6 +203,7 @@ export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps
           );
           if (!pr.ok) throw new Error('Polling ebaõnnestus');
           const pd = await parseJsonResponse(pr);
+          if (!isCurrent()) return;
           if (pd.status === 'done') {
             setReocrStatus('done');
             setReocrText(pd.text ?? '');
@@ -176,15 +215,16 @@ export function useReOcr({ page, authToken, viewRef, setIsDirty }: UseReOcrProps
             reocrPollRef.current = setTimeout(poll, 3000);
           }
         } catch {
-          reocrPollRef.current = setTimeout(poll, 4000);
+          if (isCurrent()) reocrPollRef.current = setTimeout(poll, 4000);
         }
       };
       reocrPollRef.current = setTimeout(poll, 3000);
     } catch (e: any) {
+      if (!isCurrent()) return;
       setReocrStatus('error');
       setReocrError(e.message || 'Viga');
     }
-  }, [pageFilename, page.work_id, page.page_number, authToken, reocrStorageKey]);
+  }, [pageFilename, pageKey, page.work_id, page.page_number, authToken, reocrStorageKey]);
 
   const applyReOcr = useCallback(() => {
     if (reocrText !== null) {


### PR DESCRIPTION
## Probleem

Pärast #190 ei monteeru editor lehe vahetusel enam maha (ADR 0010), aga `useReOcr` eeldas endiselt remounti: olek lähtestus ainult mount'il ja `.ocr` faili kontroll oli ühekordse `didCheckStoredJobRef` guardi taga.

- "Transkriptsioon käib" banner rippus kaasa igale järgmisele lehele
- uue lehe `.ocr` faili ei kontrollitud üldse
- vana lehe poll kirjutas valmiva tulemuse praeguse lehe olekusse — **"Rakenda" oleks kirjutanud võõra lehe teksti avatud dokumenti**

## Lahendus

- `reocrPageIdentity.ts` — puhas lehe-identiteedi tuletus (`work_id/failinimi`); `localStorage` võtme formaat muutmata, et pooleliolevad tööd leitaks üles
- `useReOcr` — mount-guardi asemel effect dep-listiga `[authToken, isAdmin, pageKey]`; `pageKeyRef` valvab iga async-vastuse ees
- `isAdmin` prop — `/admin/.../page-ocr` on admin-only; ilma selleta teeks per-lehe kontroll igal pöördel mitte-adminidele 403-päringu
- `PageCommentsPanel` sai `key={page.id}` — sama regressiooniperekond: kommentaari mustand jäi järgmisele lehele rippuma
- ADR 0010 "Tagajärjed" — muster kirja

## Kontroll

- `npm run typecheck` puhas, `npm test` 624/624 (55 faili), `npm run build` läbib
- Uued testid: `src/components/editor/__tests__/reocrPageIdentity.test.ts`
- Käsitsi testitud serveris: banner ei tule enam lehepöördel kaasa, tulemus ilmub ainult omal lehel

🤖 Generated with [Claude Code](https://claude.com/claude-code)