### PR TITLE
fix: dashboardi kaanepilt lõigatakse kaardi kastile (udu portreelehtedel)

### DIFF
--- a/server/image_server.py
+++ b/server/image_server.py
@@ -92,13 +92,23 @@ except ImportError:
 # Thumbnaili seaded
 THUMB_HEIGHT = 560  # Kõrgus pikslites (portree- ja topeltlehtedel ühtlane kõrgus)
 THUMB_QUALITY = 85  # JPEG kvaliteet (0-100)
-# Dashboardi kaanepilt on OMA variant: kaart kuvab seda 160 px kõrgusena, seega
-# 360 px katab Retina ja säästab ~60% baite võrreldes leheküljegridi 560/85-ga.
+# Dashboardi kaanepilt on OMA variant, mis LÕIGATAKSE kaardi kastile (mitte ei
+# skaleerita proportsionaalselt nagu leheküljethumb). Kaart (`WorkCard`, `h-40` +
+# `object-cover`) on LAI kast ~320×160 CSS px, seega 640×320 katab Retina.
+#
+# MIKS crop, mitte kõrguse järgi skaleerimine: `object-cover` sobitab pildi kasti
+# SUUREMA teguri järgi. Portreelehelt (2311×3448) andis kõrguse-põhine 360 px vaid
+# 241 px laiust → kaart venitas seda 1,3× (Retinal 2,6×) ja kaas oli udune, samal ajal
+# kui topeltleht (6118×4428) sai 497 px ja näis terav. Crop annab täpselt need pikslid,
+# mida brauser kuvab: portreel kaob udu, topeltlehel kaob raisatud üla-/alaserv.
+#
 # Eraldi nimeruum (_cover_) hoiab selle leheküljethumbidest lahus — vt
 # get_or_create_thumbnail koristusloogika.
-COVER_HEIGHT = 360
-COVER_QUALITY = 80
-COVER_VERSION = 1  # Muutmisel uueneb failinimi → vanad coverid genereeritakse ümber.
+COVER_BOX = (640, 320)
+COVER_QUALITY = 78
+COVER_VERSION = 2  # Muutmisel uueneb failinimi → vanad coverid genereeritakse ümber.
+                   # NB: uuenda ka src/services/workImageService.ts COVER_VERSION-it,
+                   # muidu näeb olemasolev kasutaja brauseri cache'ist vana pilti.
 OG_IMAGE_SIZE = (1200, 630)
 OG_IMAGE_QUALITY = 88
 OG_IMAGE_VERSION = 2  # Muutmisel uueneb failinimi ja jagamis-URL-i cache-võti.
@@ -154,7 +164,9 @@ def generate_thumbnail(source_path, thumb_path, height=THUMB_HEIGHT, quality=THU
         source_path: Lähtefaili tee
         thumb_path: Sihtfaili tee (_thumb_XXXX.jpg)
         height: Thumbnaili kõrgus (laius arvutatakse proportsionaalselt)
-        quality: JPEG kvaliteet (dashboardi kaas kasutab madalamat, vt COVER_QUALITY)
+        quality: JPEG kvaliteet
+
+    NB: dashboardi kaas EI kasuta seda funktsiooni — vt generate_cover/COVER_BOX.
 
     Returns:
         True kui õnnestus, False kui mitte
@@ -192,38 +204,59 @@ def generate_thumbnail(source_path, thumb_path, height=THUMB_HEIGHT, quality=THU
         return False
 
 
+def _generate_fitted_image(source_path, output_path, size, quality, log_tag):
+    """Lõikab pildi täpselt etteantud kasti (nagu CSS ``object-cover``) ja salvestab.
+
+    Kirjutus on atomaarne (tmp + ``os.replace``), sest pildiserver on mitmelõimeline —
+    pooleliolevat faili ei tohi teisele päringule serveerida.
+    """
+    if not PILLOW_AVAILABLE:
+        return False
+
+    tmp_path = None
+    try:
+        with Image.open(source_path) as source:
+            source = ImageOps.exif_transpose(source).convert('RGB')
+            fitted = ImageOps.fit(
+                source,
+                size,
+                method=Image.Resampling.LANCZOS,
+                centering=(0.5, 0.5),
+            )
+
+        tmp_path = f"{output_path}.tmp.{os.getpid()}.{time.time_ns()}"
+        fitted.save(tmp_path, 'JPEG', quality=quality, optimize=True)
+        os.chmod(tmp_path, 0o644)
+        os.replace(tmp_path, output_path)
+        return True
+    except Exception as e:
+        print(f"[{log_tag}] Viga genereerimisel {source_path}: {e}")
+        try:
+            if tmp_path and os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except OSError:
+            pass
+        return False
+
+
 def generate_og_image(source_path, output_path):
     """Genereerib keele-neutraalse 1200×630 jagamispildi.
 
     Esileht täidab ala nagu dashboard'i CSS ``object-cover``. Teksti, gradienti
     ega märgendeid pilti ei lisata, sest sama URL-i jagatakse eri keeltes.
     """
-    if not PILLOW_AVAILABLE:
-        return False
+    return _generate_fitted_image(source_path, output_path, OG_IMAGE_SIZE,
+                                  OG_IMAGE_QUALITY, 'OG')
 
-    try:
-        with Image.open(source_path) as source:
-            source = ImageOps.exif_transpose(source).convert('RGB')
-            card = ImageOps.fit(
-                source,
-                OG_IMAGE_SIZE,
-                method=Image.Resampling.LANCZOS,
-                centering=(0.5, 0.5),
-            )
 
-        tmp_path = f"{output_path}.tmp.{os.getpid()}.{time.time_ns()}"
-        card.save(tmp_path, 'JPEG', quality=OG_IMAGE_QUALITY, optimize=True)
-        os.chmod(tmp_path, 0o644)
-        os.replace(tmp_path, output_path)
-        return True
-    except Exception as e:
-        print(f"[OG] Viga genereerimisel {source_path}: {e}")
-        try:
-            if 'tmp_path' in locals() and os.path.exists(tmp_path):
-                os.remove(tmp_path)
-        except OSError:
-            pass
-        return False
+def generate_cover(source_path, cover_path):
+    """Genereerib dashboardi kaanepildi — esileht lõigatuna kaardi kastile.
+
+    EI kasuta ``generate_thumbnail``-i: see skaleerib kõrguse järgi, mis on õige
+    leheküljegridile (ühtlane kõrgus), aga vale laiale kaardile — vt COVER_BOX.
+    """
+    return _generate_fitted_image(source_path, cover_path, COVER_BOX,
+                                  COVER_QUALITY, 'THUMB')
 
 
 def get_or_create_og_image(work_path):
@@ -254,7 +287,7 @@ def get_or_create_og_image(work_path):
 def get_or_create_thumbnail(work_path):
     """Tagastab teose dashboardi-kaanepildi tee, genereerides selle vajadusel.
 
-    Kaas on OMA variant (`_cover_v{N}_NIMI.jpg`, COVER_HEIGHT/COVER_QUALITY), mitte
+    Kaas on OMA variant (`_cover_v{N}_NIMI.jpg`, COVER_BOX/COVER_QUALITY), mitte
     leheküljegridi thumb. Nimeruum on tahtlikult eraldi: varem kandis kaas sama nime
     kui esilehe grid-thumb (`_thumb_NIMI.jpg`) ja alumine koristus glob'is `_thumb_*.jpg`,
     mistõttu iga dashboardi vaatamine kustutas KÕIK selle teose leheküljethumbid ja
@@ -294,9 +327,7 @@ def get_or_create_thumbnail(work_path):
     # 3. Genereeri vajadusel
     if not os.path.exists(expected_cover_path):
         os.makedirs(thumbs_dir, exist_ok=True)
-        success = generate_thumbnail(first_image, expected_cover_path,
-                                     height=COVER_HEIGHT, quality=COVER_QUALITY)
-        if not success:
+        if not generate_cover(first_image, expected_cover_path):
             return None
 
     return expected_cover_path

--- a/src/services/workImageService.ts
+++ b/src/services/workImageService.ts
@@ -15,7 +15,7 @@ export const getFullImageUrl = (imagePath: string): string => {
 // URL on stabiilne (/{work_id}/_thumb) ja pildid on 30 päeva brauseri-cache'is, seega
 // serveripoolsest failinime-versioonist üksi ei piisa: ilma ?v-ta näeks olemasolev
 // kasutaja vana 560 px pilti kuni cache aegumiseni.
-const COVER_VERSION = 1;
+const COVER_VERSION = 2;
 
 // Kaanepildi URL konstrueerimine (server leiab ise õige faili)
 export const getThumbUrl = (workId: string): string => {

--- a/tests/test_image_server.py
+++ b/tests/test_image_server.py
@@ -111,7 +111,7 @@ def test_get_or_create_og_image_uses_first_page_and_cache(tmp_path):
 def _make_work(tmp_path, pages=3, size=(400, 600)):
     from PIL import Image
     work = tmp_path / "work"
-    work.mkdir()
+    work.mkdir(parents=True)
     for i in range(1, pages + 1):
         Image.new("RGB", size, "white").save(work / f"page_00{i}.jpg")
         (work / f"page_00{i}.json").write_text('{"sequence": %d}' % i, encoding="utf-8")
@@ -131,15 +131,30 @@ def test_cover_on_eraldi_versioonitud_fail(tmp_path):
     assert os.path.exists(first)
 
 
-def test_cover_on_360px_korgusega(tmp_path):
-    """CSS kuvab 160 px; 360 px katab Retina. Varem 560 px."""
+def test_cover_on_kaardi_kasti_moodus(tmp_path):
+    """Kaart on LAI kast (h-40 + object-cover) — kaas peab katma laiuse, mitte ainult
+    kõrguse. Ainult kõrguse järgi skaleerimine andis portreelehelt 241 px laia pildi,
+    mida kaart venitas ~1,3× (Retinal 2,6×) → udu."""
     from PIL import Image
-    from server.image_server import get_or_create_thumbnail, COVER_HEIGHT
+    from server.image_server import get_or_create_thumbnail, COVER_BOX
 
     work = _make_work(tmp_path)
     with Image.open(get_or_create_thumbnail(str(work))) as img:
-        assert img.height == COVER_HEIGHT == 360
-        assert img.width == 240  # 400x600 → proportsionaalne
+        assert img.size == COVER_BOX == (640, 320)
+
+
+def test_cover_on_sama_moodus_ka_topeltlehel(tmp_path):
+    """REGRESSIOON: portreeleht (udu) ja topeltleht (terav) said varem eri laiuse
+    (241 vs 497 px). Kaardi kast on sama → kaas peab olema sama."""
+    from PIL import Image
+    from server.image_server import get_or_create_thumbnail
+
+    portree = _make_work(tmp_path / "a", size=(2311, 3448))
+    topelt = _make_work(tmp_path / "b", size=(6118, 4428))
+
+    with Image.open(get_or_create_thumbnail(str(portree))) as a, \
+            Image.open(get_or_create_thumbnail(str(topelt))) as b:
+        assert a.size == b.size == (640, 320)
 
 
 def test_cover_ei_kustuta_lehekulje_thumbe(tmp_path):
@@ -206,7 +221,8 @@ def test_invalidate_cover_ei_puutu_teise_lehe_muutmisel(tmp_path):
 
 
 def test_cover_on_vaiksem_kui_vana_560px_variant(tmp_path):
-    """Mõõdetav eesmärk: ~60% väiksem payload dashboardi kaardi kohta."""
+    """Kaas peab jääma leheküljegridi thumbist kergemaks. Crop lisab laiust, aga võtab
+    ära üla-/alaserva, mida kaart niikuinii ei kuva — päris skaneeringul 75 → 60 kB."""
     from server.image_server import generate_thumbnail, get_or_create_thumbnail
 
     work = _make_work(tmp_path, size=(1200, 1800))


### PR DESCRIPTION
## Probleem

Osad dashboardi kaanepildid on udused, teised teravad. Näited: [xq9m53](https://vutt.utlib.ut.ee/work/xq9m53) terav, [nxm6nl](https://vutt.utlib.ut.ee/work/nxm6nl) udune.

## Juurpõhjus

Kaant skaleeriti **ainult kõrguse järgi** (`COVER_HEIGHT = 360`), aga kaart (`WorkCard`, `h-40` + `object-cover`) on **lai kast**, kus sidumisdimensioon on **laius**. `object-cover` sobitab pildi kasti suurema teguri järgi:

| Teos | Esilehe originaal | Kaas | Tulemus |
|---|---|---|---|
| `nxm6nl` | 2311×3448 **portree** | **241**×360 | venitatud 1,3× (Retinal 2,6×) → udu |
| `xq9m53` | 6118×4428 **topeltleht** | **497**×360 | mahub → terav |

Ehk **kõik üheleheküljelised teosed olid udused, topeltleheküljelised teravad**. 82-st juba genereeritud kaanest oli 65 (79%) kitsad.

Koodikommentaar (`image_server.py`) põhjendas 360 px valikut sõnadega "kaart kuvab seda 160 px kõrgusena, seega 360 px katab Retina" — arvestus vaatas ainult kõrgust ja jättis kõrvale, et `object-cover` lõikab portreepildi kõrgust ja **venitab laiust**.

## Lahendus

Kaas lõigatakse serveripoolselt kaardi kastile (`ImageOps.fit`), st genereeritakse täpselt need pikslid, mida brauser kuvab:

- `COVER_HEIGHT = 360` → `COVER_BOX = (640, 320)` (kaardi ~320×160 CSS px @2x), `COVER_QUALITY` 80 → 78
- uus `generate_cover()`; `get_or_create_thumbnail` ei kutsu enam `generate_thumbnail`-i (see jääb leheküljegridile, kus kõrguse järgi skaleerimine ongi õige)
- `generate_og_image` + `generate_cover` jagavad `_generate_fitted_image` abifunktsiooni → kaanekirjutus sai ka atomaarse tmp+`os.replace` mustri (pildiserver on mitmelõimeline)
- `COVER_VERSION` 1 → 2 **mõlemas otsas**: serveripoolne failinimi (vanad `_cover_v1_*` koristab olemasolev glob-loogika esimesel päringul — migratsiooniskripti pole vaja) ja `workImageService.ts` `?v=` (URL on stabiilne, pildid 30 päeva brauseri cache'is)

## Baidid (mõõdetud päris skaneeringutel)

| | enne | pärast |
|---|---|---|
| portree (`nxm6nl`) | 28,5 kB | 59,5 kB |
| topeltleht (`xq9m53`) | 32,8 kB | 30,6 kB |

Portree kasvab, sest praegune fail oli väike just alalahutuse tõttu. Topeltleht **kahaneb**, sest crop viskab ära üla-/alaserva, mida kaart niikuinii ei kuvanud. Dashboardi leht (12 kaarti): ~353 → ~640 kB, lazy-load'itud ja cache'itud.

## Testid

`test_cover_on_360px_korgusega` asendatud kahega:
- `test_cover_on_kaardi_kasti_moodus` — kaas on `COVER_BOX`-mõõdus
- `test_cover_on_sama_moodus_ka_topeltlehel` — regressioonitest: portree ja topeltleht annavad **sama** mõõdu (erinev mõõt ongi see bug)

`1004 passed`, `tsc --noEmit` puhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)