### PR TITLE
perf: koonda sama teose Meilisearchi sünkroniseerimised (#176)

### DIFF
--- a/docs/decisions/0013-meili-sunk-koondatakse-teose-kaupa.md
+++ b/docs/decisions/0013-meili-sunk-koondatakse-teose-kaupa.md
@@ -1,0 +1,63 @@
+# 0013 — Meilisearchi sünk koondatakse teose kaupa, dirty-lipp elab vea üle
+
+**Staatus:** kehtib
+
+## Kontekst
+
+Iga salvestus lisab teose Meilisearchi sünkroniseerimise töö. Sünk ei uuenda
+üht välja, vaid ehitab teose **kõik** lehe-dokumendid uuesti
+(`build_work_documents`) ja upsertib need — 9-leheküljelise teose puhul
+~0,5–0,6 s. Tootmislogis oli sama teose kolm sünki 9 sekundi jooksul: kasutaja
+salvestas kolm korda järjest ja iga salvestus indekseeris kõik lehed otsast
+peale.
+
+Töid piiras ainult `ThreadPoolExecutor` (10 töötajat). See hoidis Meilisearchi
+koormust vaos, aga ei vähendanud tehtud tööd: N salvestust = N täisindekseerimist.
+
+## Otsus
+
+1. **Korraga üks aktiivne sünk teose kohta.** `_meili_active_syncs` hoiab
+   teoseid, mille sünk parasjagu käib.
+
+2. **Aktiivse töö ajal saabuv päring märgib teose ainult dirty'ks**
+   (`_meili_dirty_syncs`) ja loeb selle coalesced'iks. Kümme päringut aktiivse
+   töö ajal annavad täpselt ühe järeljooksu, mitte kümme.
+
+3. **Järeljooks loeb ketast uuesti.** Sünk ei kanna endaga mingit hetkeseisu —
+   see loeb `_metadata.json`-i ja lehefailid käivitumise hetkel. Seetõttu katab
+   üks järeljooks kõigi vahepealsete salvestuste tulemuse korraga.
+
+4. **Eri teosed ei blokeeri teineteist** — coalescing on teosepõhine, pool
+   jääb endiselt paralleelseks.
+
+5. **Loendurid on health-vastuses** (`requested`, `coalesced`, `active`,
+   `dirty`), et koondamise mõju oleks tootmises näha, mitte oletatav.
+
+## Tagajärjed
+
+- **Järeljooksu ajastus PEAB olema `finally`-harus, mitte `try`-haru lõpus.**
+  Kui aktiivne sünk viskab vea (Meili maas, võrgutõrge) ja järeljooks jääks
+  vahele, kaoks vahepealne salvestus jäljetult ja teos jääks otsingus vanaks.
+  See on vaikne andmelahknemine, mitte nähtav viga — seepärast on
+  `test_dirty_work_survives_failed_sync` regressioonitestina olemas.
+
+- **Teos jääb `active` hulka järeljooksu ajaks.** Kui ta sealt vahepeal
+  eemaldataks, tekiks aken, milles uus päring käivitaks paralleelse sünki
+  samale teosele.
+
+- **Sünk peab jääma idempotentseks ja kettapõhiseks.** Kui keegi hakkab
+  sünkile andma kaasa "mida muuta" (delta), laguneb coalescing: järeljooks ei
+  teaks enam, mida vahepealsed päringud tahtsid. Osaline update (nt üks
+  lehekülg) on võimalik alles siis, kui sellega tuleb ka koondamise
+  ümbermõtlemine.
+
+- **Väiksem viivitus ei ole garantii.** Kasutaja salvestuse järel võib sünk
+  oodata eelmise lõppu. See oli nii ka varem (pool), aga nüüd on ootamine
+  teadlik ja mõõdetav (`dirty` loendur).
+
+## Viited
+
+- Issue #176 (koondülevaade #182)
+- `server/meilisearch_ops.py` — `sync_work_to_meilisearch_async`, `_sync_work_task`
+- Testid: `tests/test_meili_coalescing.py`
+- Seotud: ADR 0005 (keep-warm), ADR 0012 (muutusteta salvestus ei tekita sünki üldse)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -32,3 +32,4 @@ lisa uus kirje, mis viitab vanale („asendab 000X").
 | [0010](0010-lehe-vahetus-ei-monteeri-editorit-maha.md) | Lehe vahetus ei monteeri editorit maha; sisuvahetus on märgistatud | kehtib |
 | [0011](0011-i18n-keelepakid-laisalt-ilma-fallbackita.md) | i18n laeb ühe keele korraga; `fallbackLng` väljas + pariteeditest | kehtib |
 | [0012](0012-muutusteta-salvestus-on-no-op.md) | Muutusteta salvestus ei kirjuta, ei commiti ega indekseeri | kehtib |
+| [0013](0013-meili-sunk-koondatakse-teose-kaupa.md) | Meili sünk koondatakse teose kaupa; dirty-lipp elab vea üle | kehtib |

--- a/server/meilisearch_ops.py
+++ b/server/meilisearch_ops.py
@@ -323,6 +323,15 @@ _meili_sync_last_error = None
 _meili_sync_last_error_at = None
 _meili_sync_last_success_at = None
 _meili_sync_completed = 0
+
+# Per-teose coalescing (#176): korraga üks aktiivne sünk teose kohta. Kui teose
+# kohta tuleb päring, kui sünk juba käib, märgitakse teos dirty'ks ja pärast
+# aktiivse töö lõppu tehakse TÄPSELT üks järeljooks — see loeb ketast uuesti,
+# seega kannab kõigi vahepealsete salvestuste tulemuse korraga.
+_meili_active_syncs = set()   # dir_name'id, mille sünk parasjagu käib
+_meili_dirty_syncs = set()    # dir_name'id, mis vajavad järeljooksu
+_meili_sync_requested = 0
+_meili_sync_coalesced = 0
 register_job("meilisearch_async_sync", description="Asünkroonne teoste sünkroonimine Meilisearchi")
 register_job("metadata_watcher", interval_seconds=60, description="Uute teosekaustade metaandmete jälgija")
 
@@ -347,8 +356,19 @@ def _sync_work_task(dir_name):
         mark_error("meilisearch_async_sync", e, detail={"dir_name": dir_name})
         logger.error(f"ASYNC MEILISEARCH VIGA ({dir_name}): {e}")
     finally:
+        # NB: finally, mitte try-haru — vea korral EI TOHI vahepeal saabunud
+        # muudatus kaduda, muidu jääks teos Meilisearchis vanaks.
         with _meili_sync_lock:
             _meili_sync_pending = max(0, _meili_sync_pending - 1)
+            rerun = dir_name in _meili_dirty_syncs
+            if rerun:
+                _meili_dirty_syncs.discard(dir_name)
+                _meili_sync_pending += 1  # teos jääb aktiivseks järeljooksu ajaks
+            else:
+                _meili_active_syncs.discard(dir_name)
+        if rerun:
+            logger.info(f"MEILI COALESCING: järeljooks ({dir_name})")
+            _meilisearch_executor.submit(_sync_work_task, dir_name)
 
 
 def get_meilisearch_sync_status():
@@ -360,6 +380,10 @@ def get_meilisearch_sync_status():
             "queued": queued,
             "pool_size": MEILISEARCH_POOL_SIZE,
             "completed": _meili_sync_completed,
+            "requested": _meili_sync_requested,
+            "coalesced": _meili_sync_coalesced,
+            "active": len(_meili_active_syncs),
+            "dirty": len(_meili_dirty_syncs),
             "last_success_at": datetime.fromtimestamp(_meili_sync_last_success_at, timezone.utc).isoformat() if _meili_sync_last_success_at else None,
             "last_error": _meili_sync_last_error,
             "last_error_at": datetime.fromtimestamp(_meili_sync_last_error_at, timezone.utc).isoformat() if _meili_sync_last_error_at else None,
@@ -372,11 +396,33 @@ def sync_work_to_meilisearch_async(dir_name):
     Kasutaja päring ei pea ootama indekseerimise lõppu.
     Vead logitakse, aga ei katkesta kasutaja tööd.
     Pool piirab samaagsete päringute arvu (max 10).
+
+    Sama teose järjestikused päringud koondatakse (#176): kui teose sünk juba
+    käib, märgitakse teos ainult dirty'ks ja järeljooks teeb töö ära korra.
+    Eri teosed käivad endiselt paralleelselt.
     """
-    global _meili_sync_pending
+    global _meili_sync_pending, _meili_sync_requested, _meili_sync_coalesced
     with _meili_sync_lock:
+        _meili_sync_requested += 1
+        if dir_name in _meili_active_syncs:
+            _meili_dirty_syncs.add(dir_name)
+            _meili_sync_coalesced += 1
+            return
+        _meili_active_syncs.add(dir_name)
         _meili_sync_pending += 1
     _meilisearch_executor.submit(_sync_work_task, dir_name)
+
+
+def _reset_sync_state_for_tests():
+    """Nullib coalescing-oleku ja loendurid. Ainult testide jaoks."""
+    global _meili_sync_pending, _meili_sync_requested, _meili_sync_coalesced, _meili_sync_completed
+    with _meili_sync_lock:
+        _meili_active_syncs.clear()
+        _meili_dirty_syncs.clear()
+        _meili_sync_pending = 0
+        _meili_sync_requested = 0
+        _meili_sync_coalesced = 0
+        _meili_sync_completed = 0
 
 
 def _ensure_filterable_attributes():

--- a/tests/test_meili_coalescing.py
+++ b/tests/test_meili_coalescing.py
@@ -1,0 +1,137 @@
+"""Sama teose järjestikused Meili sünkroniseerimised koondatakse (#176)."""
+import threading
+import time
+
+import pytest
+
+from server import meilisearch_ops as mo
+
+
+def _wait_until(predicate, timeout=5.0):
+    """Ootab tingimuse täitumist; tagastab True kui täitus enne timeout'i."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+@pytest.fixture
+def sync_state(monkeypatch):
+    """Nullib coalescing-oleku ja annab kontrollitava fake-sünki.
+
+    Fake blokeerub `gate`-il, nii et test saab hoida sünki 'aktiivsena'.
+    """
+    mo._reset_sync_state_for_tests()
+
+    state = {
+        "calls": [],           # dir_name'id käivitamise järjekorras
+        "started": threading.Semaphore(0),
+        "gate": threading.Event(),
+        "raise_on": set(),
+    }
+    lock = threading.Lock()
+
+    def fake_sync(dir_name):
+        with lock:
+            state["calls"].append(dir_name)
+        state["started"].release()
+        state["gate"].wait(timeout=5)
+        if dir_name in state["raise_on"]:
+            raise RuntimeError("sünk kukkus")
+        return True
+
+    monkeypatch.setattr(mo, "sync_work_to_meilisearch", fake_sync)
+    yield state
+    state["gate"].set()
+    _wait_until(lambda: mo.get_meilisearch_sync_status()["active"] == 0)
+    mo._reset_sync_state_for_tests()
+
+
+def test_ten_requests_produce_one_active_and_one_followup(sync_state):
+    for _ in range(10):
+        mo.sync_work_to_meilisearch_async("teos-a")
+
+    assert sync_state["started"].acquire(timeout=5)
+    # Aktiivse töö ajal ei tohi teist sama teose tööd käivituda
+    time.sleep(0.05)
+    assert sync_state["calls"] == ["teos-a"]
+
+    sync_state["gate"].set()
+    assert _wait_until(lambda: len(sync_state["calls"]) == 2)
+    # Täpselt üks järeljooks, mitte üheksa
+    time.sleep(0.05)
+    assert sync_state["calls"] == ["teos-a", "teos-a"]
+
+
+def test_followup_sees_latest_disk_state(monkeypatch):
+    """Järeljooks loeb ketast uuesti — ta ei kanna endaga vana seisu kaasa."""
+    mo._reset_sync_state_for_tests()
+    disk = {"value": "vana"}
+    seen = []
+    started = threading.Semaphore(0)
+    gate = threading.Event()
+
+    def fake_sync(dir_name):
+        seen.append(disk["value"])
+        started.release()
+        gate.wait(timeout=5)
+        return True
+
+    monkeypatch.setattr(mo, "sync_work_to_meilisearch", fake_sync)
+
+    mo.sync_work_to_meilisearch_async("teos-a")
+    assert started.acquire(timeout=5)
+
+    # Kasutaja salvestab uuesti, kuni esimene sünk veel käib
+    disk["value"] = "uus"
+    mo.sync_work_to_meilisearch_async("teos-a")
+    gate.set()
+
+    assert _wait_until(lambda: len(seen) == 2)
+    assert seen == ["vana", "uus"]
+    mo._reset_sync_state_for_tests()
+
+
+def test_different_works_are_not_blocked_by_each_other(sync_state):
+    mo.sync_work_to_meilisearch_async("teos-a")
+    mo.sync_work_to_meilisearch_async("teos-b")
+
+    assert sync_state["started"].acquire(timeout=5)
+    assert sync_state["started"].acquire(timeout=5)
+    assert sorted(sync_state["calls"]) == ["teos-a", "teos-b"]
+    assert mo.get_meilisearch_sync_status()["active"] == 2
+
+
+def test_dirty_work_survives_failed_sync(sync_state):
+    """Kui aktiivne sünk viskab vea, ei tohi vahepealne muudatus kaduda."""
+    sync_state["raise_on"].add("teos-a")
+
+    mo.sync_work_to_meilisearch_async("teos-a")
+    assert sync_state["started"].acquire(timeout=5)
+    mo.sync_work_to_meilisearch_async("teos-a")
+    sync_state["gate"].set()
+
+    assert _wait_until(lambda: len(sync_state["calls"]) == 2)
+
+
+def test_status_exposes_coalescing_counters(sync_state):
+    for _ in range(5):
+        mo.sync_work_to_meilisearch_async("teos-a")
+    assert sync_state["started"].acquire(timeout=5)
+
+    status = mo.get_meilisearch_sync_status()
+    assert status["requested"] == 5
+    assert status["coalesced"] == 4
+    assert status["active"] == 1
+    assert status["dirty"] == 1
+
+
+def test_work_leaves_active_set_when_done(sync_state):
+    mo.sync_work_to_meilisearch_async("teos-a")
+    assert sync_state["started"].acquire(timeout=5)
+    sync_state["gate"].set()
+
+    assert _wait_until(lambda: mo.get_meilisearch_sync_status()["active"] == 0)
+    assert mo.get_meilisearch_sync_status()["dirty"] == 0


### PR DESCRIPTION
Sulgeb #176 (koondülevaade #182). Viimane tükk komplektist #173 + #175 + #176.

## Probleem

Meili sünk ei uuenda üht välja — ta ehitab teose **kõik** lehe-dokumendid uuesti (`build_work_documents`) ja upsertib need. 9-leheküljelise teose puhul ~0,5–0,6 s. Tootmislogis oli sama teose kolm sünki 9 sekundi jooksul: kolm salvestust = kolm täisindekseerimist. `ThreadPoolExecutor` piiras ainult samaaegsust, mitte tehtud tööd.

## Lahendus

Per-teose coalescing `sync_work_to_meilisearch_async`-is:

- `_meili_active_syncs` — korraga üks aktiivne sünk teose kohta
- aktiivse töö ajal saabuv päring märgib teose ainult `_meili_dirty_syncs`-i ja loeb end coalesced'iks → **10 päringut = 1 aktiivne + 1 järeljooks**
- järeljooks **loeb ketast uuesti**, seega katab kõigi vahepealsete salvestuste tulemuse korraga
- eri teosed käivad endiselt paralleelselt (coalescing on teosepõhine)
- health-vastus (`/health`, `meilisearch_sync`) näitab `requested` / `coalesced` / `active` / `dirty`

## Kriitiline detail (ADR 0013)

Järeljooksu ajastus on **`finally`-harus, mitte `try`-haru lõpus**. Kui aktiivne sünk viskab vea (Meili maas, võrgutõrge) ja järeljooks jääks vahele, kaoks vahepealne salvestus jäljetult ja teos jääks otsingus vanaks — vaikne andmelahknemine, mitte nähtav viga. Teos jääb ka `active` hulka järeljooksu ajaks, muidu tekiks aken paralleelseks sünkiks samale teosele.

ADR 0013 fikseerib lisaks: **sünk peab jääma idempotentseks ja kettapõhiseks**. Kui sünkile hakataks andma kaasa deltat ("mida muuta"), laguneb coalescing — järeljooks ei teaks, mida vahepealsed päringud tahtsid.

## Testid

6 uut (`tests/test_meili_coalescing.py`), determinstlikud (semafor + event, mitte sleep-lootus):

- 10 päringut → 1 aktiivne + täpselt 1 järeljooks
- järeljooks näeb viimast kettaseisu (`["vana", "uus"]`)
- eri teosed ei blokeeru
- **dirty töö elab ebaõnnestunud sünki üle**
- loendurid health-vastuses; teos lahkub `active` hulgast, kui töö lõppeb

Mutatsiooniga üle kontrollitud: coalescing välja → 2 testi kukub; dirty maha vea korral → `test_dirty_work_survives_failed_sync` kukub.

Kogu komplekt: 979 passed.

## Mõju #175-le

Sulgeb ka #175 jäänuki: bulk-operatsiooni N teose sünk oli juba teosepõhiselt dedupitud, nüüd ei kuhju ka järjestikused päringud sama teose peale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)