### PR TITLE
perf: muutusteta salvestus ei commiti ega indekseeri (#173)

### DIFF
--- a/docs/decisions/0012-muutusteta-salvestus-on-no-op.md
+++ b/docs/decisions/0012-muutusteta-salvestus-on-no-op.md
@@ -1,0 +1,83 @@
+# 0012 — Muutusteta salvestus on no-op: ei kirjuta, ei commiti, ei indekseeri
+
+**Staatus:** kehtib
+
+## Kontekst
+
+Salvestamine on tööriista sagedaseim kirjutav tegevus ja kasutajad vajutavad
+Ctrl+S harjumusest ka siis, kui midagi muutunud ei ole. Enne #173 maksis
+selline salvestus täishinna:
+
+- **Metaandmed.** Native Git CLI jättis tühja commiti küll vahele
+  (`save_with_git` → `is_noop`), kuid `save_work_metadata` ei vaadanud seda
+  tulemust. Järeltegevused — `work_collections_index.json`,
+  `person_to_works.json`, `works_creators_index.json`, Meilisearchi sünk,
+  Wikidata labelite rikastamine, cache'ide tühjendamine — käivitusid ikka.
+  Tootmismõõtmine: 122 ms serveripoolset tööd + ~0,6 s taustaindekseerimist
+  olematu muudatuse eest.
+
+- **Leheküljed.** Klient lööb igale salvestusele uue `updated_at` ajatempli
+  (`pageService.ts`). Git nägi seetõttu alati diffi ja tegi päris commiti:
+  ajalukku tekkis müra, mille diff koosnes ainult ajatemplist.
+
+Meilisearchi ja tuletatud indeksite mõttes on muutusteta salvestus definitsiooni
+järgi tühitöö: sisend on identne sellega, millest need indeksid juba ehitati.
+
+## Otsus
+
+1. **Võrdlus on semantiline, mitte serialiseeritud.** `server/save_diff.py`
+   võrdleb Pythoni struktuure (`old == new`), mitte `json.dumps` stringe.
+   Võtmete järjekord ega vormindus ei tekita valemuudatust; **loendi järjekord
+   loeb** (creators/collections järjestus on sisuline).
+
+2. **`save_work_metadata` tagastab `(meta, changed)`.** `changed=False` korral
+   lõpetab funktsioon enne Git commiti, tuletatud indekseid ja Meili sünki.
+   Kutsuja vastutab sellega seotud taustatööde vahelejätmise eest
+   (`/update-work-metadata` ei kutsu rikastamist ega `_invalidate_all_caches`).
+
+3. **Kaks kaitsekihti.** Semantiline võrdlus enne kirjutamist ja
+   `save_with_git` `is_noop` pärast — kui Git leiab, et kettal olev sisu on
+   juba sama, jäävad järeltegevused samuti tegemata.
+
+4. **`updated_at` on lenduv väli.** Lehekülje no-op võrdlus ignoreerib
+   `VOLATILE_PAGE_FIELDS` välju. Muutusteta salvestusel ei kirjutata uut
+   ajatemplit üldse kettale — muidu poleks võrdlus idempotentne ja iga teine
+   salvestus tekitaks commiti.
+
+5. **Puuduv fail on alati muudatus.** Uus lehekülg või puuduv
+   `_metadata.json` läheb alati kettale ja commiti, ka siis kui sisu on tühi
+   või kõik väljad filtreeriti välja.
+
+6. **UX ei muutu.** Endpoint vastab endiselt `{"status": "success"}`, lisaks
+   `changed: false`. Kasutaja jaoks õnnestub salvestus nagu varem.
+
+## Tagajärjed
+
+- **`save_work_metadata` kutsujad peavad tuple'i lahti pakkima.** Tagastustüüp
+  on `Tuple[dict, bool]`; kutsuja, kes ootab dict-i, saab vaikse vea. Uus
+  kutsuja peab otsustama, mida `changed=False` korral vahele jätta.
+
+- **Salvestuse taga peituv „paranda ise" ei tööta enam.** Kui teose
+  Meilisearchi dokument on kettaga lahku läinud (nt varasem ebaõnnestunud
+  taustasünk), ei paranda seda enam sama sisu uuesti salvestamine — no-op
+  jätab sünki tegemata. Taastamise teed on `scripts/server_seed_data.sh` ja
+  `sync_work_to_meilisearch` otsekutse. Kui lahknemine muutub sagedaseks,
+  vajab see eraldi kontrollitud parandusteed, mitte no-op'i tagasipööramist.
+
+- **`ensure_prosopo_stubs` jääb võrdlusest ettepoole.** See asendab
+  `updates`-is Wikidata Q-koodid `vutt:P` ID-dega, seega võrrelda saab alles
+  pärast seda. Stub-kaartide loomine on idempotentne, aga muutusteta
+  salvestusel siiski üleliigne — teadlik kompromiss võrdluse õigsuse kasuks.
+
+- **Lenduvate väljade nimekiri on üks koht.** Kui klient hakkab saatma uue
+  automaatse välja (nt `last_seen_by`), tuleb see lisada
+  `VOLATILE_PAGE_FIELDS`-i, muidu naaseb ajatempli-müra ajalukku.
+
+- **Ajalugu muutub hõredamaks.** Lehe ajaloo vaates ei teki enam kirjeid,
+  mille diff on ainult `updated_at`. See on eesmärk, mitte kõrvalmõju.
+
+## Viited
+
+- Issue #173 (koondülevaade #182)
+- `server/save_diff.py`, `server/metadata_ops.py`, `server/routers/editing.py`
+- Testid: `tests/test_save_noop.py`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -31,3 +31,4 @@ lisa uus kirje, mis viitab vanale („asendab 000X").
 | [0009](0009-marginaalia-iga-fuusiline-rida-eraldi.md) | Iga füüsiline marginaaliarida on eraldi `<m>` plokk | kehtib |
 | [0010](0010-lehe-vahetus-ei-monteeri-editorit-maha.md) | Lehe vahetus ei monteeri editorit maha; sisuvahetus on märgistatud | kehtib |
 | [0011](0011-i18n-keelepakid-laisalt-ilma-fallbackita.md) | i18n laeb ühe keele korraga; `fallbackLng` väljas + pariteeditest | kehtib |
+| [0012](0012-muutusteta-salvestus-on-no-op.md) | Muutusteta salvestus ei kirjuta, ei commiti ega indekseeri | kehtib |

--- a/server/metadata_ops.py
+++ b/server/metadata_ops.py
@@ -4,10 +4,11 @@ Metaandmete kirjutamise ühtne loogika.
 save_work_metadata() on ainus koht kus _metadata.json uuendatakse —
 git commit, person_to_works indeks ja Meilisearch sync ühes kohas.
 """
+import copy
 import json
 import os
 import time
-from typing import Callable
+from typing import Callable, Tuple
 
 from .config import get_logger
 from .utils import metadata_lock
@@ -15,6 +16,7 @@ from .git_ops import save_with_git
 from .meilisearch_ops import sync_work_to_meilisearch, sync_work_to_meilisearch_async
 from .prosopography.indices import update_person_to_works, update_work_collections
 from .prosopography.person_crud import ensure_prosopo_stubs
+from .save_diff import metadata_unchanged
 
 logger = get_logger(__name__)
 
@@ -123,7 +125,7 @@ def save_work_metadata(
     background_tasks=None,
     sync_meili: bool = True,
     call_ptw: bool = True,
-) -> dict:
+) -> Tuple[dict, bool]:
     """
     Kirjutab _metadata.json ja käivitab järeloperatsioonid.
 
@@ -138,7 +140,9 @@ def save_work_metadata(
       call_ptw        — True → kutsub update_person_to_works (nt tags/creators muutumisel)
                         False → jätab vahele (nt bulk-collection, bulk-genre)
 
-    Tagastab uuendatud meta dict-i.
+    Tagastab (meta, changed). changed=False tähendab, et salvestus oli sisuliselt
+    muutusteta — sel juhul jäävad Git commit, tuletatud indeksid ja Meilisearchi
+    sünk tegemata (#173).
     """
     started = time.monotonic()
     slug = os.path.basename(os.path.dirname(meta_path))
@@ -153,25 +157,41 @@ def save_work_metadata(
     stubs_done = time.monotonic()
 
     with metadata_lock:
-        if os.path.exists(meta_path):
+        file_existed = os.path.exists(meta_path)
+        if file_existed:
             with open(meta_path, "r", encoding="utf-8") as f:
                 meta = json.load(f)
         else:
             meta = {}
 
+        previous = copy.deepcopy(meta)
         clean = {k: v for k, v in updates.items() if k in ALLOWED_METADATA_FIELDS}
         meta.update(clean)
 
         for field in _V1_FIELDS:
             meta.pop(field, None)
 
-        save_with_git(
-            meta_path,
-            json.dumps(meta, indent=2, ensure_ascii=False),
-            username,
-            message=git_message,
-        )
+        changed = not file_existed or not metadata_unchanged(previous, meta)
+        if changed:
+            git_result = save_with_git(
+                meta_path,
+                json.dumps(meta, indent=2, ensure_ascii=False),
+                username,
+                message=git_message,
+            )
+            # Teine kaitsekiht: Git näeb faili baitidena ja võib leida, et kettal
+            # olev sisu on juba sama (nt vormindus). Siis on ka järeltegevused üleliigsed.
+            if isinstance(git_result, dict) and git_result.get("is_noop"):
+                changed = False
     git_done = time.monotonic()
+
+    if not changed:
+        logger.info(
+            "METADATA SAVE (%s): muutusteta — commit, indeksid ja Meili jäetakse vahele (%.0fms)",
+            slug,
+            (git_done - started) * 1000,
+        )
+        return meta, False
 
     # Kollektsioonid uuenevad ka bulk-collection teel (call_ptw=False) — tingimusteta
     update_work_collections(meta.get("id"), meta.get("collections") or [])
@@ -207,4 +227,4 @@ def save_work_metadata(
         (finished - collections_done) * 1000,
         sync_meili,
     )
-    return meta
+    return meta, True

--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -31,6 +31,7 @@ from ..meilisearch_ops import sync_work_to_meilisearch_async
 from ..metadata_ops import bulk_update_field, save_work_metadata
 from ..people_ops import process_person_fields_metadata
 from ..prosopography.relations import update_page_person_mentions
+from ..save_diff import page_content_unchanged
 from ..utils import find_directory_by_id
 router = APIRouter()
 
@@ -93,6 +94,8 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
 
     txt_path = os.path.join(BASE_DIR, catalog, filename)
     additional = []
+    json_path = None
+    meta_content = None
     if data.get('meta_content'):
         json_path = os.path.join(BASE_DIR, catalog, os.path.splitext(filename)[0] + ".json")
         meta_content = data['meta_content']
@@ -106,6 +109,11 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
             except Exception:
                 pass
         additional.append((json_path, json.dumps(meta_content, indent=2, ensure_ascii=False)))
+
+    # Muutusteta Ctrl+S: ei kirjuta kettale, ei commiti ega indekseeri (#173).
+    # Kliendi värske updated_at üksi ei ole muudatus — vt server/save_diff.py.
+    if await run_in_threadpool(page_content_unchanged, txt_path, text, json_path, meta_content):
+        return {"status": "success", "changed": False, "git_committed": True, "commit_hash": ""}
 
     git_result = await run_in_threadpool(
         save_with_git,
@@ -126,7 +134,7 @@ async def save(request: Request, background_tasks: BackgroundTasks, user=Depends
     if page_tag_qcodes:
         background_tasks.add_task(enrich_entity_labels_async_qcodes, page_tag_qcodes)
 
-    response = {"status": "success", "commit_hash": git_result.get("commit_hash", "")[:8], "git_committed": True}
+    response = {"status": "success", "changed": True, "commit_hash": git_result.get("commit_hash", "")[:8], "git_committed": True}
     if git_result.get("success") is False:
         response["git_committed"] = False
         response["warning"] = "Tekst salvestati kettale, aga Git versioonihalduse commit ebaõnnestus."
@@ -143,7 +151,7 @@ async def update_work_metadata(request: Request, background_tasks: BackgroundTas
     meta_path = os.path.join(path, '_metadata.json')
     slug = os.path.basename(path)
 
-    meta = await run_in_threadpool(
+    meta, changed = await run_in_threadpool(
         save_work_metadata,
         meta_path,
         data.get('metadata', {}),
@@ -155,10 +163,12 @@ async def update_work_metadata(request: Request, background_tasks: BackgroundTas
         sync_meili=False,
         call_ptw=True,
     )
-    background_tasks.add_task(process_person_fields_metadata, meta)
-    background_tasks.add_task(enrich_entity_labels_async, meta)
-    _invalidate_all_caches()
-    return {"status": "success"}
+    # Muutusteta salvestus ei vaja rikastamist ega cache'ide tühjendamist (#173).
+    if changed:
+        background_tasks.add_task(process_person_fields_metadata, meta)
+        background_tasks.add_task(enrich_entity_labels_async, meta)
+        _invalidate_all_caches()
+    return {"status": "success", "changed": changed}
 
 @router.post("/get-work-metadata")
 async def get_work_meta_direct(request: Request, user=Depends(require_role("editor"))):

--- a/server/save_diff.py
+++ b/server/save_diff.py
@@ -1,0 +1,60 @@
+"""
+Muutusteta salvestuse tuvastamine (#173).
+
+Kui salvestus ei muuda ühtegi sisulist välja, ei tohi järgneda Git commit,
+tuletatud indeksite ümberkirjutamine ega Meilisearchi sünk. Võrdlus on
+semantiline (Pythoni struktuuride võrdlus), mitte serialiseeritud JSON-i
+stringivõrdlus — võtmete järjekord ega vormindus ei loe, loendi järjekord loeb.
+"""
+import json
+import os
+
+# Klient lööb igale lehekülje salvestusele uue ajatempli. Ainuüksi see ei ole
+# sisuline muudatus, muidu tekitaks iga juhuslik Ctrl+S uue commiti.
+VOLATILE_PAGE_FIELDS = ("updated_at",)
+
+
+def metadata_unchanged(old: dict, new: dict) -> bool:
+    """True kui kaks metaandmete dict-i on sisuliselt samad."""
+    return old == new
+
+
+def _read_json(path: str):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _without_volatile(meta: dict) -> dict:
+    return {k: v for k, v in meta.items() if k not in VOLATILE_PAGE_FIELDS}
+
+
+def page_content_unchanged(txt_path: str, text: str, json_path, meta_content) -> bool:
+    """
+    True kui lehekülje tekst JA meta vastavad juba kettal olevale sisule.
+
+    Puuduv fail on alati muudatus — uus lehekülg peab kettale ja commiti jõudma.
+    Vigast/loetamatut JSON-i käsitleme samuti muudatusena, et salvestus selle üle
+    kirjutaks.
+    """
+    if not os.path.exists(txt_path):
+        return False
+    try:
+        with open(txt_path, "r", encoding="utf-8") as f:
+            if f.read() != text:
+                return False
+    except OSError:
+        return False
+
+    if meta_content is None or not json_path:
+        return True
+
+    if not os.path.exists(json_path):
+        return False
+    try:
+        on_disk = _read_json(json_path)
+    except (OSError, ValueError):
+        return False
+    if not isinstance(on_disk, dict) or not isinstance(meta_content, dict):
+        return False
+
+    return _without_volatile(on_disk) == _without_volatile(meta_content)

--- a/tests/test_async_endpoint_offload.py
+++ b/tests/test_async_endpoint_offload.py
@@ -146,7 +146,7 @@ def test_metadata_save_jookseb_threadpoolis(monkeypatch):
         seen["thread"] = _worker_thread_name()
         seen["sync_meili"] = kwargs.get("sync_meili")
         seen["background_tasks"] = kwargs.get("background_tasks")
-        return {"id": "w1"}
+        return {"id": "w1"}, True
 
     monkeypatch.setattr(editing, "save_work_metadata", fake_save)
     monkeypatch.setattr(editing, "process_person_fields_metadata", lambda *_a: None)
@@ -159,7 +159,7 @@ def test_metadata_save_jookseb_threadpoolis(monkeypatch):
         user={"username": "admin", "role": "admin"},
     ))
 
-    assert result == {"status": "success"}
+    assert result == {"status": "success", "changed": True}
     assert seen["thread"] != MAIN_THREAD
     assert seen["sync_meili"] is False
     assert isinstance(seen["background_tasks"], BackgroundTasks)

--- a/tests/test_save_noop.py
+++ b/tests/test_save_noop.py
@@ -1,0 +1,366 @@
+"""Muutusteta salvestus ei tohi teha commiti, tuletatud indekseid ega Meili sünki (#173)."""
+import asyncio
+import json
+
+import pytest
+from fastapi import BackgroundTasks
+from starlette.requests import Request
+
+from server.routers import editing
+
+
+def _json_request(body: bytes) -> Request:
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-type", b"application/json")],
+        "path": "/",
+        "query_string": b"",
+    }
+    return Request(scope, receive)
+
+
+# =========================================================
+# Puhtad võrdlusfunktsioonid
+# =========================================================
+
+def test_metadata_unchanged_ignores_key_order():
+    from server.save_diff import metadata_unchanged
+
+    old = {"title": "T", "year": 1632, "tags": [{"label": "a", "id": "Q1"}]}
+    new = {"year": 1632, "tags": [{"id": "Q1", "label": "a"}], "title": "T"}
+
+    assert metadata_unchanged(old, new) is True
+
+
+def test_metadata_unchanged_false_when_value_differs():
+    from server.save_diff import metadata_unchanged
+
+    assert metadata_unchanged({"title": "T"}, {"title": "T2"}) is False
+
+
+def test_metadata_unchanged_false_when_list_order_differs():
+    """Loendi järjekord on sisuline (nt creators) — see EI ole no-op."""
+    from server.save_diff import metadata_unchanged
+
+    old = {"collections": ["a", "b"]}
+    new = {"collections": ["b", "a"]}
+
+    assert metadata_unchanged(old, new) is False
+
+
+def test_page_content_unchanged_ignores_updated_at(tmp_path):
+    """Frontend lisab igale salvestusele uue updated_at — see üksi ei ole muudatus."""
+    from server.save_diff import page_content_unchanged
+
+    txt = tmp_path / "page.txt"
+    txt.write_text("tekst", encoding="utf-8")
+    js = tmp_path / "page.json"
+    js.write_text(json.dumps({"status": "Valmis", "updated_at": "2026-01-01T00:00:00"}), encoding="utf-8")
+
+    assert page_content_unchanged(
+        str(txt), "tekst", str(js), {"status": "Valmis", "updated_at": "2026-07-26T12:00:00"}
+    ) is True
+
+
+def test_page_content_unchanged_false_when_text_differs(tmp_path):
+    from server.save_diff import page_content_unchanged
+
+    txt = tmp_path / "page.txt"
+    txt.write_text("tekst", encoding="utf-8")
+    js = tmp_path / "page.json"
+    js.write_text(json.dumps({"status": "Valmis"}), encoding="utf-8")
+
+    assert page_content_unchanged(str(txt), "muudetud tekst", str(js), {"status": "Valmis"}) is False
+
+
+def test_page_content_unchanged_false_when_meta_differs(tmp_path):
+    from server.save_diff import page_content_unchanged
+
+    txt = tmp_path / "page.txt"
+    txt.write_text("tekst", encoding="utf-8")
+    js = tmp_path / "page.json"
+    js.write_text(json.dumps({"status": "Toores", "updated_at": "2026-01-01T00:00:00"}), encoding="utf-8")
+
+    assert page_content_unchanged(
+        str(txt), "tekst", str(js), {"status": "Valmis", "updated_at": "2026-07-26T12:00:00"}
+    ) is False
+
+
+def test_page_content_unchanged_false_when_file_missing(tmp_path):
+    """Uus lehekülg peab alati kettale ja commiti jõudma."""
+    from server.save_diff import page_content_unchanged
+
+    txt = tmp_path / "page.txt"
+    js = tmp_path / "page.json"
+
+    assert page_content_unchanged(str(txt), "tekst", str(js), {"status": "Toores"}) is False
+
+
+def test_page_content_unchanged_without_meta(tmp_path):
+    """Kui klient meta_content'i ei saada, otsustab ainult tekst."""
+    from server.save_diff import page_content_unchanged
+
+    txt = tmp_path / "page.txt"
+    txt.write_text("tekst", encoding="utf-8")
+
+    assert page_content_unchanged(str(txt), "tekst", None, None) is True
+    assert page_content_unchanged(str(txt), "muu", None, None) is False
+
+
+# =========================================================
+# save_work_metadata
+# =========================================================
+
+@pytest.fixture
+def meta_work(tmp_path, monkeypatch):
+    """Teose kaust koos _metadata.json-iga ja kõigi järeltegevuste spioonidega."""
+    from server import metadata_ops
+
+    work_dir = tmp_path / "teos"
+    work_dir.mkdir()
+    meta_path = work_dir / "_metadata.json"
+    meta_path.write_text(
+        json.dumps({"id": "w1", "title": "Teos", "year": 1632, "collections": ["c1"]}),
+        encoding="utf-8",
+    )
+
+    calls = {"git": 0, "collections": 0, "ptw": 0, "meili": 0}
+    monkeypatch.setattr(metadata_ops, "save_with_git", lambda *a, **k: calls.__setitem__("git", calls["git"] + 1))
+    monkeypatch.setattr(
+        metadata_ops, "update_work_collections",
+        lambda *a, **k: calls.__setitem__("collections", calls["collections"] + 1),
+    )
+    monkeypatch.setattr(
+        metadata_ops, "update_person_to_works",
+        lambda *a, **k: calls.__setitem__("ptw", calls["ptw"] + 1),
+    )
+    monkeypatch.setattr(
+        metadata_ops, "sync_work_to_meilisearch",
+        lambda *a, **k: calls.__setitem__("meili", calls["meili"] + 1),
+    )
+    return str(meta_path), calls
+
+
+def test_save_work_metadata_skips_everything_when_unchanged(meta_work):
+    from server.metadata_ops import save_work_metadata
+
+    meta_path, calls = meta_work
+    meta, changed = save_work_metadata(
+        meta_path, {"title": "Teos", "year": 1632}, "tester", "Meta: teos",
+        sync_meili=True, call_ptw=True,
+    )
+
+    assert changed is False
+    assert meta["title"] == "Teos"
+    assert calls == {"git": 0, "collections": 0, "ptw": 0, "meili": 0}
+
+
+def test_save_work_metadata_runs_followups_when_changed(meta_work):
+    from server.metadata_ops import save_work_metadata
+
+    meta_path, calls = meta_work
+    meta, changed = save_work_metadata(
+        meta_path, {"title": "Uus pealkiri"}, "tester", "Meta: teos",
+        sync_meili=True, call_ptw=True,
+    )
+
+    assert changed is True
+    assert meta["title"] == "Uus pealkiri"
+    assert calls == {"git": 1, "collections": 1, "ptw": 1, "meili": 1}
+
+
+def test_save_work_metadata_ignores_disallowed_field_as_change(meta_work):
+    """Lubamatu väli filtreeritakse välja → sisuliselt muutusteta salvestus."""
+    from server.metadata_ops import save_work_metadata
+
+    meta_path, calls = meta_work
+    _meta, changed = save_work_metadata(meta_path, {"kurjus": "x"}, "tester", "Meta: teos")
+
+    assert changed is False
+    assert calls["git"] == 0
+
+
+def test_save_work_metadata_v1_field_removal_is_change(tmp_path, monkeypatch):
+    """Vana v1 välja eemaldamine on päris muudatus ja peab commitima."""
+    from server import metadata_ops
+
+    work_dir = tmp_path / "teos"
+    work_dir.mkdir()
+    meta_path = work_dir / "_metadata.json"
+    meta_path.write_text(json.dumps({"id": "w1", "title": "T", "pealkiri": "vana"}), encoding="utf-8")
+
+    calls = {"git": 0}
+    monkeypatch.setattr(metadata_ops, "save_with_git", lambda *a, **k: calls.__setitem__("git", 1))
+    monkeypatch.setattr(metadata_ops, "update_work_collections", lambda *a, **k: None)
+    monkeypatch.setattr(metadata_ops, "update_person_to_works", lambda *a, **k: None)
+    monkeypatch.setattr(metadata_ops, "sync_work_to_meilisearch", lambda *a, **k: None)
+
+    _meta, changed = metadata_ops.save_work_metadata(str(meta_path), {"title": "T"}, "tester", "Meta")
+
+    assert changed is True
+    assert calls["git"] == 1
+
+
+def test_save_work_metadata_new_file_is_change(tmp_path, monkeypatch):
+    from server import metadata_ops
+
+    work_dir = tmp_path / "teos"
+    work_dir.mkdir()
+    meta_path = work_dir / "_metadata.json"
+
+    calls = {"git": 0}
+    monkeypatch.setattr(metadata_ops, "save_with_git", lambda *a, **k: calls.__setitem__("git", 1))
+    monkeypatch.setattr(metadata_ops, "update_work_collections", lambda *a, **k: None)
+    monkeypatch.setattr(metadata_ops, "update_person_to_works", lambda *a, **k: None)
+    monkeypatch.setattr(metadata_ops, "sync_work_to_meilisearch", lambda *a, **k: None)
+
+    _meta, changed = metadata_ops.save_work_metadata(str(meta_path), {"title": "T"}, "tester", "Meta")
+
+    assert changed is True
+    assert calls["git"] == 1
+
+
+# =========================================================
+# Endpointid
+# =========================================================
+
+def test_update_work_metadata_returns_changed_false(monkeypatch):
+    """Muutusteta metaandmete salvestus ei käivita rikastamist ega cache-invalidatsiooni."""
+    background = {"tasks": 0}
+    monkeypatch.setattr(editing, "find_directory_by_id", lambda _wid: "/tmp/work")
+    monkeypatch.setattr(editing, "save_work_metadata", lambda *a, **k: ({"id": "w1"}, False))
+    monkeypatch.setattr(editing, "process_person_fields_metadata", lambda *_a: None)
+    monkeypatch.setattr(editing, "enrich_entity_labels_async", lambda *_a: None)
+    monkeypatch.setattr(editing, "_invalidate_all_caches", lambda: background.__setitem__("caches", True))
+
+    tasks = BackgroundTasks()
+    result = asyncio.run(editing.update_work_metadata(
+        _json_request(b'{"work_id":"w1","metadata":{"title":"T"}}'),
+        tasks,
+        user={"username": "admin", "role": "admin"},
+    ))
+
+    assert result == {"status": "success", "changed": False}
+    assert tasks.tasks == []
+    assert "caches" not in background
+
+
+def test_update_work_metadata_returns_changed_true(monkeypatch):
+    monkeypatch.setattr(editing, "find_directory_by_id", lambda _wid: "/tmp/work")
+    monkeypatch.setattr(editing, "save_work_metadata", lambda *a, **k: ({"id": "w1"}, True))
+    monkeypatch.setattr(editing, "process_person_fields_metadata", lambda *_a: None)
+    monkeypatch.setattr(editing, "enrich_entity_labels_async", lambda *_a: None)
+    monkeypatch.setattr(editing, "_invalidate_all_caches", lambda: None)
+
+    tasks = BackgroundTasks()
+    result = asyncio.run(editing.update_work_metadata(
+        _json_request(b'{"work_id":"w1","metadata":{"title":"T"}}'),
+        tasks,
+        user={"username": "admin", "role": "admin"},
+    ))
+
+    assert result == {"status": "success", "changed": True}
+    assert len(tasks.tasks) == 2
+
+
+def _page_env(tmp_path, monkeypatch, *, text="tekst", meta=None):
+    monkeypatch.setattr(editing, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(editing, "_require_catalog_access", lambda *a, **k: {"id": "w1"})
+    work_dir = tmp_path / "teos"
+    work_dir.mkdir()
+    (work_dir / "page.txt").write_text(text, encoding="utf-8")
+    (work_dir / "page.json").write_text(
+        json.dumps(meta if meta is not None else {"status": "Valmis", "updated_at": "2026-01-01T00:00:00"}),
+        encoding="utf-8",
+    )
+    calls = {"git": 0}
+    monkeypatch.setattr(editing, "save_with_git", lambda *a, **k: calls.__setitem__("git", calls["git"] + 1) or {"commit_hash": "abc1234def"})
+    return calls
+
+
+def test_save_page_unchanged_skips_git_and_background(tmp_path, monkeypatch):
+    calls = _page_env(tmp_path, monkeypatch)
+
+    payload = json.dumps({
+        "original_path": "teos",
+        "file_name": "page.txt",
+        "text_content": "tekst",
+        "meta_content": {"status": "Valmis", "updated_at": "2026-07-26T12:00:00"},
+        "work_id": "w1",
+    }).encode()
+
+    tasks = BackgroundTasks()
+    result = asyncio.run(editing.save(
+        _json_request(payload), tasks, user={"username": "editor", "role": "editor"},
+    ))
+
+    assert result["status"] == "success"
+    assert result["changed"] is False
+    assert calls["git"] == 0
+    assert tasks.tasks == []
+    # updated_at ei tohi kettale jõuda
+    on_disk = json.loads((tmp_path / "teos" / "page.json").read_text(encoding="utf-8"))
+    assert on_disk["updated_at"] == "2026-01-01T00:00:00"
+
+
+def test_metadata_save_twice_creates_one_commit(tmp_path, monkeypatch):
+    """Otsast-otsani päris Git repoga: teine identne salvestus ei lisa commiti."""
+    import git
+
+    from server import git_ops, metadata_ops
+
+    repo = git.Repo.init(str(tmp_path))
+    seed = tmp_path / "seed.txt"
+    seed.write_text("seed", encoding="utf-8")
+    repo.index.add(["seed.txt"])
+    actor = git.Actor("seed", "seed@vutt.local")
+    repo.index.commit("seed", author=actor, committer=actor)
+
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: repo)
+    monkeypatch.setattr(metadata_ops, "update_work_collections", lambda *a, **k: None)
+    monkeypatch.setattr(metadata_ops, "update_person_to_works", lambda *a, **k: None)
+    monkeypatch.setattr(metadata_ops, "sync_work_to_meilisearch", lambda *a, **k: None)
+
+    work_dir = tmp_path / "teos"
+    work_dir.mkdir()
+    meta_path = work_dir / "_metadata.json"
+    meta_path.write_text(json.dumps({"id": "w1", "title": "Vana"}), encoding="utf-8")
+
+    _m, first = metadata_ops.save_work_metadata(
+        str(meta_path), {"title": "Uus"}, "editor", "Meta: teos", sync_meili=False,
+    )
+    after_first = repo.head.commit.hexsha
+
+    _m, second = metadata_ops.save_work_metadata(
+        str(meta_path), {"title": "Uus"}, "editor", "Meta: teos", sync_meili=False,
+    )
+
+    assert (first, second) == (True, False)
+    assert repo.head.commit.hexsha == after_first
+    assert json.loads(meta_path.read_text(encoding="utf-8"))["title"] == "Uus"
+
+
+def test_save_page_changed_text_commits(tmp_path, monkeypatch):
+    calls = _page_env(tmp_path, monkeypatch)
+
+    payload = json.dumps({
+        "original_path": "teos",
+        "file_name": "page.txt",
+        "text_content": "uus tekst",
+        "meta_content": {"status": "Valmis", "updated_at": "2026-07-26T12:00:00"},
+        "work_id": "w1",
+    }).encode()
+
+    tasks = BackgroundTasks()
+    result = asyncio.run(editing.save(
+        _json_request(payload), tasks, user={"username": "editor", "role": "editor"},
+    ))
+
+    assert result["changed"] is True
+    assert calls["git"] == 1
+    assert len(tasks.tasks) >= 1


### PR DESCRIPTION
Sulgeb #173 (koondülevaade #182).

## Probleem

Muutusteta Ctrl+S maksis täishinna:

- **Metaandmed** — `save_with_git` jättis tühja commiti vahele (`is_noop`), aga `save_work_metadata` ei vaadanud seda tulemust: `work_collections_index.json`, `person_to_works.json`, Meili sünk, Wikidata labelite rikastamine ja cache-invalidatsioon jooksid ikka. Mõõdetud tootmises: 122 ms + ~0,6 s taustaindekseerimist olematu muudatuse eest.
- **Leheküljed** — klient lööb igale salvestusele uue `updated_at` (`pageService.ts`), seega nägi Git alati diffi. Ajalukku tekkis müra, mille diff on ainult ajatempel.

## Lahendus

**`server/save_diff.py`** (uus) — võrdlus on semantiline, mitte serialiseeritud:

- `metadata_unchanged(old, new)` — Pythoni struktuuride võrdlus. Võtmete järjekord/vormindus ei loe, **loendi järjekord loeb** (creators/collections järjestus on sisuline).
- `page_content_unchanged(...)` — ignoreerib `VOLATILE_PAGE_FIELDS = ("updated_at",)`. Puuduv või vigane fail on alati muudatus.

**`save_work_metadata` tagastab `(meta, changed)`** ja lõpetab `changed=False` korral enne commiti, tuletatud indekseid ja Meili sünki. Kaks kaitsekihti: semantiline võrdlus enne kirjutamist, `save_with_git` `is_noop` pärast.

**Endpointid** — `/save` ei kirjuta muutusteta lehte kettale ega lisa taustatöid; `/update-work-metadata` ei käivita rikastamist ega `_invalidate_all_caches()`-i. Mõlemad tagastavad `changed`; UX jääb samaks (`status: success`).

**ADR 0012** dokumenteerib invariandid.

## Frontend

Muudatust ei vaja — `pageService.ts` ei kasuta `commit_hash`-i ega `git_committed`-it ja edu-UX ei muutu.

## Teadlikud kompromissid

1. **Salvestamine ei paranda enam Meili lahknemist.** Kui teose Meili dokument on kettaga lahku läinud (nt varasem ebaõnnestunud taustasünk), ei aita sama sisu uuesti salvestada. Taastetee: `./scripts/server_seed_data.sh` või `sync_work_to_meilisearch` otsekutse. Kirjas ADR 0012 tagajärgedes.
2. **`ensure_prosopo_stubs` jääb võrdlusest ettepoole** — see asendab `updates`-is Q-koodid `vutt:P` ID-dega, seega võrrelda saab alles pärast. Idempotentne, aga no-op salvestusel siiski üleliigne.

## Testid

18 uut (`tests/test_save_noop.py`): puhtad võrdlusfunktsioonid, `save_work_metadata` no-op/muudatus/uus fail/v1-välja eemaldus, mõlemad endpointid, ja otsast-otsani test **päris Git repoga** (teine identne salvestus ei lisa commiti). Kogu komplekt: 959 passed.

`tests/test_async_endpoint_offload.py` fake uuendatud uuele tuple-tagastusele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)