### PR TITLE
perf: HTTP/2, brotli ja piltidele oma rate-limit tsoon (#177)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,26 @@ Frontend deploy (pärast `npm run build` lokaalses masinas):
 rsync -avz --delete dist/ vutt:~/VUTT/dist/
 ```
 
+`npm run build` teeb Vite build'i JA eelkompressiooni (`scripts/precompress-dist.mjs`):
+iga tekstivara kõrvale tekib `.br` (brotli 11) ja `.gz` (gzip 9). nginx serveerib
+need `brotli_static`/`gzip_static` kaudu — **need failid PEAVAD rsync'iga kaasa
+minema**, muidu langeb server tagasi lennult pakkimisele (~15% suurem).
+
+### nginx konfiguratsioon
+
+Aktiivne config on serveris (`/etc/nginx/sites-available/vutt`), **mitte gitis** —
+repos on koopia `nginx.host.conf`. Muutmisel uuenda MÕLEMAT:
+
+```bash
+scp nginx.host.conf vutt:/tmp/vutt.nginx.new
+ssh vutt 'sudo cp /tmp/vutt.nginx.new /etc/nginx/sites-available/vutt && sudo nginx -t && sudo systemctl reload nginx'
+```
+
+Eeldused hostis (ei ole `nginx.host.conf`-is): rate-limit tsoonid
+`/etc/nginx/nginx.conf` http{} blokis (`vutt_auth` 1r/s, `vutt_api` 10r/s,
+`vutt_meili` 20r/s, `vutt_images` 60r/s) ja brotli moodulid
+(`libnginx-mod-http-brotli-filter`, `libnginx-mod-http-brotli-static`).
+
 ## Architecture
 
 ```

--- a/nginx.host.conf
+++ b/nginx.host.conf
@@ -4,13 +4,17 @@
 #   limit_req_zone $binary_remote_addr zone=vutt_auth:10m rate=1r/s;
 #   limit_req_zone $binary_remote_addr zone=vutt_api:10m rate=10r/s;
 #   limit_req_zone $binary_remote_addr zone=vutt_meili:10m rate=20r/s;
+#   limit_req_zone $binary_remote_addr zone=vutt_images:10m rate=60r/s;
 #   limit_req_status 429;
+#
+# Eeldab ka brotli mooduleid (Ubuntu: libnginx-mod-http-brotli-filter,
+# libnginx-mod-http-brotli-static) — vt /etc/nginx/modules-enabled/.
 
 # Tuvasta sotsiaalmeedia robotid                                                                                                                        
 map $http_user_agent $is_bot {                                                                                                                          
     default 0;
     ~*(facebookexternalhit|twitterbot|Bluesky|whatsapp|telegrambot|linkedinbot|embedly|quora\ link\
-preview|showyoubot|outbrain|pinterest\/0\.|bingbot|googlebot) 1;
+preview|showyoubot|outbrain|slackbot|discordbot|mastodon|pinterest\/0\.|bingbot|googlebot) 1;
 }
 
 server {
@@ -21,7 +25,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
     server_name vutt.utlib.ut.ee;
 
     # SSL Sertifikaadid (eeldatud asukoht host-masinas)
@@ -56,6 +60,21 @@ server {
     gzip_proxied any;
     gzip_comp_level 6;
     gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
+    # Jõudlus: Brotli (gzip jääb alles klientidele, kes br-i ei toeta).
+    # Sama MIME-tüüpide komplekt mis gzip'il. Tase 5 on brotli mõistlik
+    # kompromiss lennult pakkimisel (11 on arhiveerimiseks, mitte serveerimiseks).
+    brotli on;
+    brotli_comp_level 5;
+    brotli_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
+    # Staatilised varad on build'i ajal ette pakitud (scripts/precompress-dist.mjs,
+    # brotli tase 11) — nginx serveerib .br/.gz kõrvalfaili ega paki iga päringu
+    # peal uuesti. Mõõdetud: ette pakitud br-11 võidab gzip-6 ees 15%, lennult
+    # br-5 ainult 6%. Lennult pakkimine jääb alles dünaamilistele vastustele
+    # (Meili otsingutulemused: 2185 B → 967 B).
+    brotli_static on;
+    gzip_static on;
     
     # Logid
     access_log /var/log/nginx/vutt_access.log;
@@ -86,6 +105,14 @@ server {
         expires 1y;
         add_header Cache-Control "public, no-transform";
         access_log off; # Vähendab logimüra
+    }
+
+    # Sitemap: proovi staatilist faili, muidu proxi backendi (dünaamiline XML).
+    # Exact-match, et mitte langeda location / SPA-fallbacki (index.html).
+    location = /sitemap.xml {
+        proxy_pass http://127.0.0.1:8002/sitemap.xml;
+        proxy_set_header Host $host;
+        add_header Cache-Control "no-cache";
     }
 
     # Bot-koduleht: linkgraafi jaotuspunkt (botid saavad serveripoolse indeksi
@@ -151,7 +178,10 @@ server {
 
     # API - pildid (Image Server - Port 8001)
     location /api/images/ {
-        limit_req zone=vutt_api burst=50 nodelay;
+        # Oma tsoon, MITTE vutt_api: dashboard laeb korraga 12+ pisipilti ja
+        # töölaud eellaeb kõrvallehti. Ühises tsoonis sõid pildipäringud API
+        # tokenid ära ja viewer-token/meili-token said 429 (vt #177).
+        limit_req zone=vutt_images burst=100 nodelay;
 
         proxy_pass http://127.0.0.1:8001/;
         proxy_set_header Host $host;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node scripts/precompress-dist.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/scripts/precompress-dist.mjs
+++ b/scripts/precompress-dist.mjs
@@ -1,0 +1,64 @@
+/**
+ * Eelkompressioon: loob dist/ tekstivaradele .br ja .gz kõrvalfailid.
+ *
+ * nginx serveerib need `brotli_static on` / `gzip_static on` kaudu, seega
+ * pakkimine toimub üks kord build'i ajal maksimaalse kvaliteediga (brotli 11),
+ * mitte iga päringu peal (kus mõistlik lagi on ~5).
+ *
+ * Mõõdetud: br-11 annab gzip-6 peale 13–20% juurde; lennult br-5 andis 5–12%.
+ *
+ * Kasutab ainult Node'i sisseehitatud zlib-i — npm-sõltuvust ei lisa.
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import zlib from 'node:zlib';
+
+const DIST = join(process.cwd(), 'dist');
+
+// Ainult tekstivormingud; pildid ja fondid on juba pakitud.
+const EXTENSIONS = new Set(['.js', '.css', '.html', '.svg', '.json', '.txt', '.xml']);
+// Alla selle pole pakkimisest kasu (HTTP-päised söövad võidu ära).
+const MIN_BYTES = 1024;
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(path);
+    else if (entry.isFile()) yield path;
+  }
+}
+
+let files = 0;
+let raw = 0;
+let brotli = 0;
+let gzip = 0;
+
+for (const file of walk(DIST)) {
+  if (!EXTENSIONS.has(extname(file))) continue;
+  if (file.endsWith('.br') || file.endsWith('.gz')) continue;
+  const data = readFileSync(file);
+  if (data.length < MIN_BYTES) continue;
+
+  const br = zlib.brotliCompressSync(data, {
+    params: {
+      [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+      [zlib.constants.BROTLI_PARAM_SIZE_HINT]: data.length,
+    },
+  });
+  const gz = zlib.gzipSync(data, { level: 9 });
+
+  // Kirjuta ainult siis, kui pakitud on päriselt väiksem kui originaal.
+  if (br.length < data.length) writeFileSync(`${file}.br`, br);
+  if (gz.length < data.length) writeFileSync(`${file}.gz`, gz);
+
+  files += 1;
+  raw += data.length;
+  brotli += br.length;
+  gzip += gz.length;
+}
+
+const kb = (n) => (n / 1024).toFixed(1).padStart(7);
+console.log(
+  `precompress: ${files} faili | raw ${kb(raw)} KB → gzip ${kb(gzip)} KB → brotli ${kb(brotli)} KB` +
+  ` (br võit gzip'i ees ${(100 * (gzip - brotli) / gzip).toFixed(1)}%)`
+);


### PR DESCRIPTION
Sulgeb #177. **Muudatused on juba tootmises** (nginx config elab serveris, mitte gitis) — see PR sünkroniseerib repo koopia, lisab build-sammu ja dokumenteerib hosti eeldused.

## 1. HTTP/2

`listen 443 ssl http2;` — nginx 1.24 süntaks (`http2 on;` tuli alles 1.25.1). Varem vastas tootmine HTTP/1.1-ga.

## 2. Piltidele oma rate-limit tsoon

Uus `vutt_images` (60r/s, burst 100) senise jagatud `vutt_api` (10r/s) asemel. Logides olid reaalsed 429-d `api/meili-token`-il ja `notifications`-il ajal, mil brauser laadis pisipilte — pildipäringud sõid API tokenid ära.

Kontroll pärast muudatust: 40 paralleelset pildipäringut ~1 s jooksul → **0 × 429**.

## 3. Brotli — kahes osas, sest mõõtmine näitas vahet

**Lennult (tase 5)** dünaamilistele vastustele. Suurim võit on JSON-il:

| | gzip | brotli |
|---|---|---|
| Meili otsingutulemus | 2185 B | **967 B** |

**Eelkompressioon build'i ajal** staatilistele varadele (`scripts/precompress-dist.mjs`, brotli 11 + gzip 9) + `brotli_static` / `gzip_static`. Vahe oli oluline:

| tee | võit gzip-6 ees |
|---|---|
| lennult br-5 | 6,3% |
| ette pakitud br-11 | **15,0%** |

Esmase laadimise varad kokku: **184,2 → 157,5 KB (-14,5%)**.

| vara | gzip | brotli | võit |
|---|---|---|---|
| vendor-react | 87,3 KB | 75,9 KB | 13,1% |
| index (entry) | 59,3 KB | 50,9 KB | 14,1% |
| index.css | 28,4 KB | 22,9 KB | 19,2% |
| icons | 9,3 KB | 7,8 KB | 15,6% |

Skript kasutab ainult Node'i sisseehitatud `zlib`-i — **npm-sõltuvust ei lisa**. `npm run build` teeb nüüd Vite build'i + eelkompressiooni.

## Kontrollitud tootmises

- kõik marsruudid 200 HTTP/2 (`/`, `/search`, `/persons`, `/sitemap.xml`, `/robots.txt`)
- bot-prerender terve (Googlebot saab endiselt serveripoolse HTML-i)
- `vary: Accept-Encoding` olemas; ainult-gzip klient saab gzip'i; `identity` saab pakkimata
- `content-length` vastab ette pakitud faili suurusele → serveeritakse `.br`, mitte lennult
- `nginx -t` enne iga reload'i; varukoopiad `/etc/nginx/sites-available/vutt.bak-177` ja `nginx.conf.bak-177`

## Repo-hügieen

`nginx.host.conf` oli serveri omast maas (puudusid bot-UA-d `slackbot|discordbot|mastodon` ja `/sitemap.xml` plokk) — sünkitud õiges suunas enne muudatuste lisamist.

CLAUDE.md dokumenteerib nüüd: config'i kahesuunaline uuendamine, hosti eeldused (rate-limit tsoonid `nginx.conf`-is, brotli moodulid) ja selle, et `.br`/`.gz` failid **peavad** rsync'iga kaasa minema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)