### PR TITLE
perf: bulk-metaandmed ühte commiti + garanteeritud Meili sünk (#175)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,8 @@ docker compose ps
 
 Frontend deploy (pärast `npm run build` lokaalses masinas):
 ```bash
-rsync -avz dist/ vutt:~/VUTT/dist/
+# --delete on tahtlik: ilma selleta kogunevad serverisse vanad hashitud chunk-failid
+rsync -avz --delete dist/ vutt:~/VUTT/dist/
 ```
 
 ## Architecture

--- a/docs/decisions/0012-muutusteta-salvestus-on-no-op.md
+++ b/docs/decisions/0012-muutusteta-salvestus-on-no-op.md
@@ -76,8 +76,29 @@ järgi tühitöö: sisend on identne sellega, millest need indeksid juba ehitati
 - **Ajalugu muutub hõredamaks.** Lehe ajaloo vaates ei teki enam kirjeid,
   mille diff on ainult `updated_at`. See on eesmärk, mitte kõrvalmõju.
 
+## Laiendus: bulk-operatsioonid (#175)
+
+Sama võrdlus kehtib bulk-teel (`bulk_update_works`), kuid seal lisandub üks
+tugevam reegel:
+
+- **Meilisearchi sünk EI OLE bulk-teel lipuga valitav.** Varem oli
+  `bulk_update_field(sync_meili=False)` vaikimisi ja ükski kolmest bulk-endpointist
+  seda ei tõstnud — kollektsiooni, märksõnade ja žanri massimuudatused ei jõudnud
+  kunagi otsinguindeksisse ja dashboardi filtrid jäid vanaks kuni järgmise
+  üksiksalvestuse või reseed'ini. Iga päriselt muutunud teos saab nüüd täpselt ühe
+  sünki, olenemata sellest, mitu korda ta partiis esineb.
+
+- **Üks partii = üks Git commit.** Kõik muutunud `_metadata.json` failid lähevad
+  ühte path-skoobitud commiti (`save_with_git(..., additional_files=...)`).
+  Commiti sõnum loendab teoseid, mitte ei nimeta üht work_id-d.
+
+- **Osaline ebaõnnestumine ei katkesta partiid.** Vigase transformi või
+  loetamatu faili korral jääb SEE teos tervikuna kirjutamata (pooleli jäänud
+  transform võis meta juba osaliselt muuta) ja ülejäänud partii läheb edasi.
+  Endpoint tagastab `updated/skipped/failed`.
+
 ## Viited
 
-- Issue #173 (koondülevaade #182)
+- Issue #173, #175 (koondülevaade #182)
 - `server/save_diff.py`, `server/metadata_ops.py`, `server/routers/editing.py`
-- Testid: `tests/test_save_noop.py`
+- Testid: `tests/test_save_noop.py`, `tests/test_bulk_atomicity.py`

--- a/server/metadata_ops.py
+++ b/server/metadata_ops.py
@@ -8,7 +8,7 @@ import copy
 import json
 import os
 import time
-from typing import Callable, Tuple
+from typing import Callable, Iterable, Tuple
 
 from .config import get_logger
 from .utils import metadata_lock
@@ -54,66 +54,116 @@ def clean_archive_refs(value):
 _V1_FIELDS = ["pealkiri", "aasta", "koht", "trükkal", "autor", "respondens"]
 
 
-def bulk_update_field(
-    meta_path: str,
-    transform: Callable[[dict], dict],
+def bulk_update_works(
+    items: Iterable[Tuple[str, Callable[[dict], dict]]],
     username: str,
     git_message: str,
     *,
     background_tasks=None,
-    sync_meili: bool = False,
     call_ptw: bool = False,
-) -> None:
+) -> dict:
     """
-    Atomaarne bulk-uuendus: loeb, transformeerib ja kirjutab ühe metadata_lock tsükliga.
-    Väldib TOCTOU akent, mis tekib eraldi loe+kirjuta kutsete vahel.
+    Atomaarne bulk-uuendus mitmele teosele: üks lukutsükkel, üks Git commit.
 
-    transform(current_meta) → dict of field updates to apply.
+    items — järjend `(meta_path, transform)` paare; `transform(current_meta)`
+    tagastab rakendatavad väljad. Iga teos loetakse ja transformeeritakse sama
+    `metadata_lock` all, mis väldib TOCTOU akent loe+kirjuta vahel.
+
+    Muutusteta teosed jäetakse vahele (vt ADR 0012). Kõik päriselt muutunud
+    failid kirjutatakse ja commititakse ÜHE path-skoobitud commitina, misjärel
+    iga unikaalne teos saab täpselt ühe Meilisearchi sünki — bulk-muudatus ei
+    tohi jätta otsinguindeksit failisüsteemist maha (#175).
+
+    Tagastab loendurid `{"updated": n, "skipped": n, "failed": n}`.
     """
-    if not os.path.exists(meta_path):
-        return
+    originals = {}   # meta_path -> kettalt loetud seis
+    pending = {}     # meta_path -> jooksev seis (kordused ahelduvad)
+    order = []       # unikaalsed teed sisendjärjekorras
+    failed_paths = set()
 
     with metadata_lock:
-        with open(meta_path, "r", encoding="utf-8") as f:
-            meta = json.load(f)
+        for meta_path, transform in items:
+            if meta_path not in pending:
+                if not os.path.exists(meta_path):
+                    failed_paths.add(meta_path)
+                    logger.warning("BULK: metaandmete faili ei leitud: %s", meta_path)
+                    continue
+                try:
+                    with open(meta_path, "r", encoding="utf-8") as f:
+                        meta = json.load(f)
+                except Exception as e:
+                    failed_paths.add(meta_path)
+                    logger.warning("BULK: metaandmeid ei saa lugeda (%s): %s", meta_path, e)
+                    continue
+                originals[meta_path] = copy.deepcopy(meta)
+                pending[meta_path] = meta
+                order.append(meta_path)
 
-        updates = transform(meta)
-        clean = {k: v for k, v in updates.items() if k in ALLOWED_METADATA_FIELDS}
-        meta.update(clean)
-        for field in _V1_FIELDS:
-            meta.pop(field, None)
+            meta = pending[meta_path]
+            try:
+                updates = transform(meta)
+                clean = {k: v for k, v in updates.items() if k in ALLOWED_METADATA_FIELDS}
+                meta.update(clean)
+                for field in _V1_FIELDS:
+                    meta.pop(field, None)
+            except Exception as e:
+                # Pooleli jäänud transform võis meta juba osaliselt muuta — see teos
+                # jääb tervikuna kirjutamata, ülejäänud partii läheb edasi.
+                failed_paths.add(meta_path)
+                logger.warning("BULK: teose uuendamine ebaõnnestus (%s): %s", meta_path, e)
 
-        save_with_git(
-            meta_path,
-            json.dumps(meta, indent=2, ensure_ascii=False),
-            username,
-            message=git_message,
-        )
+        usable = [p for p in order if p not in failed_paths]
+        changed = [p for p in usable if not metadata_unchanged(originals[p], pending[p])]
+        skipped = len(usable) - len(changed)
+        failed = len(failed_paths)
 
-    slug = os.path.basename(os.path.dirname(meta_path))
+        if changed:
+            first_path = changed[0]
+            extra = [
+                (path, json.dumps(pending[path], indent=2, ensure_ascii=False))
+                for path in changed[1:]
+            ]
+            save_with_git(
+                first_path,
+                json.dumps(pending[first_path], indent=2, ensure_ascii=False),
+                username,
+                message=git_message,
+                additional_files=extra or None,
+            )
 
-    # Kollektsioonid uuenevad ka bulk-collection teel (call_ptw=False) — tingimusteta
-    update_work_collections(meta.get("id"), meta.get("collections") or [])
+    # Tuletatud indeksid ja sünk ainult päriselt muutunud teostele, üks kord teose kohta.
+    for meta_path in changed:
+        meta = pending[meta_path]
+        slug = os.path.basename(os.path.dirname(meta_path))
 
-    if call_ptw:
-        ptw_args = (
-            meta.get("id"),
-            meta.get("creators", []),
-            meta.get("tags") or [],
-            meta.get("publisher"),
-            meta.get("title") or "",
-            meta.get("year"),
-        )
-        if background_tasks is not None:
-            background_tasks.add_task(update_person_to_works, *ptw_args)
-        else:
-            update_person_to_works(*ptw_args)
+        update_work_collections(meta.get("id"), meta.get("collections") or [])
 
-    if sync_meili:
+        if call_ptw:
+            ptw_args = (
+                meta.get("id"),
+                meta.get("creators", []),
+                meta.get("tags") or [],
+                meta.get("publisher"),
+                meta.get("title") or "",
+                meta.get("year"),
+            )
+            if background_tasks is not None:
+                background_tasks.add_task(update_person_to_works, *ptw_args)
+            else:
+                update_person_to_works(*ptw_args)
+
+        # Meilisearchi sünk on kohustuslik, mitte lipuga valitav: ilma selleta
+        # jäävad dashboardi filtrid failisüsteemist maha (#175).
         if background_tasks is not None:
             background_tasks.add_task(sync_work_to_meilisearch_async, slug)
         else:
             sync_work_to_meilisearch(slug)
+
+    logger.info(
+        "BULK: %s — uuendatud=%d vahele jäetud=%d ebaõnnestus=%d",
+        git_message, len(changed), skipped, failed,
+    )
+    return {"updated": len(changed), "skipped": skipped, "failed": failed}
 
 
 def save_work_metadata(

--- a/server/routers/editing.py
+++ b/server/routers/editing.py
@@ -28,7 +28,7 @@ from ..git_ops import (
 )
 from ..marginalia_normalize import normalize_marginalia_tags
 from ..meilisearch_ops import sync_work_to_meilisearch_async
-from ..metadata_ops import bulk_update_field, save_work_metadata
+from ..metadata_ops import bulk_update_works, save_work_metadata
 from ..people_ops import process_person_fields_metadata
 from ..prosopography.relations import update_page_person_mentions
 from ..save_diff import page_content_unchanged
@@ -190,6 +190,40 @@ async def metadata_suggestions(request: Request, user=Depends(require_role("edit
 # =========================================================
 # GIT AJALUGU JA BULK
 # =========================================================
+
+def _resolve_bulk_items(work_ids, transform):
+    """Lahendab work_id-d meta-teedeks. Tagastab (items, tundmatud_arv).
+
+    Failisüsteemi skaneering (`find_directory_by_id`) käib threadpoolis, mitte
+    event-loopis (ADR 0002).
+    """
+    items = []
+    unknown = 0
+    for work_id in work_ids or []:
+        path = find_directory_by_id(work_id)
+        meta_path = os.path.join(path, '_metadata.json') if path else None
+        if meta_path and os.path.exists(meta_path):
+            items.append((meta_path, transform))
+        else:
+            unknown += 1
+    return items, unknown
+
+
+async def _run_bulk(work_ids, transform, username, label, background_tasks, *, call_ptw=False):
+    """Ühine bulk-tee: üks commit, garanteeritud Meili sünk, loendurid (#175)."""
+    items, unknown = await run_in_threadpool(_resolve_bulk_items, work_ids, transform)
+    counts = await run_in_threadpool(
+        bulk_update_works,
+        items,
+        username,
+        f"{label}: {len(items)} teost",
+        background_tasks=background_tasks,
+        call_ptw=call_ptw,
+    )
+    counts["failed"] += unknown
+    _invalidate_all_caches()
+    return {"status": "success", **counts}
+
 
 @router.get("/recent-edits")
 async def recent_edits(request: Request, user=Depends(get_user)):
@@ -402,33 +436,23 @@ async def bulk_collection(request: Request, background_tasks: BackgroundTasks, u
     mode = data.get('mode', 'set')
     collection_id = data.get('collection_id') or data.get('collection')
 
-    for work_id in data.get('work_ids', []):
-        path = find_directory_by_id(work_id)
-        if not (path and os.path.exists(os.path.join(path, '_metadata.json'))): continue
+    def make_transform(coll_id=collection_id, m=mode):
+        def transform(meta):
+            current = meta.get('collections', [])
+            if m == 'add':
+                if coll_id and coll_id not in current:
+                    return {'collections': current + [coll_id]}
+                return {'collections': current}
+            elif m == 'remove':
+                return {'collections': [c for c in current if c != coll_id]}
+            else:  # set
+                return {'collections': [coll_id] if coll_id else []}
+        return transform
 
-        def make_transform(coll_id=collection_id, m=mode):
-            def transform(meta):
-                current = meta.get('collections', [])
-                if m == 'add':
-                    if coll_id and coll_id not in current:
-                        return {'collections': current + [coll_id]}
-                    return {'collections': current}
-                elif m == 'remove':
-                    return {'collections': [c for c in current if c != coll_id]}
-                else:  # set
-                    return {'collections': [coll_id] if coll_id else []}
-            return transform
-
-        await run_in_threadpool(
-            bulk_update_field,
-            os.path.join(path, '_metadata.json'),
-            make_transform(),
-            user['username'],
-            f"Bulk collection: {work_id}",
-            background_tasks=background_tasks,
-        )
-    _invalidate_all_caches()
-    return {"status": "success"}
+    return await _run_bulk(
+        data.get('work_ids', []), make_transform(), user['username'],
+        "Bulk collection", background_tasks,
+    )
 
 @router.post("/works/bulk-tags")
 async def bulk_tags(request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("admin"))):
@@ -436,40 +460,29 @@ async def bulk_tags(request: Request, background_tasks: BackgroundTasks, user=De
     tags_to_update = data.get('tags', [])
     tag_mode = data.get('mode', 'set')
 
-    for work_id in data.get('work_ids', []):
-        path = find_directory_by_id(work_id)
-        if not (path and os.path.exists(os.path.join(path, '_metadata.json'))): continue
+    def make_transform(mode=tag_mode, new_tags=tags_to_update):
+        def transform(meta):
+            cur = list(meta.get('tags', []))
+            if mode == 'add':
+                for t in new_tags:
+                    if t not in cur:
+                        cur.append(t)
+            elif mode == 'remove':
+                remove_ids = {t['id'] for t in new_tags if t.get('id')}
+                remove_labels = {t.get('label', '').lower() for t in new_tags if not t.get('id')}
+                cur = [t for t in cur if not (
+                    (t.get('id') and t['id'] in remove_ids) or
+                    (not t.get('id') and t.get('label', '').lower() in remove_labels)
+                )]
+            else:
+                cur = list(new_tags)
+            return {'tags': cur}
+        return transform
 
-        def make_transform(mode=tag_mode, new_tags=tags_to_update):
-            def transform(meta):
-                cur = list(meta.get('tags', []))
-                if mode == 'add':
-                    for t in new_tags:
-                        if t not in cur:
-                            cur.append(t)
-                elif mode == 'remove':
-                    remove_ids = {t['id'] for t in new_tags if t.get('id')}
-                    remove_labels = {t.get('label', '').lower() for t in new_tags if not t.get('id')}
-                    cur = [t for t in cur if not (
-                        (t.get('id') and t['id'] in remove_ids) or
-                        (not t.get('id') and t.get('label', '').lower() in remove_labels)
-                    )]
-                else:
-                    cur = list(new_tags)
-                return {'tags': cur}
-            return transform
-
-        await run_in_threadpool(
-            bulk_update_field,
-            os.path.join(path, '_metadata.json'),
-            make_transform(),
-            user['username'],
-            f"Bulk tags: {work_id}",
-            background_tasks=background_tasks,
-            call_ptw=True,
-        )
-    _invalidate_all_caches()
-    return {"status": "success"}
+    return await _run_bulk(
+        data.get('work_ids', []), make_transform(), user['username'],
+        "Bulk tags", background_tasks, call_ptw=True,
+    )
 
 @router.post("/works/bulk-genre")
 async def bulk_genre(request: Request, background_tasks: BackgroundTasks, user=Depends(require_role("admin"))):
@@ -484,33 +497,23 @@ async def bulk_genre(request: Request, background_tasks: BackgroundTasks, user=D
     genre = data.get('genre')
     mode = data.get('mode', 'add')
 
-    for work_id in data.get('work_ids', []):
-        path = find_directory_by_id(work_id)
-        if not (path and os.path.exists(os.path.join(path, '_metadata.json'))): continue
+    def make_transform(g=genre, m=mode):
+        def transform(meta):
+            current = meta.get('genre', [])
+            if not isinstance(current, list):
+                current = [current] if current else []
+            if m == 'add':
+                if g and g not in current:
+                    current = current + [g]
+            elif m == 'remove':
+                current = [x for x in current if x != g]
+            else:  # set
+                current = [g] if g else []
+            return {'genre': current}
+        return transform
 
-        def make_transform(g=genre, m=mode):
-            def transform(meta):
-                current = meta.get('genre', [])
-                if not isinstance(current, list):
-                    current = [current] if current else []
-                if m == 'add':
-                    if g and g not in current:
-                        current = current + [g]
-                elif m == 'remove':
-                    current = [x for x in current if x != g]
-                else:  # set
-                    current = [g] if g else []
-                return {'genre': current}
-            return transform
-
-        await run_in_threadpool(
-            bulk_update_field,
-            os.path.join(path, '_metadata.json'),
-            make_transform(),
-            user['username'],
-            f"Bulk genre: {work_id}",
-            background_tasks=background_tasks,
-        )
-    _invalidate_all_caches()
-    return {"status": "success"}
+    return await _run_bulk(
+        data.get('work_ids', []), make_transform(), user['username'],
+        "Bulk genre", background_tasks,
+    )
 

--- a/tests/test_bulk_atomicity.py
+++ b/tests/test_bulk_atomicity.py
@@ -1,8 +1,8 @@
+"""Bulk-metaandmete atomaarsus: üks commit, garanteeritud Meili sünk, loendurid (#175)."""
 import json
-import os
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -11,37 +11,74 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 
+def _work(tmp_path, slug, meta):
+    work_dir = tmp_path / slug
+    work_dir.mkdir()
+    path = work_dir / "_metadata.json"
+    path.write_text(json.dumps(meta), encoding="utf-8")
+    return str(path)
+
+
 @pytest.fixture
 def meta_file(tmp_path):
-    path = tmp_path / "_metadata.json"
-    path.write_text(json.dumps({
+    return _work(tmp_path, "teos-a", {
+        "id": "w1",
         "title": "Test",
         "collections": ["col-a"],
         "tags": [{"id": "Q1", "label": "foo"}],
         "genre": [],
-    }), encoding="utf-8")
-    return str(path)
+    })
 
 
-def test_bulk_update_field_applies_transform(meta_file):
-    """bulk_update_field loeb, transformeerib ja kirjutab ühe lukutsüklina."""
-    from server.metadata_ops import bulk_update_field
+@pytest.fixture
+def spies(monkeypatch):
+    """Kõik järeltegevused spioonideks; save_with_git tagastab õnnestumise."""
+    from server import metadata_ops
+
+    seen = {"git": [], "collections": [], "ptw": [], "meili": []}
+    monkeypatch.setattr(
+        metadata_ops, "save_with_git",
+        lambda path, content, user, message=None, additional_files=None: (
+            seen["git"].append({
+                "path": path, "content": content, "message": message,
+                "additional_files": additional_files or [],
+            }) or {"success": True, "commit_hash": "abc123", "is_noop": False}
+        ),
+    )
+    monkeypatch.setattr(
+        metadata_ops, "update_work_collections",
+        lambda work_id, colls: seen["collections"].append((work_id, colls)),
+    )
+    monkeypatch.setattr(
+        metadata_ops, "update_person_to_works",
+        lambda *args: seen["ptw"].append(args[0]),
+    )
+    monkeypatch.setattr(
+        metadata_ops, "sync_work_to_meilisearch",
+        lambda slug: seen["meili"].append(slug),
+    )
+    return seen
+
+
+# =========================================================
+# Senine käitumine, mis peab säilima
+# =========================================================
+
+def test_transform_result_is_written(meta_file, spies):
+    from server.metadata_ops import bulk_update_works
 
     def add_collection(meta):
-        current = meta.get("collections", [])
-        return {"collections": current + ["col-b"]}
+        return {"collections": meta.get("collections", []) + ["col-b"]}
 
-    with patch("server.metadata_ops.save_with_git") as mock_git:
-        bulk_update_field(meta_file, add_collection, "testuser", "bulk test")
-        assert mock_git.called
-        saved_content = mock_git.call_args[0][1]
-        saved = json.loads(saved_content)
-        assert saved["collections"] == ["col-a", "col-b"]
+    bulk_update_works([(meta_file, add_collection)], "testuser", "bulk test")
+
+    saved = json.loads(spies["git"][0]["content"])
+    assert saved["collections"] == ["col-a", "col-b"]
 
 
-def test_bulk_update_field_transform_sees_current_state(meta_file):
+def test_transform_sees_current_state(meta_file, spies):
     """transform näeb _metadata.json praegust seisu — ei kasuta vananenud väärtust."""
-    from server.metadata_ops import bulk_update_field
+    from server.metadata_ops import bulk_update_works
 
     seen_collections = []
 
@@ -49,31 +86,324 @@ def test_bulk_update_field_transform_sees_current_state(meta_file):
         seen_collections.extend(meta.get("collections", []))
         return {"collections": []}
 
-    with patch("server.metadata_ops.save_with_git"):
-        bulk_update_field(meta_file, inspect_and_remove, "testuser", "bulk test")
+    bulk_update_works([(meta_file, inspect_and_remove)], "testuser", "bulk test")
 
     assert "col-a" in seen_collections
 
 
-def test_bulk_update_field_skips_disallowed_keys(meta_file):
+def test_disallowed_keys_are_dropped(meta_file, spies):
     """transform ei saa lisada väljakesi, mida ALLOWED_METADATA_FIELDS ei luba."""
-    from server.metadata_ops import bulk_update_field
+    from server.metadata_ops import bulk_update_works
 
-    def add_evil(meta):
-        return {"collections": ["ok"], "__evil__": "injected"}
+    bulk_update_works(
+        [(meta_file, lambda m: {"collections": ["ok"], "__evil__": "injected"})],
+        "testuser", "bulk test",
+    )
 
-    with patch("server.metadata_ops.save_with_git") as mock_git:
-        bulk_update_field(meta_file, add_evil, "testuser", "bulk test")
-        saved = json.loads(mock_git.call_args[0][1])
-        assert "__evil__" not in saved
-        assert saved["collections"] == ["ok"]
+    saved = json.loads(spies["git"][0]["content"])
+    assert "__evil__" not in saved
+    assert saved["collections"] == ["ok"]
 
 
-def test_bulk_update_field_missing_file_is_noop(tmp_path):
-    """Puuduva faili korral ei kutsuta save_with_git."""
-    from server.metadata_ops import bulk_update_field
+def test_missing_file_makes_no_commit(tmp_path, spies):
+    from server.metadata_ops import bulk_update_works
 
-    missing = str(tmp_path / "nonexistent.json")
-    with patch("server.metadata_ops.save_with_git") as mock_git:
-        bulk_update_field(missing, lambda m: {"collections": []}, "user", "msg")
-        mock_git.assert_not_called()
+    missing = str(tmp_path / "puudub" / "_metadata.json")
+    result = bulk_update_works([(missing, lambda m: {"collections": []})], "user", "msg")
+
+    assert spies["git"] == []
+    assert result == {"updated": 0, "skipped": 0, "failed": 1}
+
+
+# =========================================================
+# Uus: üks commit, sünk, loendurid (#175)
+# =========================================================
+
+def test_three_works_produce_one_commit(tmp_path, spies):
+    from server.metadata_ops import bulk_update_works
+
+    items = [
+        (_work(tmp_path, f"teos-{i}", {"id": f"w{i}", "title": f"T{i}", "collections": []}),
+         lambda m: {"collections": ["uus"]})
+        for i in range(3)
+    ]
+
+    result = bulk_update_works(items, "testuser", "Bulk collection: 3 teost")
+
+    assert len(spies["git"]) == 1
+    commit = spies["git"][0]
+    assert commit["message"] == "Bulk collection: 3 teost"
+    # Esimene fail läheb põhiargumendina, ülejäänud additional_files kaudu — üks commit
+    assert len(commit["additional_files"]) == 2
+    assert result["updated"] == 3
+
+
+def test_every_changed_work_reaches_meilisearch(tmp_path, spies):
+    """#175 tuum: bulk-muudatus EI TOHI jätta Meilisearchi vanaks."""
+    from server.metadata_ops import bulk_update_works
+
+    items = [
+        (_work(tmp_path, f"teos-{i}", {"id": f"w{i}", "title": f"T{i}", "collections": []}),
+         lambda m: {"collections": ["uus"]})
+        for i in range(3)
+    ]
+
+    bulk_update_works(items, "testuser", "bulk")
+
+    assert sorted(spies["meili"]) == ["teos-0", "teos-1", "teos-2"]
+
+
+def test_meili_sync_is_coalesced_per_work(tmp_path, spies):
+    """Sama teos kaks korda nimekirjas → üks sünk, mitte kaks."""
+    from server.metadata_ops import bulk_update_works
+
+    path = _work(tmp_path, "teos-a", {"id": "w1", "title": "T", "collections": []})
+    items = [
+        (path, lambda m: {"collections": ["a"]}),
+        (path, lambda m: {"collections": ["a", "b"]}),
+    ]
+
+    bulk_update_works(items, "testuser", "bulk")
+
+    assert spies["meili"] == ["teos-a"]
+
+
+def test_unchanged_work_is_skipped(tmp_path, spies):
+    """Juba õige väärtusega teos ei tekita commiti, indeksi- ega Meili tööd."""
+    from server.metadata_ops import bulk_update_works
+
+    path = _work(tmp_path, "teos-a", {"id": "w1", "title": "T", "collections": ["olemas"]})
+
+    result = bulk_update_works([(path, lambda m: {"collections": ["olemas"]})], "u", "bulk")
+
+    assert result == {"updated": 0, "skipped": 1, "failed": 0}
+    assert spies["git"] == []
+    assert spies["meili"] == []
+    assert spies["collections"] == []
+
+
+def test_mixed_batch_counts_updated_skipped_failed(tmp_path, spies):
+    from server.metadata_ops import bulk_update_works
+
+    changed = _work(tmp_path, "teos-muutub", {"id": "w1", "title": "T", "collections": []})
+    same = _work(tmp_path, "teos-sama", {"id": "w2", "title": "T", "collections": ["x"]})
+    missing = str(tmp_path / "puudub" / "_metadata.json")
+
+    result = bulk_update_works(
+        [
+            (changed, lambda m: {"collections": ["x"]}),
+            (same, lambda m: {"collections": ["x"]}),
+            (missing, lambda m: {"collections": ["x"]}),
+        ],
+        "u", "bulk",
+    )
+
+    assert result == {"updated": 1, "skipped": 1, "failed": 1}
+    assert spies["meili"] == ["teos-muutub"]
+
+
+def test_failing_transform_does_not_stop_batch(tmp_path, spies):
+    """Ühe teose viga ei tohi ülejäänud partiid katkestada."""
+    from server.metadata_ops import bulk_update_works
+
+    boom = _work(tmp_path, "teos-vigane", {"id": "w1", "title": "T", "collections": []})
+    ok = _work(tmp_path, "teos-korras", {"id": "w2", "title": "T", "collections": []})
+
+    def explode(_meta):
+        raise ValueError("katki")
+
+    result = bulk_update_works(
+        [(boom, explode), (ok, lambda m: {"collections": ["x"]})], "u", "bulk",
+    )
+
+    assert result == {"updated": 1, "skipped": 0, "failed": 1}
+    assert spies["meili"] == ["teos-korras"]
+
+
+def test_derived_indices_updated_for_changed_works_only(tmp_path, spies):
+    from server.metadata_ops import bulk_update_works
+
+    changed = _work(tmp_path, "teos-muutub", {"id": "w1", "title": "T", "collections": []})
+    same = _work(tmp_path, "teos-sama", {"id": "w2", "title": "T", "collections": ["x"]})
+
+    bulk_update_works(
+        [(changed, lambda m: {"collections": ["x"]}), (same, lambda m: {"collections": ["x"]})],
+        "u", "bulk", call_ptw=True,
+    )
+
+    assert spies["collections"] == [("w1", ["x"])]
+    assert spies["ptw"] == ["w1"]
+
+
+def test_ptw_skipped_when_not_requested(meta_file, spies):
+    from server.metadata_ops import bulk_update_works
+
+    bulk_update_works([(meta_file, lambda m: {"collections": ["uus"]})], "u", "bulk")
+
+    assert spies["ptw"] == []
+    assert spies["collections"] == [("w1", ["uus"])]
+
+
+def test_background_tasks_receive_meili_sync(tmp_path, spies):
+    """background_tasks olemasolul läheb sünk tausta, mitte sünkroonselt."""
+    from fastapi import BackgroundTasks
+
+    from server import metadata_ops
+
+    path = _work(tmp_path, "teos-a", {"id": "w1", "title": "T", "collections": []})
+    tasks = BackgroundTasks()
+
+    metadata_ops.bulk_update_works(
+        [(path, lambda m: {"collections": ["x"]})], "u", "bulk", background_tasks=tasks,
+    )
+
+    assert spies["meili"] == []
+    assert [t.func for t in tasks.tasks] == [metadata_ops.sync_work_to_meilisearch_async]
+    assert tasks.tasks[0].args == ("teos-a",)
+
+
+# =========================================================
+# Endpointide juhtmestik
+# =========================================================
+
+def _json_request(body: bytes):
+    from starlette.requests import Request
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request({
+        "type": "http", "method": "POST", "path": "/", "query_string": b"",
+        "headers": [(b"content-type", b"application/json")],
+    }, receive)
+
+
+@pytest.fixture
+def bulk_endpoint_env(tmp_path, monkeypatch):
+    """Kaks päris teost + üks tundmatu work_id; bulk_update_works spiooniks."""
+    from server.routers import editing
+
+    dirs = {}
+    for work_id, slug in (("w1", "teos-a"), ("w2", "teos-b")):
+        path = _work(tmp_path, slug, {"id": work_id, "title": "T", "collections": [], "tags": [], "genre": []})
+        dirs[work_id] = str(Path(path).parent)
+
+    monkeypatch.setattr(editing, "find_directory_by_id", lambda wid: dirs.get(wid))
+    monkeypatch.setattr(editing, "_invalidate_all_caches", lambda: None)
+
+    seen = {}
+
+    def fake_bulk(items, username, message, **kwargs):
+        seen["items"] = list(items)
+        seen["message"] = message
+        seen["username"] = username
+        seen["call_ptw"] = kwargs.get("call_ptw", False)
+        seen["background_tasks"] = kwargs.get("background_tasks")
+        return {"updated": len(seen["items"]), "skipped": 0, "failed": 0}
+
+    monkeypatch.setattr(editing, "bulk_update_works", fake_bulk)
+    return seen
+
+
+def test_bulk_collection_endpoint_sends_one_batch(bulk_endpoint_env):
+    """Kolm work_id-d (üks tundmatu) → üks bulk-kutse, tundmatu läheb failed alla."""
+    import asyncio
+
+    from fastapi import BackgroundTasks
+
+    from server.routers import editing
+
+    body = json.dumps({"work_ids": ["w1", "w2", "puudub"], "mode": "add", "collection_id": "c1"}).encode()
+    result = asyncio.run(editing.bulk_collection(
+        _json_request(body), BackgroundTasks(), user={"username": "admin", "role": "admin"},
+    ))
+
+    assert len(bulk_endpoint_env["items"]) == 2
+    assert bulk_endpoint_env["message"] == "Bulk collection: 2 teost"
+    assert result == {"status": "success", "updated": 2, "skipped": 0, "failed": 1}
+
+
+def test_bulk_collection_transform_adds_collection(bulk_endpoint_env):
+    import asyncio
+
+    from fastapi import BackgroundTasks
+
+    from server.routers import editing
+
+    body = json.dumps({"work_ids": ["w1"], "mode": "add", "collection_id": "c1"}).encode()
+    asyncio.run(editing.bulk_collection(
+        _json_request(body), BackgroundTasks(), user={"username": "admin", "role": "admin"},
+    ))
+
+    _path, transform = bulk_endpoint_env["items"][0]
+    assert transform({"collections": ["olemas"]}) == {"collections": ["olemas", "c1"]}
+
+
+def test_bulk_tags_endpoint_requests_person_index_update(bulk_endpoint_env):
+    """Märksõnad võivad olla isikud → person_to_works peab uuenema."""
+    import asyncio
+
+    from fastapi import BackgroundTasks
+
+    from server.routers import editing
+
+    body = json.dumps({"work_ids": ["w1"], "tags": [{"id": "Q1", "label": "x"}], "mode": "add"}).encode()
+    asyncio.run(editing.bulk_tags(
+        _json_request(body), BackgroundTasks(), user={"username": "admin", "role": "admin"},
+    ))
+
+    assert bulk_endpoint_env["call_ptw"] is True
+    assert bulk_endpoint_env["message"] == "Bulk tags: 1 teost"
+
+
+def test_bulk_genre_endpoint_passes_background_tasks(bulk_endpoint_env):
+    import asyncio
+
+    from fastapi import BackgroundTasks
+
+    from server.routers import editing
+
+    tasks = BackgroundTasks()
+    body = json.dumps({"work_ids": ["w1", "w2"], "genre": {"id": "Q2", "label": "g"}, "mode": "add"}).encode()
+    result = asyncio.run(editing.bulk_genre(
+        _json_request(body), tasks, user={"username": "admin", "role": "admin"},
+    ))
+
+    assert bulk_endpoint_env["background_tasks"] is tasks
+    assert result["updated"] == 2
+
+
+def test_bulk_works_end_to_end_single_commit(tmp_path, monkeypatch):
+    """Päris Git repoga: kolm teost, üks commit, kõik failid sees."""
+    import git
+
+    from server import git_ops, metadata_ops
+
+    repo = git.Repo.init(str(tmp_path))
+    seed = tmp_path / "seed.txt"
+    seed.write_text("seed", encoding="utf-8")
+    repo.index.add(["seed.txt"])
+    actor = git.Actor("seed", "seed@vutt.local")
+    repo.index.commit("seed", author=actor, committer=actor)
+
+    monkeypatch.setattr(git_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(git_ops, "get_or_init_repo", lambda: repo)
+    monkeypatch.setattr(metadata_ops, "update_work_collections", lambda *a: None)
+    monkeypatch.setattr(metadata_ops, "update_person_to_works", lambda *a: None)
+    monkeypatch.setattr(metadata_ops, "sync_work_to_meilisearch", lambda *a: None)
+
+    items = [
+        (_work(tmp_path, f"teos-{i}", {"id": f"w{i}", "title": f"T{i}", "collections": []}),
+         lambda m: {"collections": ["uus"]})
+        for i in range(3)
+    ]
+    before = len(list(repo.iter_commits()))
+
+    result = metadata_ops.bulk_update_works(items, "editor", "Bulk collection: 3 teost")
+
+    assert result["updated"] == 3
+    assert len(list(repo.iter_commits())) == before + 1
+    tree = repo.head.commit.tree
+    for i in range(3):
+        content = json.loads((tree / f"teos-{i}" / "_metadata.json").data_stream.read())
+        assert content["collections"] == ["uus"]


### PR DESCRIPTION
Sulgeb #175 (koondülevaade #182). Ehitab #173 no-op võrdluse peale.

## Leitud viga (tõsisem kui issue's kirjas)

`bulk_update_field` vaikeväärtus oli `sync_meili=False` ja **ükski kolmest bulk-endpointist ei tõstnud seda** — `works/bulk-collection`, `bulk-tags` ja `bulk-genre` muudatused ei jõudnud Meilisearchi **kunagi**. Kettal olid andmed õiged, otsinguindeksis vanad, ja Dashboard (mis loeb Meilist) näitas vana seisu kuni järgmise üksiksalvestuse või `server_seed_data.sh`-ni. See ei olnud ainult jõudlusprobleem.

## Muudatus

**`bulk_update_field` → `bulk_update_works(items, username, message, *, background_tasks, call_ptw)`**

- Kogu partii ühes `metadata_lock` tsüklis; kõik muutunud failid **ühte path-skoobitud commiti** (`save_with_git(..., additional_files=...)`) senise N commiti asemel.
- **Meili sünk on kohustuslik**, mitte lipuga valitav. Üks sünk unikaalse teose kohta — sama teos kaks korda partiis ei tekita kahte sünki.
- Korduv teos **aheldub** in-memory (teine transform näeb esimese tulemust), ei loeta kettalt uuesti.
- Muutusteta teosed jäetakse vahele (ADR 0012 võrdlus).
- Vigane transform / loetamatu fail: **see** teos jääb tervikuna kirjutamata (pooleli jäänud transform võis meta osaliselt muuta), ülejäänud partii läheb edasi.
- Tagastab `{updated, skipped, failed}`.

**Endpointid** kasutavad ühist `_run_bulk` abifunktsiooni ja tagastavad loendurid. Tundmatu/kadunud `work_id` läheb `failed` alla (varem vaikselt `continue`). `find_directory_by_id` failisüsteemi-skaneering viidud threadpooli (ADR 0002 — varem jooksis event-loopis).

`call_ptw=True` säilib ainult bulk-tags juures nagu varem; see katab nii `person_to_works` kui `works_creators_index` (viimane uueneb `update_person_to_works` sees).

## Testid

18 testi `tests/test_bulk_atomicity.py`-s (senised 4 porditud uuele API-le):

- üks commit N teose kohta; iga muutunud teos jõuab Meilisearchi; sünk coalesced'itud
- muutusteta teos vahele; segapartii loendurid; vigane transform ei katkesta partiid
- tuletatud indeksid ainult muutunud teostele; `background_tasks` tee
- otsast-otsani **päris Git repoga**: 3 teost → 1 commit, kõik failid puus
- endpointi-juhtmestik (üks partii, loendurid, `call_ptw`, `background_tasks`)

Endpointi-testid kirjutati koodi järel, seega kontrollisin nad **mutatsiooniga** üle: `counts["failed"] += unknown` eemaldamine, `call_ptw=True` eemaldamine ja `background_tasks=None` panek kukutavad täpselt vastavad testid.

Kogu komplekt: 973 passed.

## Teadaolev jäänuk

Dashboard teeb pärast bulk-operatsiooni kohe refetch'i, sünk aga käib taustal — filtrid võivad hetkeks veel vana seisu näidata (self-heal mõne sekundiga). Varem oli see püsiv, nüüd ajutine. Päris lahendus käib #176 (sünkide coalescing) kaudu.

Frontend loendureid veel ei kuva (`failed > 0` võiks anda hoiatuse) — API tagastab need, UI on eraldi otsus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)