### PR TITLE
fix: otsingu teoste ja vastete arv work_id facetist (#174 osa)

### DIFF
--- a/src/services/__tests__/searchContentTotals.test.ts
+++ b/src/services/__tests__/searchContentTotals.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+vi.mock('../meiliService', () => ({
+  checkMixedContent: vi.fn(),
+  normalizeWork: vi.fn((hit) => hit),
+  normalizeContentSearchHit: vi.fn((hit) => hit),
+}));
+
+vi.mock('../../config', () => ({
+  MEILI_HOST: 'http://localhost:7700',
+  MEILI_INDEX: 'teosed',
+  IMAGE_BASE_URL: '/api/images',
+  FILE_API_URL: '/api/files',
+}));
+
+import { searchContent } from '../searchService';
+
+const mockIndex = { search: mockSearch } as any;
+
+/**
+ * searchContent teeb kolm paralleelset päringut: statistika (limit 5000),
+ * kuvatavad tulemused (distinct) ja lehekülgede loendur (limit 0 + work_id facet).
+ * Router valib mocki vastuse päringu kuju järgi.
+ */
+function mockQueries(opts: {
+  statsHits: string[];            // stats-päringu hittide work_id-d
+  statsEstimated: number;
+  distinctEstimated: number;
+  facet?: Record<string, number>; // work_id facet: teos → lehekülgede arv
+  pageEstimated: number;
+}) {
+  mockSearch.mockImplementation((_q: string, params: any = {}) => {
+    if (params.limit === 0 && params.facets?.includes('work_id')) {
+      return Promise.resolve({
+        hits: [],
+        estimatedTotalHits: opts.pageEstimated,
+        facetDistribution: opts.facet === undefined ? undefined : { work_id: opts.facet },
+      });
+    }
+    if (params.distinct === 'work_id') {
+      return Promise.resolve({
+        hits: [{ id: 'p1', work_id: opts.statsHits[0] ?? 'w1' }],
+        estimatedTotalHits: opts.distinctEstimated,
+      });
+    }
+    return Promise.resolve({
+      hits: opts.statsHits.map((work_id, i) => ({ id: `p${i}`, work_id })),
+      estimatedTotalHits: opts.statsEstimated,
+    });
+  });
+}
+
+beforeEach(() => mockSearch.mockReset());
+
+describe('searchContent teoste ja vastete koguarv', () => {
+  it('loeb teosed work_id facetist ka siis, kui statistikapäring lõi 5000 piiri lõhki', async () => {
+    // Päris mõõtmine: "est" → 10 000 lehte, tegelikult 1074 teost, kuid
+    // esimesed 5000 hitti katavad vaid murdosa teostest.
+    const facet: Record<string, number> = {};
+    for (let i = 0; i < 1074; i++) facet[`w${i}`] = 9;
+    mockQueries({
+      statsHits: ['w0', 'w1', 'w2'],
+      statsEstimated: 10000,
+      distinctEstimated: 10000,
+      facet,
+      pageEstimated: 10000,
+    });
+
+    const res = await searchContent(mockIndex, 'est', 1, {});
+
+    expect(res.totalWorks).toBe(1074);
+  });
+
+  it('annab sama täpse arvu ka kitsa päringu korral', async () => {
+    mockQueries({
+      statsHits: ['w1', 'w1', 'w2', 'w3'],
+      statsEstimated: 4,
+      distinctEstimated: 3,
+      facet: { w1: 2, w2: 1, w3: 1 },
+      pageEstimated: 4,
+    });
+
+    const res = await searchContent(mockIndex, 'Ludenius', 1, {});
+
+    expect(res.totalWorks).toBe(3);
+    expect(res.totalHits).toBe(4);
+  });
+
+  it('kasutab vastete koguarvuna facet-summat, mis ei ole maxTotalHits piiriga kärbitud', async () => {
+    mockQueries({
+      statsHits: ['w1'],
+      statsEstimated: 10000,
+      distinctEstimated: 10000,
+      facet: { w1: 8000, w2: 5456 },
+      pageEstimated: 10000, // Meilisearch kärbib maxTotalHits=10000 juures
+    });
+
+    const res = await searchContent(mockIndex, 'de', 1, {});
+
+    expect(res.totalHits).toBe(13456);
+  });
+
+  it('kukub tagasi vanale loogikale, kui facet puudub', async () => {
+    mockQueries({
+      statsHits: ['w1', 'w2'],
+      statsEstimated: 2,
+      distinctEstimated: 2,
+      facet: undefined,
+      pageEstimated: 2,
+    });
+
+    const res = await searchContent(mockIndex, 'Ludenius', 1, {});
+
+    expect(res.totalWorks).toBe(2);
+    expect(res.totalHits).toBe(2);
+  });
+});

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -681,23 +681,33 @@ export const searchContent = async (index: Index, query: string, page: number = 
       // Lisa work_id facet (lehekülgede arvud) otse Meilisearchist
       calculatedFacets['work_id'] = pageCountResponse.facetDistribution?.['work_id'] || {};
 
-      // Kui stats-päring mahtus limiiti, on uniqueWorks.size täpne ja ühtib facetidega.
-      // Kui limiit löödi lõhki, kasutame distinctResponse.estimatedTotalHits (ligikaudne).
-      if ((statsResponse.estimatedTotalHits || 0) <= STATS_LIMIT) {
+      const workHitCounts = pageCountResponse.facetDistribution?.['work_id'] || {};
+      const facetWorkIds = Object.keys(workHitCounts);
+
+      // work_id facet loendab KÕIKI vastavaid teoseid, sõltumata STATS_LIMIT-ist ja
+      // maxTotalHits=10000 lakkest. Varem võeti see arv üle piiri minnes
+      // distinctResponse.estimatedTotalHits-ist, mis loeb lehekülgi, mitte teoseid:
+      // "est" näitas 10 000 teost tegeliku 1074 asemel (~9x liiga palju).
+      // Facet on tasuta — see päring tehakse niikuinii lehekülgede arvude jaoks.
+      if (facetWorkIds.length > 0) {
+        totalWorks = facetWorkIds.length;
+      } else if ((statsResponse.estimatedTotalHits || 0) <= STATS_LIMIT) {
         totalWorks = uniqueWorks.size;
       } else {
         totalWorks = distinctResponse.estimatedTotalHits || uniqueWorks.size;
       }
-
-      const workHitCounts = pageCountResponse.facetDistribution?.['work_id'] || {};
       const hitsWithCounts = distinctResponse.hits.map((hit: any) => ({
         ...normalizeContentSearchHit(hit),
         hitCount: workHitCounts[hit.work_id] || 1
       }));
 
+      // Facet-väärtuste summa on täpne lehekülgede arv; estimatedTotalHits on
+      // maxTotalHits=10000 juures kärbitud.
+      const facetPageTotal = facetWorkIds.reduce((sum, id) => sum + (workHitCounts[id] || 0), 0);
+
       return {
         hits: hitsWithCounts as any,
-        totalHits: pageCountResponse.estimatedTotalHits || 0, // Lehekülgi kokku
+        totalHits: facetPageTotal || pageCountResponse.estimatedTotalHits || 0, // Lehekülgi kokku
         totalWorks: totalWorks,
         totalPages: Math.ceil(totalWorks / limit),
         page,


### PR DESCRIPTION
Osa #174-st — **korrektsuse** pool, mille sai tasuta. Facetide kallutatus jääb #174 alla edasi.

## Probleem

`searchContent` võttis teoste arvu nii:

```ts
if (statsResponse.estimatedTotalHits <= 5000) totalWorks = uniqueWorks.size;
else totalWorks = distinctResponse.estimatedTotalHits;
```

Üle 5000 lehe-vaste minnes tuli arv `distinctResponse.estimatedTotalHits`-ist, mis loeb **lehekülgi**, mitte teoseid, ja on lisaks `maxTotalHits=10000` juures kärbitud. Tulemus: "est" näitas 10 000 teost, kui tegelikult vastas 1074.

## Lahendus

`work_id` facet loendab kõiki vastavaid teoseid, sõltumata `STATS_LIMIT`-ist ja `maxTotalHits`-ist. **See päring tehakse juba niikuinii** lehekülgede arvude jaoks (`pageCountResponse`) — parandus ei lisa ühtki päringut:

- `totalWorks` = facet-võtmete arv
- `totalHits` = facet-väärtuste summa (ei ole 10 000 juures kärbitud)
- tagasilangus vanale loogikale, kui facet puudub

`maxValuesPerFacet` on 5000, korpuses ~1300 teost — ruumi on.

## Mõõdetud tootmiskorpusel

| päring | teoseid vana → uus | lehti vana → uus |
|---|---|---|
| tartu | 776 → 776 | 3537 → 3537 |
| philosophia | 554 → 554 | 2152 → 2152 |
| quod | **8081 → 990** | 9006 → 9006 |
| est | **10000 → 1074** | 10000 → **11208** |
| de | **10000 → 1234** | 10000 → **18936** |
| in | **10000 → 1234** | 10000 → **18913** |
| non | **9558 → 1050** | 10000 → **10446** |

Kitsad päringud (alla 5000 vaste) on **muutumatud** — see katab tavakasutuse.

Kõrvalmõju: `totalPages = ceil(totalWorks / limit)` paraneb samamoodi. Varem sai laia päringu puhul lapata sadadele tühjadele lehtedele.

## Testid

4 uut (`src/services/__tests__/searchContentTotals.test.ts`): üle 5000 mineva päringu teoste arv facetist; kitsa päringu regressioonikaitse; kärbitud `estimatedTotalHits` vs facet-summa; tagasilangus facetita. Frontend 641 passed, typecheck puhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)