### PR TITLE
perf: teosepõhised otsingu-facetid ilma 5000-hiti päringuta (#174)

### DIFF
--- a/src/services/__tests__/searchContentFacets.test.ts
+++ b/src/services/__tests__/searchContentFacets.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+vi.mock('../meiliService', () => ({
+  checkMixedContent: vi.fn(),
+  normalizeWork: vi.fn((hit) => hit),
+  normalizeContentSearchHit: vi.fn((hit) => hit),
+}));
+
+vi.mock('../../config', () => ({
+  MEILI_HOST: 'http://localhost:7700',
+  MEILI_INDEX: 'teosed',
+  IMAGE_BASE_URL: '/api/images',
+  FILE_API_URL: '/api/files',
+}));
+
+import { searchContent } from '../searchService';
+
+const mockIndex = { search: mockSearch } as any;
+
+/** Teosetasandi facet-päring: tühi query + lehekylje_number = 1 filter. */
+function isWorkLevelQuery(params: any) {
+  return Array.isArray(params?.filter)
+    && params.filter.some((f: string) => String(f).includes('lehekylje_number = 1'));
+}
+
+function isPageCountQuery(params: any) {
+  return params?.limit === 0 && params?.facets?.includes('work_id') && !isWorkLevelQuery(params);
+}
+
+interface MockOpts {
+  workCounts: Record<string, number>;          // work_id facet: teos → lehti
+  workFacets?: Record<string, Record<string, number>>;  // teosetasandi facetid
+  workFacetsByBatch?: Record<string, Record<string, number>>[]; // partiide kaupa
+}
+
+function mockQueries(opts: MockOpts) {
+  let batch = 0;
+  mockSearch.mockImplementation((_q: string, params: any = {}) => {
+    if (isWorkLevelQuery(params)) {
+      const dist = opts.workFacetsByBatch
+        ? (opts.workFacetsByBatch[batch++] || {})
+        : (opts.workFacets || {});
+      return Promise.resolve({ hits: [], estimatedTotalHits: 0, facetDistribution: dist });
+    }
+    if (isPageCountQuery(params)) {
+      return Promise.resolve({
+        hits: [],
+        estimatedTotalHits: Object.values(opts.workCounts).reduce((a, b) => a + b, 0),
+        facetDistribution: { work_id: opts.workCounts },
+      });
+    }
+    // Kuvatavad tulemused (distinct)
+    return Promise.resolve({
+      hits: [{ id: 'p1', work_id: Object.keys(opts.workCounts)[0] || 'w1' }],
+      estimatedTotalHits: 10,
+    });
+  });
+}
+
+const searchCalls = () => mockSearch.mock.calls.map(([, params]) => params ?? {});
+
+beforeEach(() => mockSearch.mockReset());
+
+describe('searchContent teosepõhised facetid', () => {
+  it('võtab facetid teosetasandi päringust, mitte esimesest 5000 hitist', async () => {
+    mockQueries({
+      workCounts: { w1: 9, w2: 3 },
+      workFacets: { genre_ids: { Q1: 2 }, type_ids: { Q9: 1 }, tags_ids: { Q5: 2 } },
+    });
+
+    const res = await searchContent(mockIndex, 'tartu', 1, {});
+
+    expect(res.facetDistribution?.['genre_ids']).toEqual({ Q1: 2 });
+    expect(res.facetDistribution?.['type_ids']).toEqual({ Q9: 1 });
+    expect(res.facetDistribution?.['tags_ids']).toEqual({ Q5: 2 });
+  });
+
+  it('küsib teosetasandi facetid ühelt dokumendilt teose kohta', async () => {
+    mockQueries({ workCounts: { w1: 9, w2: 3 }, workFacets: {} });
+
+    await searchContent(mockIndex, 'tartu', 1, {});
+
+    const workQuery = searchCalls().find(isWorkLevelQuery);
+    expect(workQuery).toBeDefined();
+    expect(workQuery.limit).toBe(0);
+    const filter = (workQuery.filter as string[]).join(' AND ');
+    expect(filter).toContain('work_id IN ["w1", "w2"]');
+    expect(filter).toContain('lehekylje_number = 1');
+  });
+
+  it('ei tee enam 5000-hiti statistikapäringut', async () => {
+    mockQueries({ workCounts: { w1: 1 }, workFacets: {} });
+
+    await searchContent(mockIndex, 'tartu', 1, {});
+
+    expect(searchCalls().every((p) => (p.limit ?? 0) < 1000)).toBe(true);
+    expect(mockSearch).toHaveBeenCalledTimes(3);
+  });
+
+  it('liidab respondens_names autorite facetiga, nagu varem', async () => {
+    mockQueries({
+      workCounts: { w1: 1, w2: 1 },
+      workFacets: { author_names: { Luden: 2 }, respondens_names: { Luden: 1, Virginius: 3 } },
+    });
+
+    const res = await searchContent(mockIndex, 'tartu', 1, {});
+
+    expect(res.facetDistribution?.['author_names']).toEqual({ Luden: 3, Virginius: 3 });
+  });
+
+  it('säilitab work_id faceti, mida tulemuste vaade kasutab lehekülgede arvuks', async () => {
+    mockQueries({ workCounts: { w1: 9, w2: 3 }, workFacets: {} });
+
+    const res = await searchContent(mockIndex, 'tartu', 1, {});
+
+    expect(res.facetDistribution?.['work_id']).toEqual({ w1: 9, w2: 3 });
+  });
+
+  it('jagab suure teoste hulga partiideks ja liidab loendurid', async () => {
+    const workCounts: Record<string, number> = {};
+    for (let i = 0; i < 1500; i++) workCounts[`w${i}`] = 1;
+    mockQueries({
+      workCounts,
+      workFacetsByBatch: [
+        { genre_ids: { Q1: 800, Q2: 200 } },
+        { genre_ids: { Q1: 400, Q3: 100 } },
+      ],
+    });
+
+    const res = await searchContent(mockIndex, 'de', 1, {});
+
+    expect(searchCalls().filter(isWorkLevelQuery)).toHaveLength(2);
+    expect(res.facetDistribution?.['genre_ids']).toEqual({ Q1: 1200, Q2: 200, Q3: 100 });
+  });
+
+  it('facet-päringu tõrge ei võta tulemusi maha', async () => {
+    mockSearch.mockImplementation((_q: string, params: any = {}) => {
+      if (isWorkLevelQuery(params)) return Promise.reject(new Error('filter too long'));
+      if (isPageCountQuery(params)) {
+        return Promise.resolve({ hits: [], estimatedTotalHits: 12, facetDistribution: { work_id: { w1: 9, w2: 3 } } });
+      }
+      return Promise.resolve({ hits: [{ id: 'p1', work_id: 'w1' }], estimatedTotalHits: 12 });
+    });
+
+    const res = await searchContent(mockIndex, 'tartu', 1, {});
+
+    expect(res.totalWorks).toBe(2);
+    expect(res.hits).toHaveLength(1);
+    expect(res.facetDistribution?.['work_id']).toEqual({ w1: 9, w2: 3 });
+  });
+
+  it('laseb katkestuse veal läbi, et vana otsing ei kirjutaks uut üle', async () => {
+    mockSearch.mockImplementation((_q: string, params: any = {}) => {
+      if (isWorkLevelQuery(params)) {
+        return Promise.reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+      }
+      if (isPageCountQuery(params)) {
+        return Promise.resolve({ hits: [], estimatedTotalHits: 1, facetDistribution: { work_id: { w1: 1 } } });
+      }
+      return Promise.resolve({ hits: [], estimatedTotalHits: 1 });
+    });
+
+    await expect(searchContent(mockIndex, 'tartu', 1, {})).rejects.toThrow();
+  });
+
+  it('ei tee teosetasandi päringut, kui ükski teos ei vastanud', async () => {
+    mockQueries({ workCounts: {}, workFacets: {} });
+
+    const res = await searchContent(mockIndex, 'xyzzy', 1, {});
+
+    expect(searchCalls().some(isWorkLevelQuery)).toBe(false);
+    expect(res.totalWorks).toBe(0);
+  });
+});

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -454,6 +454,74 @@ export const searchWorks = async (index: Index, query: string, options?: Dashboa
   }
 };
 
+// Mitu teost korraga ühte work_id IN [...] filtrisse. Kogu korpus (~1300 teost)
+// mahub praegu ühte päringusse; partiideks jagamine hoiab filtri stringi ohjes,
+// kui korpus kasvab.
+const WORK_FACET_BATCH = 1000;
+
+/**
+ * Teosepõhised facet-loendurid: mitu TEOST (mitte lehekülge) vastab igale
+ * žanrile/tüübile/märksõnale/autorile.
+ *
+ * Meilisearchi facetDistribution loendab alati dokumente ega arvesta
+ * `distinct`-iga. Kuna indeksis on üks dokument lehekülje kohta ja metaandmed on
+ * igale leheküljele denormaliseeritud, saame teosepõhise loenduri, piirates
+ * dokumendihulga iga teose esimese leheküljega.
+ *
+ * Eeldus: igal teosel on indeksis `lehekylje_number = 1` (kontrollitud
+ * tootmiskorpusel 1264/1264). Kui mõnel puudub, jääb ta facet-loendurist välja,
+ * kuid teoste koguarv (work_id facet) on siiski õige.
+ */
+async function fetchWorkLevelFacets(
+  index: Index,
+  workIds: string[],
+  facetFields: string[],
+  requestConfig?: { signal?: AbortSignal },
+): Promise<Record<string, Record<string, number>>> {
+  const merged: Record<string, Record<string, number>> = {};
+  for (const field of [...facetFields, 'author_names', 'originaal_kataloog']) {
+    merged[field] = {};
+  }
+  if (workIds.length === 0) return merged;
+
+  const batches: string[][] = [];
+  for (let i = 0; i < workIds.length; i += WORK_FACET_BATCH) {
+    batches.push(workIds.slice(i, i + WORK_FACET_BATCH));
+  }
+
+  let responses;
+  try {
+    responses = await Promise.all(batches.map(batch => index.search('', {
+      limit: 0,
+      filter: [
+        `work_id IN [${batch.map(id => `"${id}"`).join(', ')}]`,
+        'lehekylje_number = 1',
+      ],
+      facets: [...facetFields, 'author_names', 'respondens_names', 'originaal_kataloog'],
+    }, requestConfig)));
+  } catch (error) {
+    // Katkestus peab läbi minema, muidu kirjutaks vana otsing uue tulemused üle.
+    if (requestConfig?.signal?.aborted || isAbortError(error)) throw error;
+    // Muu tõrge: tulemused ja koguarvud on juba käes — jäta külgriba filtrid tühjaks,
+    // ära võta kogu otsingut maha.
+    console.error('fetchWorkLevelFacets error:', error);
+    return merged;
+  }
+
+  for (const response of responses) {
+    const dist = (response as any).facetDistribution || {};
+    for (const [field, values] of Object.entries(dist)) {
+      // Respondendid on otsingu külgribas autorite all, nagu varasemas loogikas.
+      const target = field === 'respondens_names' ? 'author_names' : field;
+      if (!merged[target]) merged[target] = {};
+      for (const [value, count] of Object.entries(values as Record<string, number>)) {
+        merged[target][value] = (merged[target][value] || 0) + count;
+      }
+    }
+  }
+  return merged;
+}
+
 // Täisteksti otsing
 // Kui workId on määratud - otsib ainult sellest teosest (kõik vasted, ilma distinct'ita)
 // Muidu - tagastab 10 teost (distinct), iga teose kohta 1 esinduslik vaste
@@ -607,22 +675,17 @@ export const searchContent = async (index: Index, query: string, page: number = 
     }
 
     // 2. Kui otsingusõna ON OLEMAS (sisuotsing)
-    // Siis me ei saa kasutada 'lehekylje_number = 1' filtrit, sest otsitav sõna võib olla mujal.
-    // Lahendus: Tõmbame "statistika päringuga" suure hulga vasteid (ainult ID ja meta) ja agregeerime brauseris.
+    // Otsitav sõna võib olla ükskõik millisel leheküljel, seega ei saa vasteid
+    // otse 'lehekylje_number = 1' filtriga teose tasandile viia.
+    //
+    // Kaheastmeline lahendus (#174): work_id facet annab KÕIK vastavad teosed
+    // (ei sõltu ühestki limiidist), seejärel küsime nende teoste facetid ühelt
+    // dokumendilt teose kohta. Varem tõmmati 5000 vastet ja agregeeriti brauseris —
+    // see oli kallutatud (laia päringu 5000 hitti katsid ~135 teost 1154-st),
+    // maksis ~1 s ja 5–7 MB (pakkimata) iga otsingu kohta.
     else {
-      // Optimeerimine: Küsime max 5000 vastet statistika jaoks.
-      // See katab 99% tavalistest otsingutest. Väga üldiste otsingute puhul ("a") on see ligikaudne.
-      const STATS_LIMIT = 5000;
-
-      const [statsResponse, distinctResponse, pageCountResponse] = await Promise.all([
-        // Päring 1: Statistika (kõik vasted, ainult metaandmed)
-        index.search(query, {
-          filter,
-          limit: STATS_LIMIT,
-          attributesToRetrieve: ['id', 'work_id', 'title', 'year', 'location', 'publisher', 'creators', 'genre_object', 'type_object', 'collections', 'collections_hierarchy', 'author_names', 'respondens_names', 'tags_object', genreFacetField, typeFacetField, tagsFacetField],
-          attributesToSearchOn: attributesToSearchOn
-        }, requestConfig),
-        // Päring 2: Sisu (kuvatavad teosed, distinct)
+      const [distinctResponse, pageCountResponse] = await Promise.all([
+        // Päring 1: Sisu (kuvatavad teosed, distinct)
         index.search(query, {
           offset,
           limit,
@@ -636,7 +699,8 @@ export const searchContent = async (index: Index, query: string, page: number = 
           highlightPostTag: HIGHLIGHT_POST_TAG,
           attributesToSearchOn: attributesToSearchOn
         }, requestConfig),
-        // Päring 3: Lehekülgede arvud teoste kaupa (work_id facet)
+        // Päring 2: Lehekülgede arvud teoste kaupa (work_id facet).
+        // Sama päring annab ka kõigi vastavate teoste ID-d ja täpsed koguarvud.
         index.search(query, {
           filter,
           limit: 0,
@@ -645,57 +709,28 @@ export const searchContent = async (index: Index, query: string, page: number = 
         }, requestConfig)
       ]);
 
-      // Arvuta unikaalsete teoste statistika käsitsi
-      const uniqueWorks = new Set<string>();
-      const calculatedFacets: Record<string, Record<string, number>> = {
-        [genreFacetField]: {},
-        [typeFacetField]: {},
-        [tagsFacetField]: {},
-        'author_names': {},
-        'originaal_kataloog': {} // Seda me stats querys ei küsinud, aga võiks
-      };
-
-      statsResponse.hits.forEach((hit: any) => {
-        const workId = hit.work_id;
-        if (workId && !uniqueWorks.has(workId)) {
-          uniqueWorks.add(workId);
-
-          // Helper stats
-          const addToStats = (field: string, value: string | string[]) => {
-             if (!value) return;
-             const values = Array.isArray(value) ? value : [value];
-             values.forEach(v => {
-               if (!calculatedFacets[field][v]) calculatedFacets[field][v] = 0;
-               calculatedFacets[field][v]++;
-             });
-          };
-
-          addToStats(genreFacetField, hit[genreFacetField]);
-          addToStats(typeFacetField, hit[typeFacetField]);
-          addToStats(tagsFacetField, hit[tagsFacetField]);
-          addToStats('author_names', hit.author_names);
-          addToStats('author_names', hit.respondens_names);
-        }
-      });
-
-      // Lisa work_id facet (lehekülgede arvud) otse Meilisearchist
-      calculatedFacets['work_id'] = pageCountResponse.facetDistribution?.['work_id'] || {};
-
-      const workHitCounts = pageCountResponse.facetDistribution?.['work_id'] || {};
+      const workIdFacet = pageCountResponse.facetDistribution?.['work_id'];
+      const workHitCounts = workIdFacet || {};
       const facetWorkIds = Object.keys(workHitCounts);
 
-      // work_id facet loendab KÕIKI vastavaid teoseid, sõltumata STATS_LIMIT-ist ja
-      // maxTotalHits=10000 lakkest. Varem võeti see arv üle piiri minnes
-      // distinctResponse.estimatedTotalHits-ist, mis loeb lehekülgi, mitte teoseid:
-      // "est" näitas 10 000 teost tegeliku 1074 asemel (~9x liiga palju).
-      // Facet on tasuta — see päring tehakse niikuinii lehekülgede arvude jaoks.
-      if (facetWorkIds.length > 0) {
-        totalWorks = facetWorkIds.length;
-      } else if ((statsResponse.estimatedTotalHits || 0) <= STATS_LIMIT) {
-        totalWorks = uniqueWorks.size;
-      } else {
-        totalWorks = distinctResponse.estimatedTotalHits || uniqueWorks.size;
-      }
+      // Päring 3: teosepõhised facetid — üks dokument teose kohta (esimene lehekülg).
+      // Meilisearchi facetDistribution EI arvesta distinct'iga (mõõdetud), seega
+      // ainus viis teosepõhiste loenduriteni on piirata dokumendihulk ühe leheküljega.
+      const calculatedFacets = await fetchWorkLevelFacets(
+        index, facetWorkIds,
+        [genreFacetField, typeFacetField, tagsFacetField],
+        requestConfig,
+      );
+
+      // Lisa work_id facet (lehekülgede arvud) otse Meilisearchist
+      calculatedFacets['work_id'] = workHitCounts;
+
+      // work_id facet loendab KÕIKI vastavaid teoseid, sõltumata maxTotalHits=10000
+      // lakkest. Varem võeti see arv distinctResponse.estimatedTotalHits-ist, mis
+      // loeb lehekülgi, mitte teoseid: "est" näitas 10 000 teost tegeliku 1074 asemel.
+      // Puuduv facet (nt indeksi seadistus katki) langeb tagasi vanale hinnangule —
+      // tühi facet tähendab seevastu päriselt nulli vastet.
+      totalWorks = workIdFacet ? facetWorkIds.length : (distinctResponse.estimatedTotalHits || 0);
       const hitsWithCounts = distinctResponse.hits.map((hit: any) => ({
         ...normalizeContentSearchHit(hit),
         hitCount: workHitCounts[hit.work_id] || 1
@@ -707,7 +742,7 @@ export const searchContent = async (index: Index, query: string, page: number = 
 
       return {
         hits: hitsWithCounts as any,
-        totalHits: facetPageTotal || pageCountResponse.estimatedTotalHits || 0, // Lehekülgi kokku
+        totalHits: (workIdFacet ? facetPageTotal : pageCountResponse.estimatedTotalHits) || 0, // Lehekülgi kokku
         totalWorks: totalWorks,
         totalPages: Math.ceil(totalWorks / limit),
         page,


### PR DESCRIPTION
Sulgeb #174. Jätkab PR #198-t (teoste/vastete arv), mis parandas numbrid; see PR parandab **facetid** ja eemaldab 5000-hiti päringu.

## Probleem

Külgriba facetid (žanr / tüüp / märksõna / autor) arvutati esimesest 5000 hitist. Need hitid kuhjuvad vähestesse teostesse — **"tartu" 5000 hitti katsid ainult 135 teost 1154-st**. Filtriloendid olid seega kallutatud valimi pealt, mitte ainult numbrite poolest valed.

## Kaks teed, mõõdetud tootmiskorpusel

Tõde arvutati praegusest teest kitsale päringule (kus 5000 katab kõik vasted).

**A) `distinct: 'work_id'` + `facets`** — **VALE**. Meilisearchi `facetDistribution` ei arvesta `distinct`-iga, loeb ikka lehekülgi:

| facet | erinevust tõest (tartu) |
|---|---|
| genre_ids | 17 |
| type_ids | 2 |
| tags_ids | 87 |
| author_names | 201 |

**B) `work_id IN [...] AND lehekylje_number = 1`** — **TÄPNE**. Null erinevust kõigil neljal väljal, mõlemal katsepäringul (tartu 776 teost, philosophia 554 teost).

Valitud B: `work_id` facet annab kõik vastavad teosed, seejärel üks dokument teose kohta annab teosepõhised loendurid.

## Mõõdetud tulemus ("de", 1234 teost)

| | seinakell | juhtmel (gzip) |
|---|---|---|
| vana (stats-päring) | 2044 ms | 443 KB |
| uus (3 päringut) | **~744 ms** | **61 KB** |

Kuva- ja work_id-päring käivad paralleelselt, facet-päring järgneb.

## Servajuhud kontrollitud

- **Kõigil 1264 teosel on indeksis `lehekylje_number = 1`** — eeldus kehtib. Kui mõnel puuduks, jääks ta facet-loendurist välja, aga teoste koguarv oleks siiski õige.
- Halvim juht: 1234 teost → filter 12 KB, 429 ms, vastus 38 KB.
- Partiideks jagamine 1000 kaupa (`WORK_FACET_BATCH`) hoiab skaleerumise lahti; loendurid liidetakse.
- `respondens_names` liidetakse `author_names` alla, nagu varasemas loogikas.
- **Facet-päringu tõrge ei võta enam tulemusi maha** — külgriba jääb tühjaks, tulemused ja koguarvud on käes. Katkestus (`AbortError`) läheb siiski läbi, et vana otsing ei kirjutaks uut üle.

## Mida EI tehtud

Issue punkt 6 (toorte täisteksti väljade eemaldamine kuva-päringust): mõõtsin — kuva-päring on **24 KB juhtmel** ja `text_content`-i eemaldamine säästaks **2,8 KB**. Ei kaalu regressiooniriski üles, kui midagi vaates seda välja kasutab.

## Testid

9 uut (`searchContentFacets.test.ts`): facetid tulevad teosetasandi päringust; päringu kuju (`work_id IN`, `lehekylje_number = 1`, `limit: 0`); 5000-hiti päringut enam ei tehta; respondentide liitmine; `work_id` faceti säilimine; partiideks jagamine ja loendurite liitmine; tühi tulemus; tõrke- ja katkestuskäitumine.

Frontend 650 passed, typecheck puhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)