### PR TITLE
refactor: ühtne salvestamata muudatuste dialoog (4 erinevat → 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-28-uhtne-salvestamata-muudatuste-dialoog.md
+++ b/docs/superpowers/plans/2026-07-28-uhtne-salvestamata-muudatuste-dialoog.md
@@ -1,0 +1,1684 @@
+# Ühtne salvestamata muudatuste dialoog — implementatsiooniplaan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Asendada neli erinevat salvestamata muudatuste hoiatust ühe dialoogiga, millel on kolm valikut (Loobu muudatustest / Jää siia / Salvesta ja jätka) ja üks ettearvatav käitumismudel.
+
+**Architecture:** Kolm kihti. `unsavedChangesFlow.ts` on puhas olekumasin (ei Reacti, ei DOM-i) — siin elavad kõik otsused ja seda katavad testid. `useUnsavedChangesGuard.ts` on Reacti kiht — Router `useBlocker`, `beforeunload`, async `onSave` ja ühekordne möödapääs. `UnsavedChangesDialog.tsx` on puhas presentatsioon — renderdab, hoiab fookust, kuulab klahve, ei tea ootel tegevusest midagi.
+
+**Tech Stack:** React 19, TypeScript, react-router-dom `useBlocker`, Tailwind, i18next, Vitest (`environment: 'node'`).
+
+**Spec:** `docs/superpowers/specs/2026-07-28-uhtne-salvestamata-muudatuste-dialoog-design.md`
+
+**Haru:** `feat/uhtne-salvestamata-dialoog` (juba olemas, spec on seal commitis)
+
+## Global Constraints
+
+- **Kommentaarid koodis on eesti keeles.** UI on eesti + inglise.
+- **Tõlkevõti tuleb lisada MÕLEMASSE keelde korraga** (`src/locales/et/` ja `src/locales/en/`). `fallbackLng` on välja lülitatud (ADR 0011) — puuduv võti katkestab buildi testis `src/locales/__tests__/localeParity.test.ts`.
+- **Väravad enne iga commit'i:** `npm run typecheck` ja `npm run test` peavad mõlemad läbima.
+- **ESLint lävi:** `npm run lint` `--max-warnings 56`. Parandades LANGETA arvu, ära tõsta.
+- Ei lisata uusi npm-sõltuvusi. Vitest jääb `environment: 'node'`, `include: ['src/**/*.test.ts']`.
+- Kollane nupp on **`bg-amber-600 text-white`** (sama mis `MetadataModal.tsx:922`). Ära muuda ühtegi olemasolevat kollast nuppu — kontrasti parandus on eraldi ülesanne.
+- Punane nupp on **`bg-red-600 hover:bg-red-700 text-white`** (sama mis `Places.tsx:302`).
+- Töö käib lokaalselt. Serverisse midagi ei deploy'ta selle plaani raames.
+
+---
+
+## Failide struktuur
+
+| Fail | Vastutus |
+|---|---|
+| `src/hooks/unsavedChangesFlow.ts` | **uus.** Puhas olekumasin: ootel tegevus, salvestusolek, ühekordne möödapääs. Ei impordi Reacti. |
+| `src/hooks/__tests__/unsavedChangesFlow.test.ts` | **uus.** 13 testi olekumasinale. |
+| `src/components/UnsavedChangesDialog.tsx` | **uus.** Kolme-nupu dialoog. Puhas presentatsioon, 6 propi. |
+| `src/hooks/useUnsavedChangesGuard.ts` | Ümber kirjutatud. Reacti kiht olekumasina ümber. |
+| `src/components/editor/useEditorSave.ts` | `runSave` / `handleSaveWithDrafts` tagastavad `boolean`. |
+| `src/pages/Workspace.tsx` | `pendingNavigation` ja `requestAnimationFrame` hack kaovad. |
+| `src/prosopography/pages/PersonEditPage.tsx` | `handleSave` jagatud; `skipGuardRef` → `allowNextNavigation()`. |
+| `src/pages/admin/PlacesDetail.tsx` | Päris dirty-arvutus; `handleSave` tagastab `boolean`; salvestus `saveRef`-i kaudu üles. |
+| `src/pages/admin/Places.tsx` | Guard lisatud; käsitsi modaal kaob. |
+| `src/pages/WorkManage.tsx` | `window.confirm` → `ConfirmModal`; guard lisatud. |
+| `src/components/ConfirmModal.tsx` | Esc + taustaklõps = tühista. |
+| `src/locales/{et,en}/common.json` | `unsavedChanges` plokk laiendatud. |
+| `src/locales/{et,en}/workspace.json` | `confirm.*` eemaldatud; `manage.reorder*` täiendatud. |
+| `src/locales/{et,en}/admin.json` | `places.unsaved*` eemaldatud. |
+
+---
+
+## Task 1: Puhas olekumasin
+
+**Files:**
+- Create: `src/hooks/unsavedChangesFlow.ts`
+- Test: `src/hooks/__tests__/unsavedChangesFlow.test.ts`
+
+**Interfaces:**
+- Consumes: midagi (esimene ülesanne)
+- Produces: `GuardState`, `PendingTransition`, `initialGuardState`, `requestTransition`, `stay`, `discard`, `beginSave`, `finishSave`, `allowNextTransition`, `consumeAllowance`. Kõik järgnevad ülesanded kasutavad neid.
+
+**Taust:** Miks puhas moodul? Vitest on projektis `environment: 'node'` ja `include: ['src/**/*.test.ts']` — komponenditestide infrat (jsdom, testing-library) ei ole ja seda ei lisata. Sama mustrit kasutab juba `src/components/markdownEditorHelpers.ts` + selle test. Kriitiline invariant (ebaõnnestunud salvestus EI navigeeri) saab siin päris katte.
+
+- [ ] **Step 1: Kirjuta ebaõnnestuv test**
+
+Loo `src/hooks/__tests__/unsavedChangesFlow.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import {
+  initialGuardState,
+  requestTransition,
+  stay,
+  discard,
+  beginSave,
+  finishSave,
+  allowNextTransition,
+  consumeAllowance,
+} from '../unsavedChangesFlow';
+
+describe('requestTransition', () => {
+  it('lubab ülemineku kohe, kui muudatusi ei ole', () => {
+    const run = vi.fn();
+    const r = requestTransition(initialGuardState, false, { run });
+    expect(r.runNow).toBe(true);
+    expect(r.state.pending).toBeNull();
+  });
+
+  it('paneb ülemineku ootele, kui on salvestamata muudatusi', () => {
+    const run = vi.fn();
+    const r = requestTransition(initialGuardState, true, { run });
+    expect(r.runNow).toBe(false);
+    expect(r.state.pending?.run).toBe(run);
+  });
+
+  it('esimene ootel tegevus võidab — uus ei asenda seda', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run: first });
+    const b = requestTransition(a.state, true, { run: second });
+    expect(b.runNow).toBe(false);
+    expect(b.state.pending?.run).toBe(first);
+  });
+
+  it('salvestamise ajal saabuv uus soov ei muuda ootel tegevust', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run: first });
+    const saving = beginSave(a.state);
+    const b = requestTransition(saving.state, true, { run: second });
+    expect(b.runNow).toBe(false);
+    expect(b.state.pending?.run).toBe(first);
+    expect(b.state.saving).toBe(true);
+  });
+});
+
+describe('stay', () => {
+  it('eemaldab ootel tegevuse täielikult', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const s = stay(a.state);
+    expect(s.pending).toBeNull();
+    expect(s.saveFailed).toBe(false);
+    expect(s.allowNext).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('kustutab ka eelmise salvestusvea', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const failed = finishSave(beginSave(a.state).state, false);
+    expect(failed.state.saveFailed).toBe(true);
+    expect(stay(failed.state).saveFailed).toBe(false);
+  });
+});
+
+describe('discard', () => {
+  it('vabastab ootel tegevuse salvestamata ja annab ühekordse loa', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const d = discard(a.state);
+    expect(d.action).toBe(run);
+    expect(d.state.pending).toBeNull();
+    expect(d.state.allowNext).toBe(true);
+  });
+
+  it('ei jäta möödapääsu aktiivseks pärast tarbimist', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const d = discard(a.state);
+    const c = consumeAllowance(d.state);
+    expect(c.allowed).toBe(true);
+    expect(c.state.allowNext).toBe(false);
+    expect(consumeAllowance(c.state).allowed).toBe(false);
+  });
+});
+
+describe('beginSave', () => {
+  it('alustab salvestamist, kui see veel ei käi', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const b = beginSave(a.state);
+    expect(b.start).toBe(true);
+    expect(b.state.saving).toBe(true);
+    expect(b.state.saveFailed).toBe(false);
+  });
+
+  it('topeltklikk ei alusta teist salvestust', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const first = beginSave(a.state);
+    const second = beginSave(first.state);
+    expect(second.start).toBe(false);
+    expect(second.state).toBe(first.state);
+  });
+});
+
+describe('finishSave', () => {
+  it('käivitab ootel tegevuse, kui salvestamine õnnestus', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const f = finishSave(beginSave(a.state).state, true);
+    expect(f.action).toBe(run);
+    expect(f.state.pending).toBeNull();
+    expect(f.state.saving).toBe(false);
+    expect(f.state.allowNext).toBe(true);
+  });
+
+  it('EI käivita ootel tegevust, kui salvestamine ebaõnnestus', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const f = finishSave(beginSave(a.state).state, false);
+    expect(f.action).toBeNull();
+    expect(f.state.pending?.run).toBe(run);
+    expect(f.state.saving).toBe(false);
+    expect(f.state.saveFailed).toBe(true);
+    expect(f.state.allowNext).toBe(false);
+  });
+
+  it('pärast ebaõnnestunud salvestust saab uuesti salvestada', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const failed = finishSave(beginSave(a.state).state, false);
+    const retry = beginSave(failed.state);
+    expect(retry.start).toBe(true);
+    expect(retry.state.saveFailed).toBe(false);
+    const ok = finishSave(retry.state, true);
+    expect(ok.action).toBe(run);
+  });
+
+  it('nullib oleku enne tegevuse tagastamist — tegevuse erind ei jäta guardi rippu', () => {
+    const run = vi.fn(() => { throw new Error('navigate failed'); });
+    const a = requestTransition(initialGuardState, true, { run });
+    const f = finishSave(beginSave(a.state).state, true);
+    expect(f.state.saving).toBe(false);
+    expect(f.state.pending).toBeNull();
+    expect(() => f.action?.()).toThrow('navigate failed');
+    expect(f.state.saving).toBe(false);
+    expect(f.state.pending).toBeNull();
+  });
+});
+
+describe('allowNextTransition', () => {
+  it('märgib järgmise ülemineku lubatuks ja luba on ühekordne', () => {
+    const s = allowNextTransition(initialGuardState);
+    const first = consumeAllowance(s);
+    expect(first.allowed).toBe(true);
+    expect(consumeAllowance(first.state).allowed).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub läbi**
+
+Run: `npm run test -- src/hooks/__tests__/unsavedChangesFlow.test.ts`
+Expected: FAIL — `Failed to resolve import "../unsavedChangesFlow"`
+
+- [ ] **Step 3: Kirjuta olekumasin**
+
+Loo `src/hooks/unsavedChangesFlow.ts`:
+
+```ts
+/**
+ * Salvestamata muudatuste dialoogi olekumasin.
+ *
+ * Puhas moodul: ei impordi Reacti ega puutu DOM-i. Kõik otsused elavad siin,
+ * `useUnsavedChangesGuard` on ainult Reacti kiht selle ümber. Nii saab kriitilise
+ * invariandi (ebaõnnestunud salvestus EI käivita ootel tegevust) katta testidega
+ * ilma jsdom/testing-library sõltuvusteta.
+ */
+
+/** Ootel üleminek — navigeerimine, lehepööre või koha vahetus. */
+export interface PendingTransition {
+  run: () => void;
+}
+
+export interface GuardState {
+  /** Ootel üleminek, mida dialoog kinnitama ootab. `null` = dialoog on kinni. */
+  pending: PendingTransition | null;
+  /** Salvestamine käib — nupud, Esc ja taustaklõps on blokeeritud. */
+  saving: boolean;
+  /** Viimane salvestuskatse ebaõnnestus — dialoogis on vearida. */
+  saveFailed: boolean;
+  /** Ühekordne möödapääs: järgmine üleminek lastakse guardist läbi. */
+  allowNext: boolean;
+}
+
+export const initialGuardState: GuardState = {
+  pending: null,
+  saving: false,
+  saveFailed: false,
+  allowNext: false,
+};
+
+export interface RequestResult {
+  state: GuardState;
+  /** Kas kutsuja peab tegevuse kohe käivitama (puhas olek). */
+  runNow: boolean;
+}
+
+/** Tulemus, mille juures kutsuja käivitab `action`-i, kui see ei ole `null`. */
+export interface ResolveResult {
+  state: GuardState;
+  action: (() => void) | null;
+}
+
+/**
+ * Üleminekusoov. Puhta oleku korral lubatakse kohe, muidu läheb ootele.
+ *
+ * Esimene ootel tegevus võidab: kui midagi juba ootab, uut ei võeta vastu. Vastasel
+ * juhul muutuks "Salvesta ja jätka" sihtkoht kasutaja jaoks ettearvamatuks.
+ */
+export function requestTransition(
+  state: GuardState,
+  isDirty: boolean,
+  pending: PendingTransition,
+): RequestResult {
+  if (state.pending !== null) return { state, runNow: false };
+  if (!isDirty) return { state, runNow: true };
+  return { state: { ...state, pending, saveFailed: false }, runNow: false };
+}
+
+/** "Jää siia" — ootel tegevus visatakse ära, dialoog sulgub. */
+export function stay(state: GuardState): GuardState {
+  return { ...state, pending: null, saveFailed: false };
+}
+
+/**
+ * "Loobu muudatustest" — ootel tegevus vabastatakse salvestamata.
+ *
+ * Möödapääs seatakse, sest tegevus tavaliselt navigeerib ja `isDirty` on Reacti
+ * järgmise renderduseni veel `true` — ilma selleta avaneks dialoog kohe uuesti.
+ */
+export function discard(state: GuardState): ResolveResult {
+  const action = state.pending?.run ?? null;
+  return {
+    state: { ...state, pending: null, saveFailed: false, allowNext: action !== null },
+    action,
+  };
+}
+
+/** "Salvesta ja jätka" algus. `start: false` = salvestamine juba käib (topeltklikk). */
+export function beginSave(state: GuardState): { state: GuardState; start: boolean } {
+  if (state.saving || state.pending === null) return { state, start: false };
+  return { state: { ...state, saving: true, saveFailed: false }, start: true };
+}
+
+/**
+ * Salvestuse tulemus.
+ *
+ * `saved === false` (ka erindi korral, mille kutsuja teisendab `false`-ks): ootel
+ * tegevus jääb alles, dialoog jääb avatuks, midagi ei kao.
+ */
+export function finishSave(state: GuardState, saved: boolean): ResolveResult {
+  if (!saved) {
+    return { state: { ...state, saving: false, saveFailed: true }, action: null };
+  }
+  const action = state.pending?.run ?? null;
+  return {
+    state: { ...state, pending: null, saving: false, saveFailed: false, allowNext: action !== null },
+    action,
+  };
+}
+
+/** Märgib järgmise ülemineku lubatuks. Kasutab `allowNextNavigation()` avalik API. */
+export function allowNextTransition(state: GuardState): GuardState {
+  return { ...state, allowNext: true };
+}
+
+/** Kontrollib ja tarbib ühekordse loa. Luba kehtib täpselt ühe ülemineku kohta. */
+export function consumeAllowance(state: GuardState): { state: GuardState; allowed: boolean } {
+  if (!state.allowNext) return { state, allowed: false };
+  return { state: { ...state, allowNext: false }, allowed: true };
+}
+```
+
+- [ ] **Step 4: Käivita testid ja veendu, et need läbivad**
+
+Run: `npm run test -- src/hooks/__tests__/unsavedChangesFlow.test.ts`
+Expected: PASS, 15 testi
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: vigadeta
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/unsavedChangesFlow.ts src/hooks/__tests__/unsavedChangesFlow.test.ts
+git commit -m "feat: salvestamata muudatuste olekumasin (puhas moodul + testid)"
+```
+
+---
+
+## Task 2: Dialoogikomponent ja tõlked
+
+**Files:**
+- Create: `src/components/UnsavedChangesDialog.tsx`
+- Modify: `src/locales/et/common.json:199-204`, `src/locales/en/common.json:199-204`
+
+**Interfaces:**
+- Consumes: midagi Task 1-st (dialoog on puhas presentatsioon, ei tunne olekumasinat)
+- Produces: `UnsavedChangesDialog` komponent ja `UnsavedChangesDialogProps` tüüp:
+  ```ts
+  { open: boolean; saving: boolean; saveFailed: boolean;
+    onDiscard: () => void; onStay: () => void; onSaveAndContinue: () => void }
+  ```
+
+**Taust:** Dialoog EI oma async-voogu — see kuulub hook'ile (Task 3). Siin on ainult renderdus, fookus ja klahvid.
+
+- [ ] **Step 1: Lisa tõlkevõtmed mõlemasse keelde**
+
+`src/locales/et/common.json` — asenda olemasolev `unsavedChanges` plokk (rida 199):
+
+```json
+  "unsavedChanges": {
+    "title": "Salvestamata muudatused",
+    "message": "Sul on salvestamata muudatusi.",
+    "discard": "Loobu muudatustest",
+    "stay": "Jää siia",
+    "saveAndContinue": "Salvesta ja jätka",
+    "saving": "Salvestan…",
+    "saveFailed": "Salvestamine ebaõnnestus — muudatused on alles."
+  },
+```
+
+`src/locales/en/common.json` — asenda olemasolev `unsavedChanges` plokk (rida 199):
+
+```json
+  "unsavedChanges": {
+    "title": "Unsaved changes",
+    "message": "You have unsaved changes.",
+    "discard": "Discard changes",
+    "stay": "Stay here",
+    "saveAndContinue": "Save and continue",
+    "saving": "Saving…",
+    "saveFailed": "Save failed — your changes are still here."
+  },
+```
+
+- [ ] **Step 2: Kontrolli, et keelepaarsus on korras**
+
+Run: `npm run test -- src/locales/__tests__/localeParity.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Kirjuta dialoogikomponent**
+
+Loo `src/components/UnsavedChangesDialog.tsx`:
+
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+
+export interface UnsavedChangesDialogProps {
+  open: boolean;
+  /** Salvestamine käib — kõik nupud, Esc ja taustaklõps on blokeeritud. */
+  saving: boolean;
+  /** Viimane salvestuskatse ebaõnnestus — näita vearida. */
+  saveFailed: boolean;
+  onDiscard: () => void;
+  onStay: () => void;
+  onSaveAndContinue: () => void;
+}
+
+/**
+ * Ühtne salvestamata muudatuste dialoog. Puhas presentatsioon: ootel tegevusest,
+ * salvestusfunktsioonist ega navigeerimisest ei tea siin miski midagi — see kõik
+ * elab `useUnsavedChangesGuard`-is ja `unsavedChangesFlow`-s.
+ *
+ * Nupud on KÕIKJAL identsed (järjekord, värv, tekst), ka siis kui dialoog tuli
+ * lehepöördest, mitte lahkumisest. Sihtkohta nupusildid ei nimeta.
+ */
+const UnsavedChangesDialog: React.FC<UnsavedChangesDialogProps> = ({
+  open, saving, saveFailed, onDiscard, onStay, onSaveAndContinue,
+}) => {
+  const { t } = useTranslation('common');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const stayButtonRef = useRef<HTMLButtonElement>(null);
+  // Element, millelt fookus tuli — sinna see sulgemisel tagastatakse.
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  // Fookus avanemisel kõige ohutumale valikule ("Jää siia"), et Enter ei teeks
+  // midagi hävitavat.
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    stayButtonRef.current?.focus();
+    return () => { previouslyFocusedRef.current?.focus?.(); };
+  }, [open]);
+
+  // Esc = "Jää siia", AGA mitte salvestamise ajal: muidu sulguks dialoog, salvestus
+  // jätkuks taustal ja hiljem saabuv vastus käivitaks navigeerimise ajal, mil
+  // kasutaja juba jätkab redigeerimist.
+  //
+  // Sama effect hoiab fookuse dialoogi sees (Tab ei vii välja).
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (!saving) { e.preventDefault(); onStay(); }
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button:not([disabled])',
+      );
+      if (!focusable || focusable.length === 0) { e.preventDefault(); return; }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault(); last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault(); first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, saving, onStay]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onMouseDown={e => { if (e.target === e.currentTarget && !saving) onStay(); }}
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="unsaved-changes-title"
+        aria-describedby="unsaved-changes-message"
+        aria-busy={saving}
+        className="bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden"
+      >
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
+          <div className="p-2 bg-amber-100 rounded-full">
+            <AlertTriangle className="text-amber-600" size={24} />
+          </div>
+          <h2 id="unsaved-changes-title" className="text-lg font-semibold text-gray-900">
+            {t('unsavedChanges.title')}
+          </h2>
+        </div>
+
+        <div className="px-6 py-4">
+          <p id="unsaved-changes-message" className="text-gray-600">
+            {t('unsavedChanges.message')}
+          </p>
+          {saveFailed && (
+            <p role="status" aria-live="polite" className="mt-3 text-sm text-red-700">
+              {t('unsavedChanges.saveFailed')}
+            </p>
+          )}
+        </div>
+
+        <div className="px-6 py-4 bg-gray-50 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onDiscard}
+            disabled={saving}
+            className="px-4 py-2 rounded-lg font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-700"
+          >
+            {t('unsavedChanges.discard')}
+          </button>
+          <button
+            ref={stayButtonRef}
+            type="button"
+            onClick={onStay}
+            disabled={saving}
+            className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-100 font-medium disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500"
+          >
+            {t('unsavedChanges.stay')}
+          </button>
+          <button
+            type="button"
+            onClick={onSaveAndContinue}
+            disabled={saving}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-700"
+          >
+            {saving && <Loader2 className="animate-spin" size={16} />}
+            {saving ? t('unsavedChanges.saving') : t('unsavedChanges.saveAndContinue')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UnsavedChangesDialog;
+```
+
+- [ ] **Step 4: Typecheck ja testid**
+
+Run: `npm run typecheck && npm run test`
+Expected: mõlemad vigadeta
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/UnsavedChangesDialog.tsx src/locales/et/common.json src/locales/en/common.json
+git commit -m "feat: UnsavedChangesDialog komponent + tõlked"
+```
+
+---
+
+## Task 3: Guard-hook ümber kirjutatud
+
+**Files:**
+- Modify: `src/hooks/useUnsavedChangesGuard.ts` (kogu fail asendub)
+
+**Interfaces:**
+- Consumes: Task 1 kõik eksportfunktsioonid; Task 2 `UnsavedChangesDialogProps`
+- Produces:
+  ```ts
+  useUnsavedChangesGuard(opts: {
+    isDirty: boolean;
+    onSave: () => Promise<boolean>;
+  }): {
+    dialogProps: UnsavedChangesDialogProps;
+    runGuarded: (fn: () => void) => void;
+    allowNextNavigation: () => void;
+  }
+  ```
+  Kõik ülejäänud ülesanded (5–8) kasutavad täpselt seda kuju.
+
+**Taust:** Vana API oli `useUnsavedChangesGuard(isDirty, skipRef)` ja tagastas `{ isBlocked, blockedLocation, proceed, reset }`. Kasutuskohad `Workspace.tsx:139` ja `PersonEditPage.tsx:188` lähevad üle Task 5 ja 6 raames — **pärast seda ülesannet on projekt ajutiselt katki**, see on ootuspärane. Typecheck läbib alles Task 6 lõpus.
+
+- [ ] **Step 1: Asenda faili sisu**
+
+Kirjuta `src/hooks/useUnsavedChangesGuard.ts` täies mahus ümber:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useBlocker } from 'react-router-dom';
+import type { UnsavedChangesDialogProps } from '../components/UnsavedChangesDialog';
+import {
+  initialGuardState,
+  requestTransition,
+  stay,
+  discard,
+  beginSave,
+  finishSave,
+  allowNextTransition,
+  consumeAllowance,
+  type GuardState,
+} from './unsavedChangesFlow';
+
+interface UnsavedChangesGuardOptions {
+  /** Kas on salvestamata muudatusi. */
+  isDirty: boolean;
+  /**
+   * Salvestab ja tagastab `true` AINULT siis, kui kõik on püsivalt salvestatud ja
+   * kohalikud dirty-lipud on uuendatud. `false` = ebaõnnestus. Visatud erindit
+   * käsitleb hook kaitseks samamoodi nagu `false`.
+   */
+  onSave: () => Promise<boolean>;
+}
+
+interface UnsavedChangesGuardResult {
+  dialogProps: UnsavedChangesDialogProps;
+  /**
+   * Lehesisene üleminek (lehepööre, koha vahetus). Puhta oleku korral käivitub
+   * `fn` kohe, dialoogi avamata; muidu läheb ootele.
+   */
+  runGuarded: (fn: () => void) => void;
+  /**
+   * Märgib järgmise navigatsiooni lubatuks. Mõeldud lehtedele, mis salvestavad OMA
+   * nupuga ja navigeerivad ise (nt PersonEditPage → /persons/{id}) — see on
+   * dialoogivoost sõltumatu. Luba on ühekordne.
+   */
+  allowNextNavigation: () => void;
+}
+
+/**
+ * Blokeerib lehelt lahkumise ja lehesisesed üleminekud salvestamata muudatuste korral.
+ *
+ * Kolm sisendit, üks dialoog:
+ *   - React Routeri `useBlocker` — lahkumine
+ *   - `beforeunload` — tab-i sulgemine (brauseri oma dialoog, seda me ei kontrolli)
+ *   - `runGuarded` — lehesisene üleminek
+ *
+ * Otsused elavad `unsavedChangesFlow`-s, siin on ainult Reacti ja Routeri ühendus.
+ */
+export function useUnsavedChangesGuard(
+  { isDirty, onSave }: UnsavedChangesGuardOptions,
+): UnsavedChangesGuardResult {
+  const [state, setState] = useState<GuardState>(initialGuardState);
+
+  // Blocker-callback ja async salvestus vajavad värsket olekut väljaspool renderdust.
+  const stateRef = useRef(state);
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
+  const apply = useCallback((next: GuardState) => {
+    stateRef.current = next;
+    setState(next);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirty) { e.preventDefault(); e.returnValue = ''; }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [isDirty]);
+
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    if (currentLocation.pathname === nextLocation.pathname) return false;
+    // Ühekordne möödapääs tarbitakse siin: pärast edukat salvestust või loobumist
+    // on `isDirty` Reacti järgmise renderduseni veel `true`, seega ilma selleta
+    // avaneks dialoog kohe uuesti.
+    const { state: next, allowed } = consumeAllowance(stateRef.current);
+    if (allowed) { apply(next); return false; }
+    return isDirtyRef.current;
+  });
+
+  // `useBlocker` tagastab igal renderdusel uue objekti — effect ja callback'id
+  // tohivad sõltuda ainult `blocker.state`-ist, muidu tekib lõputu tsükkel.
+  const blockerRef = useRef(blocker);
+  blockerRef.current = blocker;
+
+  // Router blokeeris navigatsiooni → pane see ootele samasse dialoogi.
+  useEffect(() => {
+    if (blocker.state !== 'blocked') return;
+    const r = requestTransition(
+      stateRef.current,
+      true,
+      { run: () => blockerRef.current.proceed() },
+    );
+    if (r.runNow) { blockerRef.current.proceed(); return; }
+    apply(r.state);
+  }, [blocker.state, apply]);
+
+  const runGuarded = useCallback((fn: () => void) => {
+    const r = requestTransition(stateRef.current, isDirtyRef.current, { run: fn });
+    if (r.runNow) { fn(); return; }
+    apply(r.state);
+  }, [apply]);
+
+  const allowNextNavigation = useCallback(() => {
+    apply(allowNextTransition(stateRef.current));
+  }, [apply]);
+
+  const onStay = useCallback(() => {
+    if (stateRef.current.saving) return;
+    // Blokeeritud navigatsioon tuleb Routerile tagasi öelda, muidu jääb blocker
+    // "blocked" olekusse ja järgmine sama navigatsioon ei käivitu.
+    if (blockerRef.current.state === 'blocked') blockerRef.current.reset();
+    apply(stay(stateRef.current));
+  }, [apply]);
+
+  const onDiscard = useCallback(() => {
+    if (stateRef.current.saving) return;
+    const r = discard(stateRef.current);
+    apply(r.state);
+    r.action?.();
+  }, [apply]);
+
+  const onSaveAndContinue = useCallback(async () => {
+    const begun = beginSave(stateRef.current);
+    if (!begun.start) return;
+    apply(begun.state);
+
+    let saved = false;
+    try {
+      saved = await onSave();
+    } catch {
+      // Ükski praegune kasutuskoht ei viska, aga tulevane refaktor ei tohi jätta
+      // dialoogi igaveseks `saving`-olekusse ega tekitada käsitlemata rejection'it.
+      saved = false;
+    }
+
+    const r = finishSave(stateRef.current, saved);
+    // Olek uuendatakse ENNE tegevust: kui tegevus viskab, ei jää guard rippu.
+    apply(r.state);
+    r.action?.();
+  }, [apply, onSave]);
+
+  return {
+    dialogProps: {
+      open: state.pending !== null,
+      saving: state.saving,
+      saveFailed: state.saveFailed,
+      onDiscard,
+      onStay,
+      onSaveAndContinue,
+    },
+    runGuarded,
+    allowNextNavigation,
+  };
+}
+```
+
+- [ ] **Step 2: Kontrolli, et olekumasina testid endiselt läbivad**
+
+Run: `npm run test -- src/hooks/__tests__/unsavedChangesFlow.test.ts`
+Expected: PASS, 13 testi (hook ei muutnud puhast moodulit)
+
+- [ ] **Step 3: Commit**
+
+Typecheck on siin veel katki (`Workspace.tsx` ja `PersonEditPage.tsx` kasutavad vana API-t) — see on ootuspärane ja laheneb Task 6 lõpuks.
+
+```bash
+git add src/hooks/useUnsavedChangesGuard.ts
+git commit -m "refactor: useUnsavedChangesGuard olekumasina peale (runGuarded + ühekordne bypass)"
+```
+
+---
+
+## Task 4: Redaktori salvestus tagastab boolean'i
+
+**Files:**
+- Modify: `src/components/editor/useEditorSave.ts:63-102`
+
+**Interfaces:**
+- Consumes: midagi
+- Produces: `runSave(...): Promise<boolean>`, `handleSave(): Promise<boolean>`, `handleSaveWithDrafts(): Promise<boolean>`. Task 5 kasutab `handleSaveWithDrafts` tagastusväärtust.
+
+**Taust — see on üks kolmest varjatud veast:** praegu püüab `runSave` erindi kinni, seab `setSaveError` ja **resolvib**. Seetõttu `Workspace.tsx:518` `await editorSaveRef.current()` õnnestub alati ja navigeerib ära; veabanner renderdub komponendis, mis on kohe lahkumas. Tekst kaob.
+
+- [ ] **Step 1: Muuda `runSave` tagastama boolean'i**
+
+`src/components/editor/useEditorSave.ts`, asenda read 63-83:
+
+```ts
+  /**
+   * Tagastab `true` AINULT siis, kui salvestus õnnestus ja `savedState`/`isDirty`
+   * on uuendatud. Salvestamata muudatuste dialoog sõltub sellest: `false` korral
+   * ei tohi navigeerida, muidu kaob tekst (vt UnsavedChangesDialog).
+   */
+  const runSave = useCallback(async (
+    updatedPage: Page,
+    savedState: EditorSavedState,
+    afterSave?: () => void,
+  ): Promise<boolean> => {
+    if (isSavingRef.current) return false;
+    isSavingRef.current = true;
+    setIsSaving(true);
+    try {
+      await onSave(updatedPage);
+      afterSave?.();
+      setSavedState(savedState);
+      setIsDirty(false);
+      return true;
+    } catch (e: any) {
+      console.error('Save error:', e);
+      setSaveError(formatSaveError(e));
+      return false;
+    } finally {
+      isSavingRef.current = false;
+      setIsSaving(false);
+    }
+  }, [formatSaveError, onSave, setIsDirty, setIsSaving, setSaveError, setSavedState]);
+```
+
+- [ ] **Step 2: Muuda `handleSave` ja `handleSaveWithDrafts` tagastama sama**
+
+Asenda read 85-102:
+
+```ts
+  const handleSave = useCallback(async (): Promise<boolean> => {
+    const updatedPage = makePage(comments, textAnnotations);
+    return runSave(updatedPage, { status, comments, page_tags, text_annotations: textAnnotations });
+  }, [comments, makePage, page_tags, runSave, status, textAnnotations]);
+
+  // Salvestus "Salvesta ja jätka" jaoks: enne salvestust liidab kommentaari-mustandi
+  // kommentaaride hulka, et see ei läheks kaduma.
+  const handleSaveWithDrafts = useCallback(async (): Promise<boolean> => {
+    if (isSavingRef.current) return false;
+    const flushed = commentFlushRef.current?.() ?? null;
+    const effectiveComments = flushed ?? comments;
+    const updatedPage = makePage(effectiveComments, textAnnotations);
+    return runSave(
+      updatedPage,
+      { status, comments: effectiveComments, page_tags, text_annotations: textAnnotations },
+      flushed ? () => setComments(flushed) : undefined,
+    );
+  }, [commentFlushRef, comments, makePage, page_tags, runSave, setComments, status, textAnnotations]);
+```
+
+- [ ] **Step 3: Uuenda `triggerSave` ref-i tüüpi**
+
+`src/components/TextEditor.tsx:37` — muuda propi tüüp:
+
+```ts
+  triggerSave?: React.MutableRefObject<(() => Promise<boolean>) | null>;
+```
+
+- [ ] **Step 4: Otsi üles kõik `runSave` kutsujad ja veendu, et ükski ei katke**
+
+Run: `grep -n "runSave\|handleSaveWithDrafts\|handleSave\b" src/components/editor/useEditorSave.ts src/components/TextEditor.tsx`
+
+Kontrolli, et need kutsujad, kes tagastusväärtust ei kasuta (nt nupuhandlerid), on endiselt korrektsed — `Promise<boolean>` ignoreerimine on TypeScriptis lubatud.
+
+- [ ] **Step 5: Commit**
+
+Typecheck on endiselt katki (Task 3 pärast). See on ootuspärane.
+
+```bash
+git add src/components/editor/useEditorSave.ts src/components/TextEditor.tsx
+git commit -m "fix: redaktori salvestus signaliseerib ebaõnnestumist (boolean)"
+```
+
+---
+
+## Task 5: Workspace üle viidud
+
+**Files:**
+- Modify: `src/pages/Workspace.tsx` — read 89-90, 135-140, 151-155, 374-379, 393-397, 478-483, 493-498, 500-531, 781-791
+
+**Interfaces:**
+- Consumes: Task 2 `UnsavedChangesDialog`, Task 3 `useUnsavedChangesGuard`, Task 4 `handleSaveWithDrafts` boolean
+- Produces: midagi järgnevatele
+
+**Taust:** Workspace'is on praegu KAKS paralleelset mehhanismi: Routeri blocker (lahkumine) ja käsitsi `pendingNavigation` (lehepööre viies kohas). Mõlemad kaovad `runGuarded` kasuks. Lisaks kaob `requestAnimationFrame` bypass-hack — hook teeb selle nüüd ise ühekordselt.
+
+**Loobumise leping:** Workspace'i lehepöördel taastab baasseisu `useEditorState.ts:71-83` (`isSwap` haru lähtestab `isDirty`, `savedState`, `annotationDraftDirty`, `saveError` ja dokumendi sisu). See on ADR 0010 / #194 sisu ja on juba olemas — eraldi `onDiscard`-i ei lisata. Lahkumisel monteeritakse komponent nagunii maha.
+
+- [ ] **Step 1: Vaheta importi ja eemalda `pendingNavigation` olek**
+
+`src/pages/Workspace.tsx:6` — asenda import:
+
+```ts
+import { useUnsavedChangesGuard } from '../hooks/useUnsavedChangesGuard';
+import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
+```
+
+Eemalda rida 89 (`const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);`).
+
+Muuda rida 90:
+
+```ts
+  const editorSaveRef = useRef<(() => Promise<boolean>) | null>(null);
+```
+
+- [ ] **Step 2: Asenda guard-kutse**
+
+Eemalda `skipBlockerRef` deklaratsioon (rida ~135-138) ja asenda rida 139-140:
+
+```ts
+  // Salvestus dialoogi jaoks: flush-variant, mis liidab ka kommentaari-mustandi.
+  // Tagastab `false`, kui salvestamine ebaõnnestus — dialoog jääb siis avatuks.
+  //
+  // Registreerimata ref (redaktorit pole monteeritud) tagastab `true`: siis ei ole
+  // ka midagi salvestada ja kasutajat ei tohi dialoogi lõksu jätta.
+  const handleGuardSave = useCallback(async (): Promise<boolean> => {
+    if (!editorSaveRef.current) return true;
+    return editorSaveRef.current();
+  }, []);
+
+  const { dialogProps, runGuarded } = useUnsavedChangesGuard({
+    isDirty: hasUnsavedChanges,
+    onSave: handleGuardSave,
+  });
+```
+
+- [ ] **Step 3: Vii viis navigeerimiskohta `runGuarded` peale**
+
+Rida 149-157 (`handlePageInputSubmit`):
+
+```ts
+      if (newPage !== currentPageNum) {
+        runGuarded(() => navigate(`/work/${workId}/${newPage}`, { replace: true }));
+      }
+```
+
+Rida 371-379 (`handleSelectFromGrid`):
+
+```ts
+  const handleSelectFromGrid = useCallback((pageNum: number) => {
+    setIsGridView(false);
+    setGridSelectedPage(pageNum);
+    runGuarded(() => navigate(`/work/${workId}/${pageNum}`, { replace: true }));
+  }, [runGuarded, navigate, workId]);
+```
+
+Rida 393-400 (`navigatePage`) — asenda `hasUnsavedChanges` plokk ja sellele järgnev `navigate`:
+
+```ts
+    // ?q= jäetakse URL-ist välja — eesmärk: otsisõna paneel avaneb ainult esimesel
+    // lehel, mitte iga lehevahetusel
+    runGuarded(() => navigate(`/work/${workId}/${newPage}`, { replace: true }));
+  }, [workId, currentPageNum, work?.page_count, runGuarded, navigate]);
+```
+
+Rida 477-483 (tagasi-navigeerimine) — asenda `hasUnsavedChanges` plokk:
+
+```ts
+    runGuarded(() => navigate(returnUrl));
+```
+
+Rida 486-498 (`handleNavigateToSearch`) — asenda lõpp:
+
+```ts
+    runGuarded(() => navigate(`/search?work=${workId}`));
+```
+
+- [ ] **Step 4: Kustuta vana dialoogiloogika**
+
+Eemalda read 500-531 tervikuna: `handleConfirmLeave`, `handleSaveAndLeave` ja `showLeaveConfirm`. Kogu see loogika (sh `requestAnimationFrame` bypass-hack) elab nüüd hook'is.
+
+Eemalda ka rida 140 `const isBlockerActive = isBlocked;`, kui see on veel alles.
+
+- [ ] **Step 5: Asenda dialoog**
+
+Asenda read 781-791:
+
+```tsx
+      {/* Salvestamata muudatuste dialoog */}
+      <UnsavedChangesDialog {...dialogProps} />
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: `Workspace.tsx` vigadeta. `PersonEditPage.tsx` võib veel vigu anda (Task 6).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/Workspace.tsx
+git commit -m "refactor: Workspace ühtsele salvestamata muudatuste dialoogile"
+```
+
+---
+
+## Task 6: PersonEditPage üle viidud
+
+**Files:**
+- Modify: `src/prosopography/pages/PersonEditPage.tsx` — read 28, 187-224, 280, 892, 949-958
+
+**Interfaces:**
+- Consumes: Task 2 `UnsavedChangesDialog`, Task 3 `useUnsavedChangesGuard`
+- Produces: midagi järgnevatele
+
+**Taust:** `handleSave` teeb praegu kahte asja korraga: salvestab JA navigeerib `/persons/{id}`-le (read 208, 213). Dialoogi `onSave` ei tohi navigeerida — sihtkoha valib dialoog. Jagame kaheks.
+
+**Loobumise leping:** komponent monteeritakse lahkumisel maha; lehesiseseid üleminekuid siin ei ole.
+
+- [ ] **Step 1: Vaheta import**
+
+Rida 28:
+
+```ts
+import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard';
+import UnsavedChangesDialog from '../../components/UnsavedChangesDialog';
+```
+
+- [ ] **Step 2: Jaga `handleSave` kaheks ja vaheta guard**
+
+Asenda read 187-224:
+
+```ts
+  /**
+   * Salvestab isiku. EI navigeeri — sihtkoha valib kutsuja (nupp läheb profiilile,
+   * salvestamata muudatuste dialoog jätkab kasutaja algatatud üleminekut).
+   * Tagastab `true` ainult siis, kui kõik on püsivalt salvestatud.
+   */
+  const savePerson = async (): Promise<boolean> => {
+    if (!draft.name_label.trim()) { setError(t('form.nameRequired')); return false; }
+    setSaving(true);
+    setError(null);
+    try {
+      if (isNew) {
+        const created = await createPerson(
+          {
+            name: draft.name_label.trim(),
+            birth_year: draft.birth.year ? parseInt(draft.birth.year) : undefined,
+            death_year: draft.death.year ? parseInt(draft.death.year) : undefined,
+            notes: draft.notes.trim() || undefined,
+          },
+          token,
+        );
+        const payload = draftToPayload(draft, created, seisused, konfessioonid);
+        await updatePerson(created.id, { ...payload, updated_at: created.updated_at }, token);
+        createdIdRef.current = created.id;
+      } else {
+        const payload = draftToPayload(draft, original ?? undefined, seisused, konfessioonid);
+        await updatePerson(id!, payload, token);
+      }
+      setIsDirty(false);
+      return true;
+    } catch (e: any) {
+      if (e?.conflict) {
+        setError(t('form.conflictError'));
+      } else {
+        setError(t('form.saveError'));
+      }
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const { dialogProps, allowNextNavigation } = useUnsavedChangesGuard({
+    isDirty,
+    onSave: savePerson,
+  });
+
+  /** Lehe oma SALVESTA nupp: salvestab ja läheb profiilile. */
+  const handleSave = async () => {
+    const ok = await savePerson();
+    if (!ok) return;
+    // Guard ei tohi seda navigatsiooni blokeerida: `isDirty` on Reacti järgmise
+    // renderduseni tõenäoliselt veel `true`.
+    allowNextNavigation();
+    navigate(`/persons/${createdIdRef.current ?? id!}`);
+  };
+```
+
+Lisa `createdIdRef` deklaratsioon `skipGuardRef`-i asemele (rida 187 kandis):
+
+```ts
+  // Uue isiku ID tekib alles salvestamisel — hoiame selle navigeerimiseks alles.
+  const createdIdRef = useRef<string | null>(null);
+```
+
+- [ ] **Step 3: Asenda dialoog**
+
+Asenda read 949-958:
+
+```tsx
+    <UnsavedChangesDialog {...dialogProps} />
+```
+
+- [ ] **Step 4: Kontrolli, et `skipGuardRef` on failist täielikult kadunud**
+
+Run: `grep -n "skipGuardRef\|isBlocked\|ConfirmModal" src/prosopography/pages/PersonEditPage.tsx`
+Expected: tühi väljund. Kui `ConfirmModal` import on veel alles, eemalda see.
+
+- [ ] **Step 5: Typecheck ja testid**
+
+Run: `npm run typecheck && npm run test`
+Expected: mõlemad vigadeta — siit alates on projekt jälle terve
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/prosopography/pages/PersonEditPage.tsx
+git commit -m "refactor: PersonEditPage ühtsele dialoogile; salvestus eraldi navigeerimisest"
+```
+
+---
+
+## Task 7: Kohtade register — päris dirty-lipp ja guard
+
+**Files:**
+- Modify: `src/pages/admin/PlacesDetail.tsx:37-51, 100-131, 145-175`
+- Modify: `src/pages/admin/Places.tsx:1-16, 40-41, 131-137, 247-261, 288-309`
+
+**Interfaces:**
+- Consumes: Task 2 `UnsavedChangesDialog`, Task 3 `useUnsavedChangesGuard`
+- Produces: midagi järgnevatele
+
+**Taust — kaks varjatud viga korraga:**
+1. Kohtade registris **puudub lahkumiskaitse täielikult** — `useUnsavedChangesGuard` ega `beforeunload` ei ole ühendatud. Lehelt lahkudes või tab-i sulgedes kaovad muudatused vaikselt.
+2. **Dirty-lipp on vale**: `PlacesDetail.tsx:111` teeb `onDirtyChange?.(editing)` — lipp on püsti alati, kui redigeerimisrežiim on lahti, ka siis kui midagi pole muudetud. Ilma paranduseta hüppaks uus dialoog ette iga kord, kui kasutaja on koha andmeid lihtsalt vaadanud.
+
+**Loobumise leping:** koha vahetusel taastab baasseisu `PlacesDetail.tsx:106-108` (`useEffect(() => setEditing(false), [placeKey])`), mis lähtestab mustandi. Lahkumisel monteeritakse komponent maha.
+
+- [ ] **Step 1: `PlacesDetail` — lisa mustandi tüüp ja normaliseerimine**
+
+**NB:** olemasolevad üksikud `useState`-id vormiväljadele (read 66-76, 100) JÄÄVAD
+puutumata — neid kasutab kogu vormi JSX. Lisandub ainult nende koondamine üheks
+objektiks võrdluse jaoks.
+
+Lisa faili tippu, väljaspool komponenti:
+
+```ts
+/** Vormi mustand — üks objekt, et baasseisuga võrdlemine oleks üks võrdlus. */
+interface PlaceFormDraft {
+  labels: Record<string, string>;
+  placeType: string;
+  qCode: string;
+  parentKey: string;
+  group: string;
+  historicalNames: string[];
+  lat: string;
+  lon: string;
+  notes: string;
+}
+
+/**
+ * Normaliseerib mustandi võrdluseks. Ilma selleta annaks `undefined` vs tühi string,
+ * puuduv võti vs tühi objekt ja trimmimata sisestus valepositiivse dirty-lipu.
+ */
+function normalizeDraft(d: PlaceFormDraft): string {
+  const labels = Object.fromEntries(
+    Object.entries(d.labels)
+      .map(([k, v]) => [k, v.trim()])
+      .filter(([, v]) => v !== '')
+      .sort(([a], [b]) => a.localeCompare(b)),
+  );
+  return JSON.stringify({
+    labels,
+    placeType: d.placeType.trim(),
+    qCode: d.qCode.trim(),
+    parentKey: d.parentKey.trim(),
+    group: d.group.trim(),
+    historicalNames: d.historicalNames.map(n => n.trim()).filter(n => n !== ''),
+    lat: d.lat.trim(),
+    lon: d.lon.trim(),
+    notes: d.notes.trim(),
+  });
+}
+
+/** Baasseis kirjest: sama kuju, mis vorm avamisel saab. */
+function draftFromEntry(entry: PlaceEntry): PlaceFormDraft {
+  return {
+    labels: { ...(entry.labels ?? {}) },
+    placeType: entry.type ?? '',
+    qCode: entry.id ?? '',
+    parentKey: entry.parent_key ?? '',
+    group: entry.group ?? '',
+    historicalNames: [...(entry.historical_names ?? [])],
+    lat: entry.coordinates?.lat != null ? String(entry.coordinates.lat) : '',
+    lon: entry.coordinates?.lon != null ? String(entry.coordinates.lon) : '',
+    notes: entry.notes ?? '',
+  };
+}
+```
+
+- [ ] **Step 2: `PlacesDetail` — asenda dirty-effect päris võrdlusega**
+
+Asenda read 110-112:
+
+```ts
+  // Baasseis: viimati laaditud või edukalt salvestatud väärtused. Dirty = mustand
+  // erineb sellest. `editing` ise EI tee vormi dirty'ks — muidu hüppaks salvestamata
+  // muudatuste dialoog ette iga kord, kui kasutaja on koha andmeid lihtsalt vaadanud.
+  const [baseline, setBaseline] = useState<string>('');
+
+  const currentDraft: PlaceFormDraft = {
+    labels, placeType, qCode, parentKey, group, historicalNames, lat, lon, notes,
+  };
+  const isDirty = editing && normalizeDraft(currentDraft) !== baseline;
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+```
+
+Read 114-131 (`useEffect` mustandi täitmiseks) — lisa sinna baasseisu seadmine, effecti lõppu enne `setSaveError(null)`:
+
+```ts
+      setBaseline(normalizeDraft(draftFromEntry(entry)));
+      setSaveError(null);
+```
+
+- [ ] **Step 3: `PlacesDetail` — `handleSave` tagastab boolean'i ja uuendab baasseisu**
+
+Asenda read 145-175 (`handleSave`):
+
+```ts
+  /**
+   * Tagastab `true` ainult siis, kui salvestus õnnestus. Salvestamata muudatuste
+   * dialoog sõltub sellest: `false` korral ei tohi kohta vahetada ega lahkuda.
+   */
+  const handleSave = async (): Promise<boolean> => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const latNum = lat.trim() ? parseFloat(lat) : undefined;
+      const lonNum = lon.trim() ? parseFloat(lon) : undefined;
+      const coordinates =
+        latNum != null && lonNum != null && !isNaN(latNum) && !isNaN(lonNum)
+          ? { lat: latNum, lon: lonNum }
+          : null;
+
+      const data: any = {
+        labels: Object.fromEntries(Object.entries(labels).filter(([, v]) => v.trim())),
+        type: placeType || undefined,
+        id: qCode.trim() || null,
+        parent_key: parentKey || undefined,
+        group: group || undefined,
+        historical_names: historicalNames,
+        notes: notes || undefined,
+      };
+      if (coordinates !== undefined) data.coordinates = coordinates;
+
+      const result = await updatePlace(placeKey, data, token);
+      onUpdated(result.key, result.entry);
+      // Edukas salvestamine teeb praegustest väärtustest uue baasseisu.
+      setBaseline(normalizeDraft(currentDraft));
+      setEditing(false);
+      return true;
+    } catch (e: any) {
+      setSaveError(e.message ?? t('places.saveError'));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+```
+
+- [ ] **Step 4: `PlacesDetail` — anna salvestus vanemale**
+
+Lisa propide liidesesse (rida 37-51):
+
+```ts
+  /** Vanem paneb siia salvestusfunktsiooni, et dialoog saaks seda kutsuda. */
+  saveRef?: React.MutableRefObject<(() => Promise<boolean>) | null>;
+```
+
+Lisa destruktureerimisse (rida 53-56) `saveRef` ja komponendi sisse, pärast `handleSave` definitsiooni:
+
+```ts
+  useEffect(() => {
+    if (saveRef) saveRef.current = handleSave;
+  });
+```
+
+- [ ] **Step 5: `Places` — ühenda guard**
+
+`src/pages/admin/Places.tsx`, lisa importidesse:
+
+```ts
+import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard';
+import UnsavedChangesDialog from '../../components/UnsavedChangesDialog';
+```
+
+Asenda read 40-41:
+
+```ts
+  const [isDirty, setIsDirty] = useState(false);
+  const placeSaveRef = useRef<(() => Promise<boolean>) | null>(null);
+
+  const handleGuardSave = useCallback(async (): Promise<boolean> => {
+    if (!placeSaveRef.current) return true;
+    return placeSaveRef.current();
+  }, []);
+
+  const { dialogProps, runGuarded } = useUnsavedChangesGuard({
+    isDirty,
+    onSave: handleGuardSave,
+  });
+```
+
+Lisa `useRef` importi reale 1: `import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';`
+
+- [ ] **Step 6: `Places` — koha vahetus `runGuarded` peale**
+
+Asenda read 131-137:
+
+```ts
+  const handleSelectKey = useCallback((key: string | null) => {
+    if (key === selectedKey) return;
+    runGuarded(() => setSelectedKey(key));
+  }, [runGuarded, selectedKey]);
+```
+
+Eemalda `pendingKey` olek (rida 41) ja käsitsi kirjutatud modaal (read 288-309) tervikuna.
+
+- [ ] **Step 7: `Places` — anna `saveRef` alla ja renderda dialoog**
+
+Rida 247-261, lisa `PlacesDetail`-ile prop:
+
+```tsx
+                    onDirtyChange={setIsDirty}
+                    saveRef={placeSaveRef}
+```
+
+Muuda ka `onSelectKey={setSelectedKey}` → `onSelectKey={handleSelectKey}`, et ka detailpaneelist tulev koha vahetus oleks kaitstud.
+
+Lisa enne komponendi sulgevat `</div>`-i (kustutatud modaali asemele):
+
+```tsx
+      <UnsavedChangesDialog {...dialogProps} />
+```
+
+- [ ] **Step 8: Typecheck ja testid**
+
+Run: `npm run typecheck && npm run test`
+Expected: mõlemad vigadeta
+
+- [ ] **Step 9: Käsitsi kontroll**
+
+Run: `npm run dev`, ava `/admin/places`.
+
+Kontrolli:
+1. Ava koht → vajuta muuda → **ära muuda midagi** → vali nimekirjast teine koht → dialoogi EI tule
+2. Muuda üht välja → vali teine koht → dialoog tuleb
+3. Taasta väärtus käsitsi algseks → vali teine koht → dialoogi EI tule
+4. Muuda välja → proovi lehelt lahkuda (Admin link) → dialoog tuleb
+5. Muuda välja → sulge tab → brauseri oma hoiatus tuleb
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/pages/admin/Places.tsx src/pages/admin/PlacesDetail.tsx
+git commit -m "fix: kohtade registri lahkumiskaitse + päris dirty-lipp"
+```
+
+---
+
+## Task 8: WorkManage ja ConfirmModal
+
+**Files:**
+- Modify: `src/components/ConfirmModal.tsx:17-44`
+- Modify: `src/pages/WorkManage.tsx:367-400` ja komponendi lõpp
+
+**Interfaces:**
+- Consumes: Task 2 `UnsavedChangesDialog`, Task 3 `useUnsavedChangesGuard`
+- Produces: `ConfirmModal` saab uue valikulise propi `closeOnBackdrop?: boolean` (vaikimisi `true`)
+
+**Taust:** `WorkManage.tsx:369` ja `:377` kasutavad natiivset `window.confirm`-i. Lisaks puudub lehel lahkumiskaitse, kuigi `changedCount` (rida 287) hoiab salvestamata järjekorra mustandit.
+
+**Tähelepanu — pesastatud kinnitus:** `handleReorderSave` küsib ise kinnitust. Kui kasutaja valib lahkumisdialoogist "Salvesta ja jätka", ei tohi järjekorra kinnitus uuesti ette hüpata. Salvestus jagatakse kaheks.
+
+**ConfirmModal tarbijate audit:** enne Esc/taustaklõpsu lisamist kontrolli, kes `ConfirmModal`-i veel kasutab.
+
+- [ ] **Step 1: Auditeeri ConfirmModal tarbijad**
+
+Run: `grep -rn "ConfirmModal" src --include=*.tsx`
+
+Pärast Task 5 ja 6 peaks alles olema ainult `src/components/ConfirmModal.tsx` ise. Kui mõni muu kasutuskoht on lisandunud, kontrolli, et selle `onCancel` on idempotentne ja et taustaklõpsuga sulgemine ei jäta pooleliolevat kohalikku olekut.
+
+- [ ] **Step 2: Lisa `ConfirmModal`-ile Esc ja taustaklõps**
+
+`src/components/ConfirmModal.tsx` — lisa importidesse `useEffect`:
+
+```tsx
+import React, { useEffect } from 'react';
+```
+
+Lisa propi liidesesse:
+
+```ts
+  /** Kas taustaklõps sulgeb. Vaikimisi jah — cancel on ohutu tee. */
+  closeOnBackdrop?: boolean;
+```
+
+Lisa destruktureerimisse `closeOnBackdrop = true`, ja komponendi sisse enne `if (!isOpen) return null;`:
+
+```tsx
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onCancel]);
+```
+
+Muuda overlay-div:
+
+```tsx
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onMouseDown={e => { if (closeOnBackdrop && e.target === e.currentTarget) onCancel(); }}
+    >
+```
+
+- [ ] **Step 3: Lisa tõlkevõtmed WorkManage'i kinnitustele**
+
+`src/locales/et/workspace.json`, `manage` ploki sisse (rida 114 kandis, `reorderConfirm` kõrvale):
+
+```json
+    "reorderConfirmTitle": "Kinnita järjekorra muutmine",
+```
+
+`src/locales/et/workspace.json`, `manage.reorder` plokk (rida 142):
+
+```json
+    "reorder": {
+      "discard": "Tühista muudatused",
+      "discardTitle": "Tühista järjekorra muudatused",
+      "discardConfirm": "Tühistada kõik salvestamata järjekorra muudatused?",
+      "changedSummary": "{{count}} lehe asukoht erineb salvestatud järjekorrast"
+    },
+```
+
+`src/locales/en/workspace.json` — samad kohad:
+
+```json
+    "reorderConfirmTitle": "Confirm reorder",
+```
+
+```json
+    "reorder": {
+      "discard": "Discard changes",
+      "discardTitle": "Discard order changes",
+      "discardConfirm": "Discard all unsaved order changes?",
+      "changedSummary": "{{count}} page(s) differ from the saved order"
+    },
+```
+
+- [ ] **Step 4: Kontrolli keelepaarsust**
+
+Run: `npm run test -- src/locales/__tests__/localeParity.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: `WorkManage` — jaga salvestus ja asenda `window.confirm`**
+
+Lisa importidesse:
+
+```ts
+import ConfirmModal from '../components/ConfirmModal';
+import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
+import { useUnsavedChangesGuard } from '../hooks/useUnsavedChangesGuard';
+```
+
+Lisa olek (teiste `useState`-ide juurde):
+
+```ts
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
+  const [reorderConfirmOpen, setReorderConfirmOpen] = useState(false);
+```
+
+Asenda read 367-373 (`handleDiscardReorder`):
+
+```ts
+  // Tühista kõik salvestamata järjekorra muudatused
+  const applyDiscardReorder = () => {
+    const init: Record<string, number> = {};
+    pages.forEach((p) => { init[p.filename] = p.page_num; });
+    setDraftPositions(init);
+    setDiscardConfirmOpen(false);
+  };
+
+  const handleDiscardReorder = () => {
+    if (changedCount > 2) { setDiscardConfirmOpen(true); return; }
+    applyDiscardReorder();
+  };
+```
+
+Asenda `handleReorderSave` (rida 375-401) nii, et kinnitus on eraldi. Kinnituseta variant:
+
+```ts
+  /**
+   * Salvestab järjekorra ILMA kinnituseta. Kasutab nii nupu-handler (mis küsib
+   * kinnituse enne) kui ka salvestamata muudatuste dialoog — muidu hüppaks
+   * dialoogi "Salvesta ja jätka" peale teine kinnitus ette.
+   *
+   * Tagastab `true` ainult siis, kui salvestus õnnestus.
+   */
+  const saveReorder = async (): Promise<boolean> => {
+    if (!workId || !authToken) return false;
+    setReorderConfirmOpen(false);
+
+    const sorted = [...pages].sort((a, b) => {
+      const pa = draftPositions[a.filename] ?? a.page_num;
+      const pb = draftPositions[b.filename] ?? b.page_num;
+      return pa - pb;
+    });
+    const order = sorted.map(p => p.filename);
+
+    setReorderSaving(true);
+    setReorderError(null);
+    try {
+      await reorderWorkPages(workId, authToken, order);
+      await loadPages();
+      // Salvestus = commit → tühjenda valik (uue protsessi eeldus). NB: Liiguta
+      // (mustand) EI tühjenda, et saaks sama plokki uuesti liigutada.
+      handleClearSelection();
+      return true;
+    } catch (e: any) {
+      setReorderError(e.message || t('manage.reorderError'));
+      return false;
+    } finally {
+      setReorderSaving(false);
+    }
+  };
+
+  const handleReorderSave = () => { setReorderConfirmOpen(true); };
+```
+
+- [ ] **Step 6: `WorkManage` — lisa guard**
+
+Lisa `changedCount` (rida 287) järele:
+
+```ts
+  const { dialogProps } = useUnsavedChangesGuard({
+    isDirty: changedCount > 0,
+    onSave: saveReorder,
+  });
+```
+
+- [ ] **Step 7: `WorkManage` — renderda kolm dialoogi**
+
+Lisa komponendi lõppu, enne sulgevat `</div>`-i:
+
+```tsx
+      <ConfirmModal
+        isOpen={discardConfirmOpen}
+        title={t('manage.reorder.discardTitle')}
+        message={t('manage.reorder.discardConfirm')}
+        onConfirm={applyDiscardReorder}
+        onCancel={() => setDiscardConfirmOpen(false)}
+        variant="danger"
+      />
+
+      <ConfirmModal
+        isOpen={reorderConfirmOpen}
+        title={t('manage.reorderConfirmTitle')}
+        message={t('manage.reorderConfirm')}
+        onConfirm={() => { void saveReorder(); }}
+        onCancel={() => setReorderConfirmOpen(false)}
+      />
+
+      <UnsavedChangesDialog {...dialogProps} />
+```
+
+- [ ] **Step 8: Veendu, et `window.confirm` on failist kadunud**
+
+Run: `grep -n "window.confirm" src/pages/WorkManage.tsx`
+Expected: tühi väljund
+
+- [ ] **Step 9: Typecheck ja testid**
+
+Run: `npm run typecheck && npm run test`
+Expected: mõlemad vigadeta
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/pages/WorkManage.tsx src/components/ConfirmModal.tsx src/locales/et/workspace.json src/locales/en/workspace.json
+git commit -m "refactor: WorkManage natiivsed confirm'id ConfirmModal'iks + lahkumiskaitse"
+```
+
+---
+
+## Task 9: Surnud tõlgete koristus ja lõppkontroll
+
+**Files:**
+- Modify: `src/locales/et/workspace.json:332-337`, `src/locales/en/workspace.json:332-337`
+- Modify: `src/locales/et/admin.json:166-169`, `src/locales/en/admin.json:166-169`
+
+**Interfaces:**
+- Consumes: kõik eelnev
+- Produces: midagi
+
+- [ ] **Step 1: Kontrolli, et vanad võtmed on tõesti kasutuseta**
+
+Run:
+```bash
+grep -rn "confirm.unsavedChanges\|confirm.saveAndLeave\|confirm.leaveWithoutSaving" src --include=*.tsx --include=*.ts
+grep -rn "places.unsavedTitle\|places.unsavedBody\|places.unsavedStay\|places.unsavedLeave" src --include=*.tsx --include=*.ts
+```
+Expected: mõlemad tühjad
+
+- [ ] **Step 2: Eemalda `workspace.json` `confirm` plokk mõlemast keelest**
+
+`src/locales/et/workspace.json` — kustuta tervikuna:
+
+```json
+  "confirm": {
+    "unsavedChanges": "Sul on salvestamata muudatusi. Kas oled kindel, et soovid lahkuda?",
+    "unsavedChangesPrompt": "Sul on salvestamata muudatusi. Kas soovid salvestada?",
+    "saveAndLeave": "Jah, salvesta",
+    "leaveWithoutSaving": "Ei, lahku"
+  },
+```
+
+`src/locales/en/workspace.json` — kustuta vastav plokk.
+
+**NB:** `workspace.editor.unsavedChanges` ("Salvestamata muudatused") JÄÄB — seda kasutab `EditorHeader`, mitte dialoog.
+
+- [ ] **Step 3: Eemalda `admin.json` `places.unsaved*` võtmed mõlemast keelest**
+
+Kustuta neli rida mõlemast (`unsavedTitle`, `unsavedBody`, `unsavedStay`, `unsavedLeave`).
+
+- [ ] **Step 4: Kontrolli keelepaarsust ja tervikut**
+
+Run: `npm run typecheck && npm run test && npm run lint`
+Expected: typecheck ja test vigadeta; lint `--max-warnings 56` piires (kui hoiatusi vähenes, langeta lävi `package.json`-is)
+
+- [ ] **Step 5: Käsitsi kontroll — täielik maatriks**
+
+Run: `npm run dev`
+
+Läbi iga kasutuskoht: **Workspace** (`/work/{id}/1`), **PersonEditPage** (`/persons/{id}/edit`), **Places** (`/admin/places`), **WorkManage** (`/work/{id}/manage`).
+
+| # | Stsenaarium | Ootus |
+|---|---|---|
+| 1 | Brauseri Back-nupp | dialoog tuleb |
+| 2 | Rakendusesisene link | dialoog tuleb |
+| 3 | Lehesisene vaheldus (Workspace lehepööre, Places koha vahetus) | dialoog tuleb |
+| 4 | "Salvesta ja jätka" õnnestub | salvestab JA jätkab sihtkohta |
+| 5 | "Salvesta ja jätka" ebaõnnestub (võta võrk maha) | **jääb kohale**, vearida dialoogis, midagi ei kao |
+| 6 | "Loobu muudatustest" | jätkab sihtkohta salvestamata |
+| 7 | "Jää siia" | jääb kohale, dialoog sulgub |
+| 8 | Topeltklikk "Salvesta ja jätka" | täpselt üks salvestus |
+| 9 | Back kaks korda järjest | teine kord käitub sama moodi |
+| 10 | **Pärast ühe dialoogi kasutamist tee uus muudatus ja lahku uuesti** | dialoog tuleb jälle — möödapääs EI jäänud aktiivseks |
+| 11 | Esc ja taustaklõps salvestamise ajal | dialoog EI sulgu |
+| 12 | Esc ja taustaklõps muul ajal | sama mis "Jää siia" |
+| 13 | Tab-i sulgemine salvestamata muudatustega | brauseri oma hoiatus |
+
+Stsenaarium 10 on kõige olulisem — just see paljastaks lekkiva möödapääsu.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/locales/
+git commit -m "chore: eemalda kasutuseta salvestamata muudatuste tõlkevõtmed"
+```
+
+---
+
+## Lõpetamine
+
+Kui kõik üheksa ülesannet on tehtud ja käsitsi maatriks läbitud, kasuta
+`superpowers:finishing-a-development-branch` skilli, et otsustada, kuidas
+`feat/uhtne-salvestamata-dialoog` `main`-i viia.
+
+**Deploy:** frontend-only muudatus. `npm run build` lokaalselt ja
+`rsync -avz --delete dist/ vutt:~/VUTT/dist/`. Backend'i ega Meilisearchi ei puuduta.

--- a/docs/superpowers/specs/2026-07-28-uhtne-salvestamata-muudatuste-dialoog-design.md
+++ b/docs/superpowers/specs/2026-07-28-uhtne-salvestamata-muudatuste-dialoog-design.md
@@ -1,0 +1,208 @@
+# Ühtne salvestamata muudatuste dialoog
+
+**Kuupäev:** 2026-07-28
+**Staatus:** disain kinnitatud, plaan tegemata
+
+## Probleem
+
+Salvestamata muudatuste hoiatus käitub rakenduses neljal erineval moel. Kasutaja
+ei saa käitumist ette aimata ja peab iga dialoogi eraldi lugema.
+
+| Koht | Mehhanism | Nupud |
+|---|---|---|
+| `Workspace.tsx:782` (tekst) | `ConfirmModal` + `useUnsavedChangesGuard` | *Ei, lahku* (hall) / **Jah, salvesta** (sinine) — "jää" varianti ei ole |
+| `PersonEditPage.tsx:949` (prosopo) | `ConfirmModal` + sama guard | *Jää* (hall) / **Lahku ilma salvestamata** (sinine primary) |
+| `Places.tsx:288` (kohad) | käsitsi kirjutatud modaal, ainult koha vahetusel | *Jää siia* (hall) / **Lahku ilma salvestamata** (punane) |
+| `WorkManage.tsx:369,377` | natiivne `window.confirm` | OK / Cancel |
+
+Kaardistamisel leitud lisaprobleemid:
+
+1. **Kohtade registris puudub lahkumiskaitse täielikult.** `useUnsavedChangesGuard`
+   ega `beforeunload` ei ole ühendatud — muudatused kaovad vaikselt, kui lahkud
+   lehelt või sulged tab-i.
+2. **Prosopograafias on hävitav valik sinine primary-nupp** (`variant="warning"`
+   annab `ConfirmModal`-is `bg-primary-600`) — kõige rõhutatum nupp on "kaota töö".
+3. **Salvestusvea korral kaob töö.** `useEditorSave.ts:76-79` püüab vea kinni ja
+   promise **resolvib**; `Workspace.tsx:518` navigeerib seetõttu alati ära. Kommentaar
+   "alert on juba TextEditoris" on eksitav — see banner renderdub komponendis, mis
+   on kohe lahkumas.
+4. **Tekstiredaktoris ei saa dialoogist loobuda.** `onCancel` on seotud
+   `handleConfirmLeave`-iga, mis lahkub; Esc ega taustaklõps ei reageeri.
+5. **Kohtade dirty-lipp on vale.** `PlacesDetail.tsx:111`: `onDirtyChange?.(editing)`
+   — lipp on püsti alati, kui redigeerimisrežiim on lahti, ka siis kui midagi pole
+   muudetud.
+
+## Eesmärk
+
+Üks dialoog, üks käitumine, samad sõnad kõikjal. Kasutaja õpib selle korra selgeks
+ja teab edaspidi ette, mis juhtub.
+
+## Lahendus
+
+### Dialoog
+
+Uus komponent `src/components/UnsavedChangesDialog.tsx`. **Ei** ole `ConfirmModal`
+laiendus: `ConfirmModal` on üldine kahe-nupu kinnitus (`extraText`/`onExtra` on
+sinna juba jõuga lisatud kolmas nupp), salvestamata muudatuste dialoogil on püsiv
+kolme-nupu kuju, oma salvestusloogika ja fikseeritud tekstid.
+
+```
+⚠  Salvestamata muudatused
+Sul on salvestamata muudatusi.
+
+[Loobu muudatustest]   [Jää siia]   [Salvesta ja jätka]
+   bg-red-600         hall ääris      bg-amber-500
+```
+
+**Värvivalik lähtub olemasolevatest signaalidest, mitte üldistest konventsioonidest:**
+
+- Kollane `bg-amber-500` = "siin on salvestamata töö, vajuta mind". Sama värv on
+  juba SALVESTA nupul `EditorHeader.tsx:75-78`, mis muutub `bg-primary-600`-lt
+  `bg-amber-500`-ks täpselt siis, kui `hasUnsavedChanges || statusDirty`.
+- Punane `bg-red-600` = hävitav kinnitus. Sama värv juba `Places.tsx:302`.
+
+### Invariandid
+
+Need on "prognoositavuse" tegelik sisu ja neid ei tohi ükski kasutuskoht murda:
+
+1. **Kollane nupp ei vii sihtkohta enne, kui salvestamine on õnnestunud.**
+   Ebaõnnestumisel jääb dialoog avatuks, midagi ei kao.
+2. **Salvestamise ajal on kõik kolm nuppu disabled**, kollasel spinner. Topeltklikk
+   ei tekita kahte salvestust.
+3. **Esc ja taustaklõps = "Jää siia".** Alati, igas kasutuskohas.
+4. **Fookus avanemisel on "Jää siia" peal.** Enter ei tee midagi hävitavat.
+5. **Nuppude järjekord, värv ja tekst on kõikjal identsed** — ka siis, kui dialoog
+   tuli lehepöördest, mitte lahkumisest. Sihtkohta nupusildid ei nimeta.
+6. **Kolm nuppu alati.** `onSave` on kohustuslik prop; kõigis kasutuskohtades
+   salvestusfunktsioon eksisteerib. Ei ole olekut, kus dialoog näeb teistsugune välja.
+
+### Salvestamise leping
+
+```ts
+onSave: () => Promise<boolean>   // true = salvestatud, false = ebaõnnestus
+```
+
+Boolean, mitte erind. Põhjus: kõik kolm salvestusteed **juba** püüavad vea kinni ja
+kuvavad selle oma veabanneris (`useEditorSave` → `setSaveError`, `PersonEditPage` →
+`setError`, `PlacesDetail` → `setSaveError`). Erindite läbi laskmine tähendaks selle
+kihi ümberehitust ja tekitaks käsitlemata rejection'eid tavalise SALVESTA nupu teel.
+
+`false` korral kuvab dialoog lühikese rea "Salvestamine ebaõnnestus — muudatused on
+alles"; detailne põhjus jääb lehe enda veabannerisse.
+
+### Hook
+
+`src/hooks/useUnsavedChangesGuard.ts` kirjutatakse ümber objekt-argumendile:
+
+```ts
+const { dialogProps, confirmAction } = useUnsavedChangesGuard({
+  isDirty,
+  onSave,    // () => Promise<boolean>
+  skipRef,   // olemasolev muster jääb alles
+});
+
+<UnsavedChangesDialog {...dialogProps} />
+
+// Lehesisesed üleminekud (lehepööre, koha vahetus):
+confirmAction(() => navigate(`/work/${workId}/${newPage}`, { replace: true }));
+```
+
+`confirmAction(fn)`: kui puhas → käivitab `fn()` kohe; kui dirty → avab dialoogi ja
+jätab `fn` ootele. See on üldistus sellest, mida `Workspace.tsx` teeb praegu käsitsi
+`pendingNavigation`-iga viies kohas ja `Places.tsx` `pendingKey`-ga. Mõlemad käsitsi
+mehhanismid kaovad.
+
+Hook katab kolm sisendit ühe dialoogiga:
+
+- React Routeri `useBlocker` — lehelt lahkumine
+- `beforeunload` — tab-i sulgemine (brauseri oma dialoog, seda me ei kontrolli)
+- `confirmAction` — lehesisene üleminek
+
+### Puhas loogikamoodul
+
+`src/hooks/unsavedChangesFlow.ts` — otsustusloogika DOM-i ja Reactita, sama
+muster mis `markdownEditorHelpers.ts`. Siin elab kriitiline invariant: ootel tegevus
+käivitub ainult siis, kui `onSave` tagastas `true`.
+
+## Ulatus
+
+| Fail | Muudatus |
+|---|---|
+| `components/UnsavedChangesDialog.tsx` | **uus** — kolme-nupu dialoog, Esc/taust, spinner, veerida |
+| `hooks/unsavedChangesFlow.ts` | **uus** — puhas otsustusloogika |
+| `hooks/__tests__/unsavedChangesFlow.test.ts` | **uus** — node-testid |
+| `hooks/useUnsavedChangesGuard.ts` | ümber kirjutatud: objekt-argument, `onSave`, `confirmAction`, `dialogProps` |
+| `pages/Workspace.tsx` | `pendingNavigation` kaob (read 152, 375, 395, 479, 494) → `confirmAction`; `handleSaveAndLeave` ei navigeeri vea korral |
+| `components/editor/useEditorSave.ts` | `runSave` ja `handleSaveWithDrafts` tagastavad `boolean` |
+| `prosopography/pages/PersonEditPage.tsx` | `handleSave` jagatud `savePerson()` + nupu-handleriks (praegu navigeerib ise, read 208/213); `ConfirmModal` → `UnsavedChangesDialog` |
+| `pages/admin/Places.tsx` | guard lisatud (puudus täiesti), käsitsi modaal (288-309) kaob, `pendingKey` → `confirmAction` |
+| `pages/admin/PlacesDetail.tsx` | päris dirty-arvutus `editing` asemel; `handleSave` `boolean`-iks ja `saveRef` kaudu üles |
+| `pages/WorkManage.tsx` | 2× `window.confirm` → `ConfirmModal`; guard `changedCount > 0` peale; `onSave` = järjekorra salvestus **ilma** pesastatud kinnituseta |
+| `components/ConfirmModal.tsx` | Esc + taustaklõps = tühista |
+| `locales/{et,en}/common.json` | uued `unsavedChanges.*` võtmed |
+| `locales/{et,en}/admin.json` | `places.unsaved*` kustutatud |
+| `locales/{et,en}/workspace.json` | `confirm.*` kustutatud |
+
+### WorkManage'i erisus
+
+`handleReorderSave` (`WorkManage.tsx:375`) küsib ise kinnitust `window.confirm`-iga.
+Kui kasutaja valib lahkumisdialoogist "Salvesta ja jätka", ei tohi järjekorra
+kinnitus uuesti ette hüpata. Salvestus jagatakse: `saveReorder()` (ilma kinnituseta,
+kasutab dialoog) + nupu-handler, mis küsib kinnituse ja kutsub `saveReorder()`.
+
+`handleDiscardReorder` (`WorkManage.tsx:368`) jääb kahe-nupu kinnituseks
+(`ConfirmModal`) — see ei ole lahkumisdialoog, vaid "viska N muudatust ära".
+
+### Tõlked
+
+Mõlemad keeled korraga, muidu katkeb build (`localeParity.test.ts`, `fallbackLng`
+on välja lülitatud — ADR 0011).
+
+`common:unsavedChanges`:
+
+| Võti | et | en |
+|---|---|---|
+| `title` | Salvestamata muudatused | Unsaved changes |
+| `message` | Sul on salvestamata muudatusi. | You have unsaved changes. |
+| `discard` | Loobu muudatustest | Discard changes |
+| `stay` | Jää siia | Stay here |
+| `saveAndContinue` | Salvesta ja jätka | Save and continue |
+| `saveFailed` | Salvestamine ebaõnnestus — muudatused on alles. | Save failed — your changes are still here. |
+
+## Ulatusest väljas
+
+- `MetadataModal` ja teised modaalid, mille sulgemisel võib olla salvestamata sisu.
+- `admin/Collections.tsx` (`CollectionEditor`) — salvestab kohe, dirty-olekut ei teki.
+- Kolme-nupu dialoogi kasutamine hävitavate tegevuste (kustutamine) kinnitamiseks —
+  need jäävad `ConfirmModal`-i.
+
+## Testimine
+
+`src/hooks/__tests__/unsavedChangesFlow.test.ts`, vitest `environment: 'node'`,
+uusi sõltuvusi ei lisata. Kaetavad juhud:
+
+- ootel tegevus käivitub, kui `onSave` tagastab `true`
+- ootel tegevus **ei** käivitu, kui `onSave` tagastab `false`; dialoog jääb avatuks
+- "Loobu muudatustest" käivitab ootel tegevuse salvestamata
+- "Jää siia" tühistab ootel tegevuse
+- `confirmAction` puhta oleku korral käivitab tegevuse dialoogi avamata
+- salvestamise ajal saabuv teine kutse ei tekita teist salvestust
+
+Dialoogi visuaal, fookus ja Esc-käitumine kontrollitakse käsitsi kõigis neljas
+kohas (jsdom/testing-library infrat projektis ei ole ja seda ei lisata).
+
+Väravad: `npm run typecheck` ja `npm run test`.
+
+## Otsuste põhjendused
+
+**Miks kollane salvestusnupule, mitte sinine primary?** Esialgu pakkusin sinist
+primary-nuppu üldise konventsiooni järgi (ohutu tegevus on rõhutatud). Rakenduses on
+aga kollane juba tähenduses "siin on salvestamata töö" (`EditorHeader.tsx:76`).
+Sinine katkestaks olemasoleva signaali; kollane jätkab seda.
+
+**Miks samad sõnad ka lehepöördel?** Sihtkoha järgi kohandatud sildid ("Salvesta ja
+mine", "Salvesta ja vaheta") on täpsemad, aga tekitavad kolm variatsiooni. Eesmärk on
+prognoositavus: sama kolm nuppu, samad sõnad, sama järjekord, olenemata sellest,
+kust dialoog tuli.
+
+**Miks eraldi komponent, mitte `ConfirmModal`?** Vt "Dialoog" ülal.

--- a/docs/superpowers/specs/2026-07-28-uhtne-salvestamata-muudatuste-dialoog-design.md
+++ b/docs/superpowers/specs/2026-07-28-uhtne-salvestamata-muudatuste-dialoog-design.md
@@ -44,22 +44,51 @@ ja teab edaspidi ette, mis juhtub.
 Uus komponent `src/components/UnsavedChangesDialog.tsx`. **Ei** ole `ConfirmModal`
 laiendus: `ConfirmModal` on üldine kahe-nupu kinnitus (`extraText`/`onExtra` on
 sinna juba jõuga lisatud kolmas nupp), salvestamata muudatuste dialoogil on püsiv
-kolme-nupu kuju, oma salvestusloogika ja fikseeritud tekstid.
+kolme-nupu kuju ja fikseeritud tekstid.
+
+**Dialoog on puhas presentatsioonikiht.** Async-salvestusvoogu ta ei oma — see kuulub
+hook'ile, otsused puhtale moodulile. Dialoog renderdab, hoiab fookust, kuulab klahve
+ja teatab kasutaja sündmustest:
+
+```ts
+type UnsavedChangesDialogProps = {
+  open: boolean;
+  saving: boolean;
+  saveFailed: boolean;
+  onDiscard: () => void;
+  onStay: () => void;
+  onSaveAndContinue: () => void;
+};
+```
+
+Nii jääb otsus "kas ootel tegevus käivitub" täielikult JSX-ist välja ja puhta mooduli
+testid katavad selle päriselt.
 
 ```
 ⚠  Salvestamata muudatused
 Sul on salvestamata muudatusi.
 
 [Loobu muudatustest]   [Jää siia]   [Salvesta ja jätka]
-   bg-red-600         hall ääris      bg-amber-500
+   bg-red-600         hall ääris      bg-amber-600
 ```
 
 **Värvivalik lähtub olemasolevatest signaalidest, mitte üldistest konventsioonidest:**
 
-- Kollane `bg-amber-500` = "siin on salvestamata töö, vajuta mind". Sama värv on
-  juba SALVESTA nupul `EditorHeader.tsx:75-78`, mis muutub `bg-primary-600`-lt
-  `bg-amber-500`-ks täpselt siis, kui `hasUnsavedChanges || statusDirty`.
+- Kollane = "siin on salvestamata töö, vajuta mind". Sama signaal on juba SALVESTA
+  nupul `EditorHeader.tsx:75-78`, mis vahetub `bg-primary-600`-lt kollaseks täpselt
+  siis, kui `hasUnsavedChanges || statusDirty`.
 - Punane `bg-red-600` = hävitav kinnitus. Sama värv juba `Places.tsx:302`.
+
+**Kollane toon: `bg-amber-600 text-white`.** Rakenduses on kollane praegu kahes toonis:
+`amber-500` (`EditorHeader.tsx:76`, `PageActionBar.tsx:116`) ja `amber-600`
+(`MetadataModal.tsx:922`, `UploadMetaForm.tsx:676`, `DashboardBulkActionBar.tsx:64`,
+`PageImageEditorModal.tsx:856`). Dialoog võtab enamuse tooni `amber-600`.
+
+Kontrast valge tekstiga: `amber-500` 2,15:1, `amber-600` 3,18:1, `amber-700` 5,02:1.
+`amber-600` on kahest olemasolevast parem, aga ei ulatu WCAG AA nõudeni (4,5:1 väikese
+teksti korral). **Kontrasti ei parandata siin ühepoolselt** — kollase nupu äratundmine
+sõltub sellest, et see näeb kõikjal ühesugune välja. Üleminek `amber-700`-le või tumedale
+tekstile on eraldi ülesanne, mis puudutab kõiki kuut kasutuskohta korraga.
 
 ### Invariandid
 
@@ -69,12 +98,22 @@ Need on "prognoositavuse" tegelik sisu ja neid ei tohi ükski kasutuskoht murda:
    Ebaõnnestumisel jääb dialoog avatuks, midagi ei kao.
 2. **Salvestamise ajal on kõik kolm nuppu disabled**, kollasel spinner. Topeltklikk
    ei tekita kahte salvestust.
-3. **Esc ja taustaklõps = "Jää siia".** Alati, igas kasutuskohas.
+3. **Esc ja taustaklõps = "Jää siia", kui salvestamist ei toimu.** Salvestamise ajal
+   on nupud, Esc ja taustaklõps kõik blokeeritud — muidu sulguks dialoog, salvestus
+   jätkuks taustal ja hiljem saabuv vastus käivitaks navigeerimise ajal, mil kasutaja
+   juba jätkab redigeerimist. Salvestuse katkestamist (`AbortController`) ei tehta.
 4. **Fookus avanemisel on "Jää siia" peal.** Enter ei tee midagi hävitavat.
 5. **Nuppude järjekord, värv ja tekst on kõikjal identsed** — ka siis, kui dialoog
    tuli lehepöördest, mitte lahkumisest. Sihtkohta nupusildid ei nimeta.
 6. **Kolm nuppu alati.** `onSave` on kohustuslik prop; kõigis kasutuskohtades
    salvestusfunktsioon eksisteerib. Ei ole olekut, kus dialoog näeb teistsugune välja.
+7. **"Loobu muudatustest" taastab baasseisu enne ootel tegevuse käivitamist.**
+   Vt "Loobumise leping" allpool.
+8. **Esimene ootel tegevus võidab.** Kui dialoog on avatud või salvestamine käib, ei
+   asenda uus `runGuarded` kutse olemasolevat ootel tegevust — seda ignoreeritakse.
+   Vastasel juhul muutuks "Salvesta ja jätka" sihtkoht kasutaja jaoks ettearvamatuks.
+   Ootel tegevus nullitakse alati: pärast "Jää siia", pärast edukat jätkamist ja
+   pärast loobumist.
 
 ### Salvestamise leping
 
@@ -90,25 +129,66 @@ kihi ümberehitust ja tekitaks käsitlemata rejection'eid tavalise SALVESTA nupu
 `false` korral kuvab dialoog lühikese rea "Salvestamine ebaõnnestus — muudatused on
 alles"; detailne põhjus jääb lehe enda veabannerisse.
 
+Leping täpsemalt:
+
+- `true` — kõik vajalik on **püsivalt** salvestatud ja kohalikud dirty-lipud ning
+  salvestatud baasseis on uuendatud. Mitte lihtsalt "HTTP päring lõppes".
+- `false` — salvestamine või valideerimine ei õnnestunud.
+- **visatud erind** — hook käsitleb seda kaitseks samamoodi nagu `false`. Ükski
+  praegune kasutuskoht ei viska, aga tulevane refaktor ei tohi jätta dialoogi
+  igaveseks `saving`-olekusse ega tekitada käsitlemata rejection'it.
+
+```ts
+try {
+  const saved = await onSave();
+  if (!saved) { showSaveFailed(); return; }
+  runPendingAction();
+} catch {
+  showSaveFailed();
+} finally {
+  setSaving(false);
+}
+```
+
+### Loobumise leping
+
+"Loobu muudatustest" ei tohi eeldada, et komponent monteeritakse maha. Invariant:
+**kohalik mustand taastatakse baasseisu enne ootel tegevuse käivitamist.**
+
+Meie neljas kasutuskohas tagab selle juba olemasolev kood ja **eraldi `onDiscard`
+propi ei lisata**:
+
+| Kasutuskoht | Mis taastab baasseisu |
+|---|---|
+| Workspace, lehepööre | `useEditorState.ts:71-83` — `isSwap` haru lähtestab `isDirty`, `savedState`, `annotationDraftDirty`, `saveError` ja dokumendi sisu. Kirjutatud täpselt selleks, et editor ei monteeru lehepöördel maha (ADR 0010, #194) |
+| Workspace, lahkumine | komponent monteeritakse maha |
+| Places, koha vahetus | `PlacesDetail.tsx:106-108` — `useEffect(() => setEditing(false), [placeKey])`, mis lähtestab mustandi |
+| Places / PersonEdit / WorkManage, lahkumine | komponent monteeritakse maha |
+
+Kohustuslik prop, mis oleks igas kasutuskohas no-op, tekitaks topeltlähtestuse riski
+ja valekindlust. Selle asemel on **plaanis verifitseerimissamm**: iga kasutuskoha
+juures näidatakse, mis baasseisu taastab. Kui mõni tulevane `runGuarded` kutse teeb
+tegevuse, mis ei navigeeri ega vaheta objekti, tuleb `onDiscard` siis lisada.
+
 ### Hook
 
 `src/hooks/useUnsavedChangesGuard.ts` kirjutatakse ümber objekt-argumendile:
 
 ```ts
-const { dialogProps, confirmAction } = useUnsavedChangesGuard({
+const { dialogProps, runGuarded, allowNextNavigation } = useUnsavedChangesGuard({
   isDirty,
   onSave,    // () => Promise<boolean>
-  skipRef,   // olemasolev muster jääb alles
 });
 
 <UnsavedChangesDialog {...dialogProps} />
 
 // Lehesisesed üleminekud (lehepööre, koha vahetus):
-confirmAction(() => navigate(`/work/${workId}/${newPage}`, { replace: true }));
+runGuarded(() => navigate(`/work/${workId}/${newPage}`, { replace: true }));
 ```
 
-`confirmAction(fn)`: kui puhas → käivitab `fn()` kohe; kui dirty → avab dialoogi ja
-jätab `fn` ootele. See on üldistus sellest, mida `Workspace.tsx` teeb praegu käsitsi
+`runGuarded(fn)`: kui puhas → käivitab `fn()` kohe, dialoogi avamata; kui dirty →
+avab dialoogi ja jätab `fn` ootele. Nimi on `confirmAction`-ist täpsem: puhtas olekus
+kinnitust ei küsita. See on üldistus sellest, mida `Workspace.tsx` teeb praegu käsitsi
 `pendingNavigation`-iga viies kohas ja `Places.tsx` `pendingKey`-ga. Mõlemad käsitsi
 mehhanismid kaovad.
 
@@ -116,7 +196,37 @@ Hook katab kolm sisendit ühe dialoogiga:
 
 - React Routeri `useBlocker` — lehelt lahkumine
 - `beforeunload` — tab-i sulgemine (brauseri oma dialoog, seda me ei kontrolli)
-- `confirmAction` — lehesisene üleminek
+- `runGuarded` — lehesisene üleminek
+
+### Möödapääs: sisemine ühekordne bypass + avalik meetod
+
+Praegune avalik `skipRef` on lekkiv abstraktsioon: kasutuskoht peab teadma, kuidas
+blokeerimisest mööda pääseb, ja võib jätta lipu kogemata püsti, mis avaks järgmise
+päris lahkumise kaitseta. Jaotatakse kaheks.
+
+**Sisemine, ühekordne.** Pärast edukat salvestust on `isDirty` Reacti järgmise
+renderduseni tõenäoliselt veel `true`, seega ootel tegevuse `navigate()` käivitaks
+guard'i kohe uuesti. Praegu hoiab seda koos `requestAnimationFrame` hack
+`Workspace.tsx:522-528`. Hook saab sisemise `allowNextTransitionRef`, mis kehtib
+**täpselt ühe** ülemineku kohta ja kustub kohe pärast selle läbilaskmist — mitte
+ajapõhiselt. Hack kaob kasutuskohtadest. Kui ootel tegevus viskab erindi, taastatakse
+bypass ja `saving` sama `finally`-plokis; guard ei jää lahtiseks.
+
+**Avalik `allowNextNavigation()`.** Toore mutable ref'i asendus samale vajadusele, mis
+`PersonEditPage.tsx:207,212` juba katab: leht salvestab **oma** nupuga ja navigeerib
+ise (`/persons/{id}`), dialoogivoost sõltumatult. Meetod tähistab järgmise navigatsiooni
+lubatuks, on ühekordne ja kehtib sama loogika järgi mis sisemine. Kutsuja ei tea ega
+puutu ühtki ref'i.
+
+### Ligipääsetavus
+
+- `role="alertdialog"` koos `aria-labelledby` (pealkiri) ja `aria-describedby` (sõnum)
+- fookus on dialoogi sees lõksustatud (Tab ei vii dialoogist välja)
+- sulgemisel taastatakse fookus elemendile, mis ülemineku algatas
+- salvestusvea rida `role="status"` / `aria-live="polite"`
+- salvestamise ajal `aria-busy="true"` dialoogil
+- fookusring on nähtav ka kollasel ja punasel nupul (`focus-visible:ring-2`
+  kontrastse tooniga, mitte nupu enda värviga)
 
 ### Puhas loogikamoodul
 
@@ -128,17 +238,17 @@ käivitub ainult siis, kui `onSave` tagastas `true`.
 
 | Fail | Muudatus |
 |---|---|
-| `components/UnsavedChangesDialog.tsx` | **uus** — kolme-nupu dialoog, Esc/taust, spinner, veerida |
+| `components/UnsavedChangesDialog.tsx` | **uus** — kolme-nupu dialoog, Esc/taust, fookuselõks, spinner, vearida |
 | `hooks/unsavedChangesFlow.ts` | **uus** — puhas otsustusloogika |
 | `hooks/__tests__/unsavedChangesFlow.test.ts` | **uus** — node-testid |
-| `hooks/useUnsavedChangesGuard.ts` | ümber kirjutatud: objekt-argument, `onSave`, `confirmAction`, `dialogProps` |
-| `pages/Workspace.tsx` | `pendingNavigation` kaob (read 152, 375, 395, 479, 494) → `confirmAction`; `handleSaveAndLeave` ei navigeeri vea korral |
+| `hooks/useUnsavedChangesGuard.ts` | ümber kirjutatud: objekt-argument, `onSave`, `runGuarded`, `allowNextNavigation`, `dialogProps`; sisemine ühekordne bypass |
+| `pages/Workspace.tsx` | `pendingNavigation` kaob (read 152, 375, 395, 479, 494) → `runGuarded`; `handleSaveAndLeave` ei navigeeri vea korral; `requestAnimationFrame` bypass-hack (522-528) kaob |
 | `components/editor/useEditorSave.ts` | `runSave` ja `handleSaveWithDrafts` tagastavad `boolean` |
-| `prosopography/pages/PersonEditPage.tsx` | `handleSave` jagatud `savePerson()` + nupu-handleriks (praegu navigeerib ise, read 208/213); `ConfirmModal` → `UnsavedChangesDialog` |
-| `pages/admin/Places.tsx` | guard lisatud (puudus täiesti), käsitsi modaal (288-309) kaob, `pendingKey` → `confirmAction` |
-| `pages/admin/PlacesDetail.tsx` | päris dirty-arvutus `editing` asemel; `handleSave` `boolean`-iks ja `saveRef` kaudu üles |
+| `prosopography/pages/PersonEditPage.tsx` | `handleSave` jagatud `savePerson()` + nupu-handleriks (praegu navigeerib ise, read 208/213); `skipGuardRef` → `allowNextNavigation()`; `ConfirmModal` → `UnsavedChangesDialog` |
+| `pages/admin/Places.tsx` | guard lisatud (puudus täiesti), käsitsi modaal (288-309) kaob, `pendingKey` → `runGuarded` |
+| `pages/admin/PlacesDetail.tsx` | päris dirty-arvutus `editing` asemel (vt allpool); `handleSave` `boolean`-iks ja `saveRef` kaudu üles |
 | `pages/WorkManage.tsx` | 2× `window.confirm` → `ConfirmModal`; guard `changedCount > 0` peale; `onSave` = järjekorra salvestus **ilma** pesastatud kinnituseta |
-| `components/ConfirmModal.tsx` | Esc + taustaklõps = tühista |
+| `components/ConfirmModal.tsx` | Esc + taustaklõps = tühista (vt tarbijate audit allpool) |
 | `locales/{et,en}/common.json` | uued `unsavedChanges.*` võtmed |
 | `locales/{et,en}/admin.json` | `places.unsaved*` kustutatud |
 | `locales/{et,en}/workspace.json` | `confirm.*` kustutatud |
@@ -152,6 +262,36 @@ kasutab dialoog) + nupu-handler, mis küsib kinnituse ja kutsub `saveReorder()`.
 
 `handleDiscardReorder` (`WorkManage.tsx:368`) jääb kahe-nupu kinnituseks
 (`ConfirmModal`) — see ei ole lahkumisdialoog, vaid "viska N muudatust ära".
+
+### Kohtade dirty-arvutus
+
+`PlacesDetail.tsx:111` asendub võrdlusega **viimati laaditud või edukalt salvestatud
+baasseisuga**, mitte "kas kasutaja on midagi puutunud". Nõutud käitumine:
+
+- redigeerimisrežiimi avamine **ei** tee vormi dirty'ks
+- välja muutmine teeb dirty'ks
+- algväärtuse käsitsi taastamine teeb vormi jälle puhtaks
+- edukas salvestamine muudab praegused väärtused uueks baasseisuks
+- teise koha laadimine loob uue baasseisu
+- loobumine taastab baasseisu
+- normaliseeritud väärtused ei tekita valepositiivset dirty't: `undefined` vs tühi
+  string, puuduv võti vs tühi objekt, trimmimata vs trimmitud — võrdlus käib
+  normaliseeritud kujul, sama funktsiooniga, mida `handleSave` payload'i ehitamisel
+  kasutab (`PlacesDetail.tsx:150-166`)
+
+See on koht, kus vale arvutus muudaks ühtse dialoogi nähtavalt tüütuks: dialoog
+hüppaks ette iga kord, kui kasutaja on koha andmeid lihtsalt vaadanud.
+
+### ConfirmModal tarbijate audit
+
+`ConfirmModal.tsx` Esc/taustaklõpsu lisamine mõjutab kõiki tarbijaid, mitte ainult
+seda disaini. Praegu on neid kolm: `Workspace.tsx`, `PersonEditPage.tsx` (mõlemad
+lähevad `UnsavedChangesDialog`-ile üle) ja pärast seda tööd `WorkManage.tsx`.
+
+Enne muudatust kontrollida, et iga alles jääva tarbija `onCancel` on idempotentne ja
+et taustaklõpsuga sulgemine ei jäta pooleliolevat kohalikku olekut. Kui mõni tulevane
+kasutuskoht ei tohi taustaklõpsuga sulguda, lisatakse `closeOnBackdrop` valik
+(vaikimisi `true`); globaalselt seda ilma auditita ei muudeta.
 
 ### Tõlked
 
@@ -175,21 +315,63 @@ on välja lülitatud — ADR 0011).
 - `admin/Collections.tsx` (`CollectionEditor`) — salvestab kohe, dirty-olekut ei teki.
 - Kolme-nupu dialoogi kasutamine hävitavate tegevuste (kustutamine) kinnitamiseks —
   need jäävad `ConfirmModal`-i.
+- **Jagatud `DialogShell` komponent** (fookuselõks, fookuse taastamine, overlay,
+  Esc, aria-sidumine) `ConfirmModal`-i ja `UnsavedChangesDialog`-i vahel. Praegu ei
+  dubleeriks see midagi: `ConfirmModal`-il ei ole fookuselõksu ega aria-sidumist
+  üldse, seega kirjutan need ühe korra uude dialoogi. Ühise aluskomponendi
+  väljavõtmine on omaette refaktor üle kolme tarbija.
+- **Kollase nupu kontrasti parandus** (`amber-700` või tume tekst) — puudutab kõiki
+  kuut kollast nuppu korraga, vt "Dialoog".
+- Salvestuse katkestamine `AbortController`-iga.
 
 ## Testimine
 
-`src/hooks/__tests__/unsavedChangesFlow.test.ts`, vitest `environment: 'node'`,
-uusi sõltuvusi ei lisata. Kaetavad juhud:
+`src/hooks/__tests__/unsavedChangesFlow.test.ts` — puhta mooduli testid Vitesti
+node-keskkonnas, uusi sõltuvusi ei lisata. Kaetavad juhud:
 
-- ootel tegevus käivitub, kui `onSave` tagastab `true`
-- ootel tegevus **ei** käivitu, kui `onSave` tagastab `false`; dialoog jääb avatuks
-- "Loobu muudatustest" käivitab ootel tegevuse salvestamata
-- "Jää siia" tühistab ootel tegevuse
-- `confirmAction` puhta oleku korral käivitab tegevuse dialoogi avamata
-- salvestamise ajal saabuv teine kutse ei tekita teist salvestust
+**Põhivoog**
 
-Dialoogi visuaal, fookus ja Esc-käitumine kontrollitakse käsitsi kõigis neljas
-kohas (jsdom/testing-library infrat projektis ei ole ja seda ei lisata).
+1. ootel tegevus käivitub, kui `onSave` tagastab `true`
+2. ootel tegevus **ei** käivitu, kui `onSave` tagastab `false`; dialoog jääb avatuks
+3. `onSave` viskab erindi → tegevust ei käivitata, `saving` lõpeb, dialoog jääb avatuks
+4. pärast ebaõnnestunud salvestust saab kasutaja uuesti salvestada
+5. "Loobu muudatustest" käivitab ootel tegevuse salvestamata
+6. "Jää siia" eemaldab ootel tegevuse täielikult
+7. `runGuarded` puhta oleku korral käivitab tegevuse dialoogi avamata
+
+**Ootel tegevuse poliitika**
+
+8. uus `runGuarded` ei asenda juba ootel tegevust (esimene võidab)
+9. topeltklikk "Salvesta ja jätka" nupul käivitab täpselt ühe `onSave`
+10. salvestamise ajal saabuv uus `runGuarded` ei muuda ootel tegevust
+
+**Bypass'i elutsükkel**
+
+11. pärast edukat jätkamist ei jää bypass aktiivseks
+12. pärast loobumist ei jää bypass aktiivseks
+13. ootel tegevuse enda erind ei jäta guard'i `saving` ega `pending` olekusse
+
+### Käsitsi kontroll
+
+Hook'i ja React Routeri integratsioon jääb kõige riskantsemaks osaks ja see ei ole
+puhta mooduliga kaetud (jsdom/testing-library infrat projektis ei ole ja seda ei
+lisata). Iga neljas kasutuskohas läbida:
+
+| # | Stsenaarium |
+|---|---|
+| 1 | brauseri Back-nupp |
+| 2 | rakendusesisene link |
+| 3 | `runGuarded` lehesisese vahetuse jaoks (lehepööre / koha vahetus) |
+| 4 | edukas salvestus dialoogist |
+| 5 | nurjunud salvestus dialoogist (võta võrk maha) |
+| 6 | "Loobu muudatustest" |
+| 7 | "Jää siia" |
+| 8 | kiire topeltklikk salvestusnupul |
+| 9 | Back kaks korda järjest |
+| 10 | **pärast ühe dialoogi kasutamist on järgmine lahkumine endiselt kaitstud** |
+| 11 | Esc ja taustaklõps salvestamise ajal ei sulge dialoogi |
+
+Stsenaarium 10 on kõige olulisem — just see paljastab lekkiva bypass'i.
 
 Väravad: `npm run typecheck` ja `npm run test`.
 
@@ -206,3 +388,17 @@ prognoositavus: sama kolm nuppu, samad sõnad, sama järjekord, olenemata selles
 kust dialoog tuli.
 
 **Miks eraldi komponent, mitte `ConfirmModal`?** Vt "Dialoog" ülal.
+
+**Miks ei ole kohustuslikku `onDiscard` propi?** Ülevaatuses soovitati seda, eeldusel
+et lehesisene üleminek võib jätta vana mustandi mällu. Meie koodis on see juba
+lahendatud: `useEditorState.ts:71-83` (ADR 0010, #194) ja `PlacesDetail.tsx:106-108`
+taastavad baasseisu. Prop, mis oleks igas kasutuskohas no-op, tekitaks
+topeltlähtestuse riski ja valekindlust. Põhimõte on üle võetud invariandina
+(nr 7) ja plaani verifitseerimissammuna. Vt "Loobumise leping".
+
+**Miks jääb avalik möödapääsu-meetod alles?** Ülevaatuses soovitati see täielikult
+hook'i sisse peita. Sisemine ühekordne bypass tulebki (ja parandab päris võistluse,
+mida praegu hoiab koos `requestAnimationFrame` hack), aga täielik eemaldamine ei ole
+võimalik: `PersonEditPage.tsx:207,212` salvestab **oma** nupuga ja navigeerib ise
+`/persons/{id}`-le, dialoogivoost sõltumatult. Toores mutable ref asendub
+meetodiga `allowNextNavigation()`, mille elutsükkel on ühekordne ja hook'i sees.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "lint:ci": "eslint . --max-warnings 56",
+    "lint:ci": "eslint . --max-warnings 55",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle } from 'lucide-react';
 
@@ -13,6 +13,8 @@ interface ConfirmModalProps {
   onCancel: () => void;
   onExtra?: () => void;
   variant?: 'warning' | 'danger';
+  /** Kas taustaklõps sulgeb. Vaikimisi jah — cancel on ohutu tee. */
+  closeOnBackdrop?: boolean;
 }
 
 const ConfirmModal: React.FC<ConfirmModalProps> = ({
@@ -25,9 +27,20 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
   onConfirm,
   onCancel,
   onExtra,
-  variant = 'warning'
+  variant = 'warning',
+  closeOnBackdrop = true
 }) => {
   const { t } = useTranslation('common');
+
+  // Esc = tühista. Ohutu tee, seega alati lubatud.
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.preventDefault(); onCancel(); }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onCancel]);
 
   const resolvedTitle = title ?? t('confirmation.title');
   const resolvedConfirmText = confirmText ?? t('buttons.confirm');
@@ -43,7 +56,10 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
   const iconClass = variant === 'danger' ? 'text-red-600' : 'text-amber-600';
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onMouseDown={e => { if (closeOnBackdrop && e.target === e.currentTarget) onCancel(); }}
+    >
       <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden">
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-3">

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -34,7 +34,7 @@ interface TextEditorProps {
   statusDirty?: boolean;
   currentStatus?: PageStatus | null;
   onStatusChange?: (status: PageStatus) => void;
-  triggerSave?: React.MutableRefObject<(() => Promise<void>) | null>;
+  triggerSave?: React.MutableRefObject<(() => Promise<boolean>) | null>;
   onWorkUpdate?: (updatedWork: Partial<Work>) => void;
   collections?: Collections;
 }

--- a/src/components/UnsavedChangesDialog.tsx
+++ b/src/components/UnsavedChangesDialog.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+
+export interface UnsavedChangesDialogProps {
+  open: boolean;
+  /** Salvestamine käib — kõik nupud, Esc ja taustaklõps on blokeeritud. */
+  saving: boolean;
+  /** Viimane salvestuskatse ebaõnnestus — näita vearida. */
+  saveFailed: boolean;
+  onDiscard: () => void;
+  onStay: () => void;
+  onSaveAndContinue: () => void;
+}
+
+/**
+ * Ühtne salvestamata muudatuste dialoog. Puhas presentatsioon: ootel tegevusest,
+ * salvestusfunktsioonist ega navigeerimisest ei tea siin miski midagi — see kõik
+ * elab `useUnsavedChangesGuard`-is ja `unsavedChangesFlow`-s.
+ *
+ * Nupud on KÕIKJAL identsed (järjekord, värv, tekst), ka siis kui dialoog tuli
+ * lehepöördest, mitte lahkumisest. Sihtkohta nupusildid ei nimeta.
+ */
+const UnsavedChangesDialog: React.FC<UnsavedChangesDialogProps> = ({
+  open, saving, saveFailed, onDiscard, onStay, onSaveAndContinue,
+}) => {
+  const { t } = useTranslation('common');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const stayButtonRef = useRef<HTMLButtonElement>(null);
+  // Element, millelt fookus tuli — sinna see sulgemisel tagastatakse.
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  // Fookus avanemisel kõige ohutumale valikule ("Jää siia"), et Enter ei teeks
+  // midagi hävitavat.
+  useEffect(() => {
+    if (!open) return;
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    stayButtonRef.current?.focus();
+    return () => { previouslyFocusedRef.current?.focus?.(); };
+  }, [open]);
+
+  // Esc = "Jää siia", AGA mitte salvestamise ajal: muidu sulguks dialoog, salvestus
+  // jätkuks taustal ja hiljem saabuv vastus käivitaks navigeerimise ajal, mil
+  // kasutaja juba jätkab redigeerimist.
+  //
+  // Sama effect hoiab fookuse dialoogi sees (Tab ei vii välja).
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (!saving) { e.preventDefault(); onStay(); }
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button:not([disabled])',
+      );
+      if (!focusable || focusable.length === 0) { e.preventDefault(); return; }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault(); last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault(); first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, saving, onStay]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onMouseDown={e => { if (e.target === e.currentTarget && !saving) onStay(); }}
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="unsaved-changes-title"
+        aria-describedby="unsaved-changes-message"
+        aria-busy={saving}
+        className="bg-white rounded-xl shadow-2xl w-full max-w-lg mx-4 overflow-hidden"
+      >
+        <div className="px-6 py-4 border-b border-gray-200 flex items-center gap-3">
+          <div className="p-2 bg-amber-100 rounded-full">
+            <AlertTriangle className="text-amber-600" size={24} />
+          </div>
+          <h2 id="unsaved-changes-title" className="text-lg font-semibold text-gray-900">
+            {t('unsavedChanges.title')}
+          </h2>
+        </div>
+
+        <div className="px-6 py-4">
+          <p id="unsaved-changes-message" className="text-gray-600">
+            {t('unsavedChanges.message')}
+          </p>
+          {saveFailed && (
+            <p role="status" aria-live="polite" className="mt-3 text-sm text-red-700">
+              {t('unsavedChanges.saveFailed')}
+            </p>
+          )}
+        </div>
+
+        <div className="px-6 py-4 bg-gray-50 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onDiscard}
+            disabled={saving}
+            className="px-4 py-2 rounded-lg font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-700"
+          >
+            {t('unsavedChanges.discard')}
+          </button>
+          <button
+            ref={stayButtonRef}
+            type="button"
+            onClick={onStay}
+            disabled={saving}
+            className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-100 font-medium disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-500"
+          >
+            {t('unsavedChanges.stay')}
+          </button>
+          <button
+            type="button"
+            onClick={onSaveAndContinue}
+            disabled={saving}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:opacity-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-amber-700"
+          >
+            {saving && <Loader2 className="animate-spin" size={16} />}
+            {saving ? t('unsavedChanges.saving') : t('unsavedChanges.saveAndContinue')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UnsavedChangesDialog;

--- a/src/components/editor/useEditorSave.ts
+++ b/src/components/editor/useEditorSave.ts
@@ -60,12 +60,17 @@ export function useEditorSave({
     t('editor.saveErrorWithMessage', { message: e.message || t('common:errors.unknownError') })
   ), [t]);
 
+  /**
+   * Tagastab `true` AINULT siis, kui salvestus õnnestus ja `savedState`/`isDirty`
+   * on uuendatud. Salvestamata muudatuste dialoog sõltub sellest: `false` korral
+   * ei tohi navigeerida, muidu kaob tekst (vt UnsavedChangesDialog).
+   */
   const runSave = useCallback(async (
     updatedPage: Page,
     savedState: EditorSavedState,
     afterSave?: () => void,
-  ) => {
-    if (isSavingRef.current) return;
+  ): Promise<boolean> => {
+    if (isSavingRef.current) return false;
     isSavingRef.current = true;
     setIsSaving(true);
     try {
@@ -73,28 +78,30 @@ export function useEditorSave({
       afterSave?.();
       setSavedState(savedState);
       setIsDirty(false);
+      return true;
     } catch (e: any) {
       console.error('Save error:', e);
       setSaveError(formatSaveError(e));
+      return false;
     } finally {
       isSavingRef.current = false;
       setIsSaving(false);
     }
   }, [formatSaveError, onSave, setIsDirty, setIsSaving, setSaveError, setSavedState]);
 
-  const handleSave = useCallback(async () => {
+  const handleSave = useCallback(async (): Promise<boolean> => {
     const updatedPage = makePage(comments, textAnnotations);
-    await runSave(updatedPage, { status, comments, page_tags, text_annotations: textAnnotations });
+    return runSave(updatedPage, { status, comments, page_tags, text_annotations: textAnnotations });
   }, [comments, makePage, page_tags, runSave, status, textAnnotations]);
 
-  // Salvestus "Salvesta ja lahku" jaoks: enne salvestust liidab kommentaari-mustandi
+  // Salvestus "Salvesta ja jätka" jaoks: enne salvestust liidab kommentaari-mustandi
   // kommentaaride hulka, et see ei läheks kaduma.
-  const handleSaveWithDrafts = useCallback(async () => {
-    if (isSavingRef.current) return;
+  const handleSaveWithDrafts = useCallback(async (): Promise<boolean> => {
+    if (isSavingRef.current) return false;
     const flushed = commentFlushRef.current?.() ?? null;
     const effectiveComments = flushed ?? comments;
     const updatedPage = makePage(effectiveComments, textAnnotations);
-    await runSave(
+    return runSave(
       updatedPage,
       { status, comments: effectiveComments, page_tags, text_annotations: textAnnotations },
       flushed ? () => setComments(flushed) : undefined,

--- a/src/hooks/__tests__/unsavedChangesFlow.test.ts
+++ b/src/hooks/__tests__/unsavedChangesFlow.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  initialGuardState,
+  requestTransition,
+  stay,
+  discard,
+  beginSave,
+  finishSave,
+  allowNextTransition,
+  consumeAllowance,
+} from '../unsavedChangesFlow';
+
+describe('requestTransition', () => {
+  it('lubab ülemineku kohe, kui muudatusi ei ole', () => {
+    const run = vi.fn();
+    const r = requestTransition(initialGuardState, false, { run });
+    expect(r.runNow).toBe(true);
+    expect(r.state.pending).toBeNull();
+  });
+
+  it('paneb ülemineku ootele, kui on salvestamata muudatusi', () => {
+    const run = vi.fn();
+    const r = requestTransition(initialGuardState, true, { run });
+    expect(r.runNow).toBe(false);
+    expect(r.state.pending?.run).toBe(run);
+  });
+
+  it('esimene ootel tegevus võidab — uus ei asenda seda', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run: first });
+    const b = requestTransition(a.state, true, { run: second });
+    expect(b.runNow).toBe(false);
+    expect(b.state.pending?.run).toBe(first);
+  });
+
+  it('salvestamise ajal saabuv uus soov ei muuda ootel tegevust', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run: first });
+    const saving = beginSave(a.state);
+    const b = requestTransition(saving.state, true, { run: second });
+    expect(b.runNow).toBe(false);
+    expect(b.state.pending?.run).toBe(first);
+    expect(b.state.saving).toBe(true);
+  });
+});
+
+describe('stay', () => {
+  it('eemaldab ootel tegevuse täielikult', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const s = stay(a.state);
+    expect(s.pending).toBeNull();
+    expect(s.saveFailed).toBe(false);
+    expect(s.allowNext).toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('kustutab ka eelmise salvestusvea', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const failed = finishSave(beginSave(a.state).state, false);
+    expect(failed.state.saveFailed).toBe(true);
+    expect(stay(failed.state).saveFailed).toBe(false);
+  });
+});
+
+describe('discard', () => {
+  it('vabastab ootel tegevuse salvestamata ja annab ühekordse loa', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const d = discard(a.state);
+    expect(d.action).toBe(run);
+    expect(d.state.pending).toBeNull();
+    expect(d.state.allowNext).toBe(true);
+  });
+
+  it('ei jäta möödapääsu aktiivseks pärast tarbimist', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const d = discard(a.state);
+    const c = consumeAllowance(d.state);
+    expect(c.allowed).toBe(true);
+    expect(c.state.allowNext).toBe(false);
+    expect(consumeAllowance(c.state).allowed).toBe(false);
+  });
+});
+
+describe('beginSave', () => {
+  it('alustab salvestamist, kui see veel ei käi', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const b = beginSave(a.state);
+    expect(b.start).toBe(true);
+    expect(b.state.saving).toBe(true);
+    expect(b.state.saveFailed).toBe(false);
+  });
+
+  it('topeltklikk ei alusta teist salvestust', () => {
+    const a = requestTransition(initialGuardState, true, { run: vi.fn() });
+    const first = beginSave(a.state);
+    const second = beginSave(first.state);
+    expect(second.start).toBe(false);
+    expect(second.state).toBe(first.state);
+  });
+});
+
+describe('finishSave', () => {
+  it('käivitab ootel tegevuse, kui salvestamine õnnestus', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const f = finishSave(beginSave(a.state).state, true);
+    expect(f.action).toBe(run);
+    expect(f.state.pending).toBeNull();
+    expect(f.state.saving).toBe(false);
+    expect(f.state.allowNext).toBe(true);
+  });
+
+  it('EI käivita ootel tegevust, kui salvestamine ebaõnnestus', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const f = finishSave(beginSave(a.state).state, false);
+    expect(f.action).toBeNull();
+    expect(f.state.pending?.run).toBe(run);
+    expect(f.state.saving).toBe(false);
+    expect(f.state.saveFailed).toBe(true);
+    expect(f.state.allowNext).toBe(false);
+  });
+
+  it('pärast ebaõnnestunud salvestust saab uuesti salvestada', () => {
+    const run = vi.fn();
+    const a = requestTransition(initialGuardState, true, { run });
+    const failed = finishSave(beginSave(a.state).state, false);
+    const retry = beginSave(failed.state);
+    expect(retry.start).toBe(true);
+    expect(retry.state.saveFailed).toBe(false);
+    const ok = finishSave(retry.state, true);
+    expect(ok.action).toBe(run);
+  });
+
+  it('nullib oleku enne tegevuse tagastamist — tegevuse erind ei jäta guardi rippu', () => {
+    const run = vi.fn(() => { throw new Error('navigate failed'); });
+    const a = requestTransition(initialGuardState, true, { run });
+    const f = finishSave(beginSave(a.state).state, true);
+    expect(f.state.saving).toBe(false);
+    expect(f.state.pending).toBeNull();
+    expect(() => f.action?.()).toThrow('navigate failed');
+    expect(f.state.saving).toBe(false);
+    expect(f.state.pending).toBeNull();
+  });
+});
+
+describe('allowNextTransition', () => {
+  it('märgib järgmise ülemineku lubatuks ja luba on ühekordne', () => {
+    const s = allowNextTransition(initialGuardState);
+    const first = consumeAllowance(s);
+    expect(first.allowed).toBe(true);
+    expect(consumeAllowance(first.state).allowed).toBe(false);
+  });
+});

--- a/src/hooks/unsavedChangesFlow.ts
+++ b/src/hooks/unsavedChangesFlow.ts
@@ -1,0 +1,118 @@
+/**
+ * Salvestamata muudatuste dialoogi olekumasin.
+ *
+ * Puhas moodul: ei impordi Reacti ega puutu DOM-i. Kõik otsused elavad siin,
+ * `useUnsavedChangesGuard` on ainult Reacti kiht selle ümber. Nii saab kriitilise
+ * invariandi (ebaõnnestunud salvestus EI käivita ootel tegevust) katta testidega
+ * ilma jsdom/testing-library sõltuvusteta.
+ */
+
+/** Ootel üleminek — navigeerimine, lehepööre või koha vahetus. */
+export interface PendingTransition {
+  run: () => void;
+}
+
+export interface GuardState {
+  /** Ootel üleminek, mida dialoog kinnitama ootab. `null` = dialoog on kinni. */
+  pending: PendingTransition | null;
+  /** Salvestamine käib — nupud, Esc ja taustaklõps on blokeeritud. */
+  saving: boolean;
+  /** Viimane salvestuskatse ebaõnnestus — dialoogis on vearida. */
+  saveFailed: boolean;
+  /** Ühekordne möödapääs: järgmine üleminek lastakse guardist läbi. */
+  allowNext: boolean;
+}
+
+export const initialGuardState: GuardState = {
+  pending: null,
+  saving: false,
+  saveFailed: false,
+  allowNext: false,
+};
+
+export interface RequestResult {
+  state: GuardState;
+  /** Kas kutsuja peab tegevuse kohe käivitama (puhas olek). */
+  runNow: boolean;
+}
+
+/** Tulemus, mille juures kutsuja käivitab `action`-i, kui see ei ole `null`. */
+export interface ResolveResult {
+  state: GuardState;
+  action: (() => void) | null;
+}
+
+/**
+ * Üleminekusoov. Puhta oleku korral lubatakse kohe, muidu läheb ootele.
+ *
+ * Esimene ootel tegevus võidab: kui midagi juba ootab, uut ei võeta vastu. Vastasel
+ * juhul muutuks "Salvesta ja jätka" sihtkoht kasutaja jaoks ettearvamatuks.
+ */
+export function requestTransition(
+  state: GuardState,
+  isDirty: boolean,
+  pending: PendingTransition,
+): RequestResult {
+  if (state.pending !== null) return { state, runNow: false };
+  if (!isDirty) return { state, runNow: true };
+  return { state: { ...state, pending, saveFailed: false }, runNow: false };
+}
+
+/** "Jää siia" — ootel tegevus visatakse ära, dialoog sulgub. */
+export function stay(state: GuardState): GuardState {
+  return { ...state, pending: null, saveFailed: false };
+}
+
+/**
+ * "Loobu muudatustest" — ootel tegevus vabastatakse salvestamata.
+ *
+ * Möödapääs seatakse, sest tegevus tavaliselt navigeerib ja `isDirty` on Reacti
+ * järgmise renderduseni veel `true` — ilma selleta avaneks dialoog kohe uuesti.
+ */
+export function discard(state: GuardState): ResolveResult {
+  const action = state.pending?.run ?? null;
+  return {
+    state: { ...state, pending: null, saveFailed: false, allowNext: action !== null },
+    action,
+  };
+}
+
+/** "Salvesta ja jätka" algus. `start: false` = salvestamine juba käib (topeltklikk). */
+export function beginSave(state: GuardState): { state: GuardState; start: boolean } {
+  if (state.saving || state.pending === null) return { state, start: false };
+  return { state: { ...state, saving: true, saveFailed: false }, start: true };
+}
+
+/**
+ * Salvestuse tulemus.
+ *
+ * `saved === false` (ka erindi korral, mille kutsuja teisendab `false`-ks): ootel
+ * tegevus jääb alles, dialoog jääb avatuks, midagi ei kao.
+ */
+export function finishSave(state: GuardState, saved: boolean): ResolveResult {
+  if (!saved) {
+    return { state: { ...state, saving: false, saveFailed: true }, action: null };
+  }
+  const action = state.pending?.run ?? null;
+  return {
+    state: {
+      ...state,
+      pending: null,
+      saving: false,
+      saveFailed: false,
+      allowNext: action !== null,
+    },
+    action,
+  };
+}
+
+/** Märgib järgmise ülemineku lubatuks. Kasutab `allowNextNavigation()` avalik API. */
+export function allowNextTransition(state: GuardState): GuardState {
+  return { ...state, allowNext: true };
+}
+
+/** Kontrollib ja tarbib ühekordse loa. Luba kehtib täpselt ühe ülemineku kohta. */
+export function consumeAllowance(state: GuardState): { state: GuardState; allowed: boolean } {
+  if (!state.allowNext) return { state, allowed: false };
+  return { state: { ...state, allowNext: false }, allowed: true };
+}

--- a/src/hooks/useUnsavedChangesGuard.ts
+++ b/src/hooks/useUnsavedChangesGuard.ts
@@ -87,17 +87,26 @@ export function useUnsavedChangesGuard(
   const blockerRef = useRef(blocker);
   blockerRef.current = blocker;
 
+  /**
+   * Blokeeritud navigatsiooni jätkamine.
+   *
+   * `proceed()` EI käivita `shouldBlock`-i uuesti, seega `discard`/`finishSave`
+   * püsti pandud ühekordne luba jääks siin tarbimata ja lekiks järgmisse
+   * navigatsiooni. Tarbime selle käsitsi ära.
+   */
+  const proceedBlocked = useCallback(() => {
+    const { state: next } = consumeAllowance(stateRef.current);
+    apply(next);
+    blockerRef.current.proceed();
+  }, [apply]);
+
   // Router blokeeris navigatsiooni → pane see ootele samasse dialoogi.
   useEffect(() => {
     if (blocker.state !== 'blocked') return;
-    const r = requestTransition(
-      stateRef.current,
-      true,
-      { run: () => blockerRef.current.proceed() },
-    );
-    if (r.runNow) { blockerRef.current.proceed(); return; }
+    const r = requestTransition(stateRef.current, true, { run: proceedBlocked });
+    if (r.runNow) { proceedBlocked(); return; }
     apply(r.state);
-  }, [blocker.state, apply]);
+  }, [blocker.state, apply, proceedBlocked]);
 
   const runGuarded = useCallback((fn: () => void) => {
     const r = requestTransition(stateRef.current, isDirtyRef.current, { run: fn });

--- a/src/hooks/useUnsavedChangesGuard.ts
+++ b/src/hooks/useUnsavedChangesGuard.ts
@@ -1,18 +1,69 @@
-import { useEffect, type MutableRefObject } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useBlocker } from 'react-router-dom';
+import type { UnsavedChangesDialogProps } from '../components/UnsavedChangesDialog';
+import {
+  initialGuardState,
+  requestTransition,
+  stay,
+  discard,
+  beginSave,
+  finishSave,
+  allowNextTransition,
+  consumeAllowance,
+  type GuardState,
+} from './unsavedChangesFlow';
+
+interface UnsavedChangesGuardOptions {
+  /** Kas on salvestamata muudatusi. */
+  isDirty: boolean;
+  /**
+   * Salvestab ja tagastab `true` AINULT siis, kui kõik on püsivalt salvestatud ja
+   * kohalikud dirty-lipud on uuendatud. `false` = ebaõnnestus. Visatud erindit
+   * käsitleb hook kaitseks samamoodi nagu `false`.
+   */
+  onSave: () => Promise<boolean>;
+}
+
+interface UnsavedChangesGuardResult {
+  dialogProps: UnsavedChangesDialogProps;
+  /**
+   * Lehesisene üleminek (lehepööre, koha vahetus). Puhta oleku korral käivitub
+   * `fn` kohe, dialoogi avamata; muidu läheb ootele.
+   */
+  runGuarded: (fn: () => void) => void;
+  /**
+   * Märgib järgmise navigatsiooni lubatuks. Mõeldud lehtedele, mis salvestavad OMA
+   * nupuga ja navigeerivad ise (nt PersonEditPage → /persons/{id}) — see on
+   * dialoogivoost sõltumatu. Luba on ühekordne.
+   */
+  allowNextNavigation: () => void;
+}
 
 /**
- * Blokeerib lehelt lahkumise salvestamata muudatuste korral.
- * Käsitleb nii React Router navigeerimist (useBlocker) kui ka
- * brauseri tab sulgemist / välist navigeerimist (beforeunload).
+ * Blokeerib lehelt lahkumise ja lehesisesed üleminekud salvestamata muudatuste korral.
  *
- * @param isDirty  - kas on salvestamata muudatusi
- * @param skip     - kui ref.current === true, blocker ignoreeritakse (nt pärast salvestamist)
+ * Kolm sisendit, üks dialoog:
+ *   - React Routeri `useBlocker` — lahkumine
+ *   - `beforeunload` — tab-i sulgemine (brauseri oma dialoog, seda me ei kontrolli)
+ *   - `runGuarded` — lehesisene üleminek
+ *
+ * Otsused elavad `unsavedChangesFlow`-s, siin on ainult Reacti ja Routeri ühendus.
  */
 export function useUnsavedChangesGuard(
-  isDirty: boolean,
-  skip?: MutableRefObject<boolean>,
-) {
+  { isDirty, onSave }: UnsavedChangesGuardOptions,
+): UnsavedChangesGuardResult {
+  const [state, setState] = useState<GuardState>(initialGuardState);
+
+  // Blocker-callback ja async salvestus vajavad värsket olekut väljaspool renderdust.
+  const stateRef = useRef(state);
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
+  const apply = useCallback((next: GuardState) => {
+    stateRef.current = next;
+    setState(next);
+  }, []);
+
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
       if (isDirty) { e.preventDefault(); e.returnValue = ''; }
@@ -21,15 +72,88 @@ export function useUnsavedChangesGuard(
     return () => window.removeEventListener('beforeunload', handler);
   }, [isDirty]);
 
-  const blocker = useBlocker(
-    ({ currentLocation, nextLocation }) =>
-      !(skip?.current) && isDirty && currentLocation.pathname !== nextLocation.pathname,
-  );
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    if (currentLocation.pathname === nextLocation.pathname) return false;
+    // Ühekordne möödapääs tarbitakse siin: pärast edukat salvestust või loobumist
+    // on `isDirty` Reacti järgmise renderduseni veel `true`, seega ilma selleta
+    // avaneks dialoog kohe uuesti.
+    const { state: next, allowed } = consumeAllowance(stateRef.current);
+    if (allowed) { apply(next); return false; }
+    return isDirtyRef.current;
+  });
+
+  // `useBlocker` tagastab igal renderdusel uue objekti — effect ja callback'id
+  // tohivad sõltuda ainult `blocker.state`-ist, muidu tekib lõputu tsükkel.
+  const blockerRef = useRef(blocker);
+  blockerRef.current = blocker;
+
+  // Router blokeeris navigatsiooni → pane see ootele samasse dialoogi.
+  useEffect(() => {
+    if (blocker.state !== 'blocked') return;
+    const r = requestTransition(
+      stateRef.current,
+      true,
+      { run: () => blockerRef.current.proceed() },
+    );
+    if (r.runNow) { blockerRef.current.proceed(); return; }
+    apply(r.state);
+  }, [blocker.state, apply]);
+
+  const runGuarded = useCallback((fn: () => void) => {
+    const r = requestTransition(stateRef.current, isDirtyRef.current, { run: fn });
+    if (r.runNow) { fn(); return; }
+    apply(r.state);
+  }, [apply]);
+
+  const allowNextNavigation = useCallback(() => {
+    apply(allowNextTransition(stateRef.current));
+  }, [apply]);
+
+  const onStay = useCallback(() => {
+    if (stateRef.current.saving) return;
+    // Blokeeritud navigatsioon tuleb Routerile tagasi öelda, muidu jääb blocker
+    // "blocked" olekusse ja järgmine sama navigatsioon ei käivitu.
+    if (blockerRef.current.state === 'blocked') blockerRef.current.reset();
+    apply(stay(stateRef.current));
+  }, [apply]);
+
+  const onDiscard = useCallback(() => {
+    if (stateRef.current.saving) return;
+    const r = discard(stateRef.current);
+    apply(r.state);
+    r.action?.();
+  }, [apply]);
+
+  const onSaveAndContinue = useCallback(async () => {
+    const begun = beginSave(stateRef.current);
+    if (!begun.start) return;
+    apply(begun.state);
+
+    let saved = false;
+    try {
+      saved = await onSave();
+    } catch {
+      // Ükski praegune kasutuskoht ei viska, aga tulevane refaktor ei tohi jätta
+      // dialoogi igaveseks `saving`-olekusse ega tekitada käsitlemata rejection'it.
+      saved = false;
+    }
+
+    const r = finishSave(stateRef.current, saved);
+    // Olek uuendatakse ENNE tegevust: kui tegevus viskab, ei jää guard rippu.
+    apply(r.state);
+    r.action?.();
+  }, [apply, onSave]);
 
   return {
-    isBlocked: blocker.state === 'blocked',
-    blockedLocation: blocker.state === 'blocked' ? blocker.location : null,
-    proceed: () => { if (blocker.state === 'blocked') blocker.proceed(); },
-    reset: () => { if (blocker.state === 'blocked') blocker.reset(); },
+    dialogProps: {
+      open: state.pending !== null,
+      saving: state.saving,
+      saveFailed: state.saveFailed,
+      onDiscard,
+      onStay,
+      onSaveAndContinue,
+    },
+    runGuarded,
+    allowNextNavigation,
   };
 }

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -163,10 +163,6 @@
     "saving": "Saving…",
     "cancel": "Cancel",
     "saveError": "Save failed",
-    "unsavedTitle": "Unsaved changes",
-    "unsavedBody": "This place has unsaved changes. Leave without saving?",
-    "unsavedStay": "Stay here",
-    "unsavedLeave": "Leave without saving",
     "labels": "Names",
     "type": "Type",
     "types": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -197,10 +197,13 @@
     "back": "Go Back"
   },
   "unsavedChanges": {
-    "title": "Unsaved Changes",
-    "message": "You have unsaved changes. Are you sure you want to leave?",
-    "leave": "Leave without saving",
-    "stay": "Stay"
+    "title": "Unsaved changes",
+    "message": "You have unsaved changes.",
+    "discard": "Discard changes",
+    "stay": "Stay here",
+    "saveAndContinue": "Save and continue",
+    "saving": "Saving…",
+    "saveFailed": "Save failed — your changes are still here."
   },
   "markdownEditor": {
     "bold": "Bold",

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -112,6 +112,7 @@
     "reorderApply": "Apply (Enter)",
     "reorderSave": "Save order",
     "reorderConfirm": "Are you sure you want to change the page order?",
+    "reorderConfirmTitle": "Confirm reorder",
     "reorderError": "Failed to save page order",
     "dangerZone": "Danger zone",
     "managePageLink": "Manage work",
@@ -141,6 +142,7 @@
     },
     "reorder": {
       "discard": "Discard changes",
+      "discardTitle": "Discard order changes",
       "discardConfirm": "Discard all unsaved order changes?",
       "changedSummary": "{{count}} page(s) differ from the saved order"
     },

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -331,12 +331,6 @@
   "zotero": {
     "hint": "Zotero: use the browser extension's \"Save to Zotero\" button"
   },
-  "confirm": {
-    "unsavedChanges": "You have unsaved changes. Are you sure you want to leave?",
-    "unsavedChangesPrompt": "You have unsaved changes. Do you want to save?",
-    "saveAndLeave": "Yes, save",
-    "leaveWithoutSaving": "No, leave"
-  },
   "mobile": {
     "imageTab": "Image",
     "gridTab": "Grid",

--- a/src/locales/et/admin.json
+++ b/src/locales/et/admin.json
@@ -163,10 +163,6 @@
     "saving": "Salvestan…",
     "cancel": "Tühista",
     "saveError": "Salvestamine ebaõnnestus",
-    "unsavedTitle": "Salvestamata muudatused",
-    "unsavedBody": "Kohale on salvestamata muudatused. Kas lahkud ilma salvestamata?",
-    "unsavedStay": "Jää siia",
-    "unsavedLeave": "Lahku ilma salvestamata",
     "labels": "Nimed",
     "type": "Tüüp",
     "types": {

--- a/src/locales/et/common.json
+++ b/src/locales/et/common.json
@@ -198,9 +198,12 @@
   },
   "unsavedChanges": {
     "title": "Salvestamata muudatused",
-    "message": "Sul on salvestamata muudatusi. Kas oled kindel, et soovid lahkuda?",
-    "leave": "Lahku ilma salvestamata",
-    "stay": "Jää"
+    "message": "Sul on salvestamata muudatusi.",
+    "discard": "Loobu muudatustest",
+    "stay": "Jää siia",
+    "saveAndContinue": "Salvesta ja jätka",
+    "saving": "Salvestan…",
+    "saveFailed": "Salvestamine ebaõnnestus — muudatused on alles."
   },
   "markdownEditor": {
     "bold": "Paks",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -331,12 +331,6 @@
   "zotero": {
     "hint": "Zotero: kasuta brauserilaiendi \"Save to Zotero\" nuppu"
   },
-  "confirm": {
-    "unsavedChanges": "Sul on salvestamata muudatusi. Kas oled kindel, et soovid lahkuda?",
-    "unsavedChangesPrompt": "Sul on salvestamata muudatusi. Kas soovid salvestada?",
-    "saveAndLeave": "Jah, salvesta",
-    "leaveWithoutSaving": "Ei, lahku"
-  },
   "mobile": {
     "imageTab": "Pilt",
     "gridTab": "Ruudustik",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -112,6 +112,7 @@
     "reorderApply": "Rakenda (Enter)",
     "reorderSave": "Salvesta järjekord",
     "reorderConfirm": "Oled kindel, et soovid lehekülgede järjekorda muuta?",
+    "reorderConfirmTitle": "Kinnita järjekorra muutmine",
     "reorderError": "Järjekorra salvestamine ebaõnnestus",
     "dangerZone": "Ohutsoon",
     "managePageLink": "Halda teost",
@@ -141,6 +142,7 @@
     },
     "reorder": {
       "discard": "Tühista muudatused",
+      "discardTitle": "Tühista järjekorra muudatused",
       "discardConfirm": "Tühistada kõik salvestamata järjekorra muudatused?",
       "changedSummary": "{{count}} lehe asukoht erineb salvestatud järjekorrast"
     },

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -15,6 +15,9 @@ import {
   RefreshCw,
 } from 'lucide-react';
 import Header from '../components/Header';
+import ConfirmModal from '../components/ConfirmModal';
+import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
+import { useUnsavedChangesGuard } from '../hooks/useUnsavedChangesGuard';
 import PageImageEditorModal from '../components/PageImageEditorModal';
 import { useUser } from '../contexts/UserContext';
 import { ApiError } from '../services/apiClient';
@@ -94,6 +97,8 @@ const WorkManage: React.FC = () => {
   const [draftPositions, setDraftPositions] = useState<Record<string, number>>({});
   const [reorderSaving, setReorderSaving] = useState(false);
   const [reorderError, setReorderError] = useState<string | null>(null);
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
+  const [reorderConfirmOpen, setReorderConfirmOpen] = useState(false);
 
   // Hulgivalik + liigutamine
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
@@ -365,17 +370,28 @@ const WorkManage: React.FC = () => {
   };
 
   // Tühista kõik salvestamata järjekorra muudatused
-  const handleDiscardReorder = () => {
-    if (changedCount > 2 && !window.confirm(t('manage.reorder.discardConfirm'))) return;
+  const applyDiscardReorder = () => {
     const init: Record<string, number> = {};
     pages.forEach((p) => { init[p.filename] = p.page_num; });
     setDraftPositions(init);
+    setDiscardConfirmOpen(false);
   };
 
-  const handleReorderSave = async () => {
-    if (!workId || !authToken) return;
-    const confirmed = window.confirm(t('manage.reorderConfirm'));
-    if (!confirmed) return;
+  const handleDiscardReorder = () => {
+    if (changedCount > 2) { setDiscardConfirmOpen(true); return; }
+    applyDiscardReorder();
+  };
+
+  /**
+   * Salvestab järjekorra ILMA kinnituseta. Kasutab nii nupu-handler (mis küsib
+   * kinnituse enne) kui ka salvestamata muudatuste dialoog — muidu hüppaks
+   * dialoogi "Salvesta ja jätka" peale teine kinnitus ette.
+   *
+   * Tagastab `true` ainult siis, kui salvestus õnnestus.
+   */
+  const saveReorder = async (): Promise<boolean> => {
+    if (!workId || !authToken) return false;
+    setReorderConfirmOpen(false);
 
     // Sorteeri pages draftPositions järgi, võta filename järjekord
     const sorted = [...pages].sort((a, b) => {
@@ -393,12 +409,24 @@ const WorkManage: React.FC = () => {
       // Salvestus = commit → tühjenda valik (uue protsessi eeldus). NB: Liiguta
       // (mustand) EI tühjenda, et saaks sama plokki uuesti liigutada.
       handleClearSelection();
+      return true;
     } catch (e: any) {
       setReorderError(e.message || t('manage.reorderError'));
+      return false;
     } finally {
       setReorderSaving(false);
     }
   };
+
+  const handleReorderSave = () => { setReorderConfirmOpen(true); };
+
+  // Salvestamata järjekorra mustand on samasugune salvestamata muudatus nagu tekst.
+  // NB: `saveReorder` (mitte `handleReorderSave`) — dialoog ei tohi küsida teist
+  // kinnitust "Salvesta ja jätka" peale.
+  const { dialogProps } = useUnsavedChangesGuard({
+    isDirty: changedCount > 0,
+    onSave: saveReorder,
+  });
 
   const handleBulkDelete = async () => {
     if (!workId || !authToken || selectedFiles.size === 0) return;
@@ -1082,6 +1110,25 @@ const WorkManage: React.FC = () => {
           onDiscardReorder={handleDiscardReorder}
         />
       )}
+
+      <ConfirmModal
+        isOpen={discardConfirmOpen}
+        title={t('manage.reorder.discardTitle')}
+        message={t('manage.reorder.discardConfirm')}
+        onConfirm={applyDiscardReorder}
+        onCancel={() => setDiscardConfirmOpen(false)}
+        variant="danger"
+      />
+
+      <ConfirmModal
+        isOpen={reorderConfirmOpen}
+        title={t('manage.reorderConfirmTitle')}
+        message={t('manage.reorderConfirm')}
+        onConfirm={() => { void saveReorder(); }}
+        onCancel={() => setReorderConfirmOpen(false)}
+      />
+
+      <UnsavedChangesDialog {...dialogProps} />
     </div>
   );
 };

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -12,7 +12,7 @@ import { PageStatus } from '../types';
 import ImageViewer from '../components/ImageViewer';
 import ThumbnailGrid from '../components/ThumbnailGrid';
 import TextEditor from '../components/TextEditor';
-import ConfirmModal from '../components/ConfirmModal';
+import UnsavedChangesDialog from '../components/UnsavedChangesDialog';
 import LanguageSwitcher from '../components/LanguageSwitcher';
 import { useUser } from '../contexts/UserContext';
 import { useCollection } from '../contexts/CollectionContext';
@@ -85,9 +85,8 @@ const Workspace: React.FC = () => {
   // Metaandmete muutmise modal
   const [isMetaModalOpen, setIsMetaModalOpen] = useState(false);
 
-  // Salvestamata muudatuste kinnitusdialoogi olek
-  const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
-  const editorSaveRef = useRef<(() => Promise<void>) | null>(null);
+  // Redaktori salvestus dialoogi jaoks (flush-variant, vt handleGuardSave)
+  const editorSaveRef = useRef<(() => Promise<boolean>) | null>(null);
 
   // Login modaali olek
   const [showLoginModal, setShowLoginModal] = useState(false);
@@ -132,12 +131,20 @@ const Workspace: React.FC = () => {
       .catch(() => {});
   }, [workId, authToken]);
 
-  // skipBlockerRef: tõese väärtuse korral ignoreerib blocker hasUnsavedChanges kontrolli
-  // (kasutatakse "Salvesta ja lahku" ajal — navigeerimiseks pärast salvestamist)
-  const skipBlockerRef = useRef(false);
+  // Salvestus dialoogi jaoks: flush-variant, mis liidab ka kommentaari-mustandi.
+  // Tagastab `false`, kui salvestamine ebaõnnestus — dialoog jääb siis avatuks.
+  //
+  // Registreerimata ref (redaktorit pole monteeritud) tagastab `true`: siis ei ole
+  // ka midagi salvestada ja kasutajat ei tohi dialoogi lõksu jätta.
+  const handleGuardSave = useCallback(async (): Promise<boolean> => {
+    if (!editorSaveRef.current) return true;
+    return editorSaveRef.current();
+  }, []);
 
-  const { isBlocked, blockedLocation, proceed, reset } = useUnsavedChangesGuard(hasUnsavedChanges, skipBlockerRef);
-  const isBlockerActive = isBlocked;
+  const { dialogProps, runGuarded } = useUnsavedChangesGuard({
+    isDirty: hasUnsavedChanges,
+    onSave: handleGuardSave,
+  });
 
   const handlePageInputSubmit = () => {
     if (!workId) return;
@@ -148,12 +155,7 @@ const Workspace: React.FC = () => {
     // Kontrollime, et number oleks valiidne ja piires (kui lehekülgede arv on teada)
     if (!isNaN(newPage) && newPage >= 1 && (totalPages === 0 || newPage <= totalPages)) {
       if (newPage !== currentPageNum) {
-        if (hasUnsavedChanges) {
-          setPendingNavigation(() => () => navigate(`/work/${workId}/${newPage}`, { replace: true }));
-          setInputPage(currentPageNum.toString());
-          return;
-        }
-        navigate(`/work/${workId}/${newPage}`, { replace: true });
+        runGuarded(() => navigate(`/work/${workId}/${newPage}`, { replace: true }));
       }
     } else {
       // Taasta praegune number, kui sisestus oli vigane
@@ -371,12 +373,8 @@ const Workspace: React.FC = () => {
   const handleSelectFromGrid = useCallback((pageNum: number) => {
     setIsGridView(false);
     setGridSelectedPage(pageNum);
-    if (hasUnsavedChanges) {
-      setPendingNavigation(() => () => navigate(`/work/${workId}/${pageNum}`, { replace: true }));
-      return;
-    }
-    navigate(`/work/${workId}/${pageNum}`, { replace: true });
-  }, [hasUnsavedChanges, navigate, workId]);
+    runGuarded(() => navigate(`/work/${workId}/${pageNum}`, { replace: true }));
+  }, [runGuarded, navigate, workId]);
 
   const navigatePage = useCallback((delta: number) => {
     if (!workId) return;
@@ -390,15 +388,9 @@ const Workspace: React.FC = () => {
     if (newPage < 1) return;
     if (work?.page_count && newPage > work.page_count) return;
 
-    // Hoiatus salvestamata muudatuste korral
-    if (hasUnsavedChanges) {
-      setPendingNavigation(() => () => navigate(`/work/${workId}/${newPage}`, { replace: true }));
-      return;
-    }
-
     // ?q= jäetakse URL-ist välja — eesmärk: otsisõna paneel avaneb ainult esimesel lehel, mitte iga lehevahetusel
-    navigate(`/work/${workId}/${newPage}`, { replace: true });
-  }, [workId, currentPageNum, work?.page_count, hasUnsavedChanges, navigate]);
+    runGuarded(() => navigate(`/work/${workId}/${newPage}`, { replace: true }));
+  }, [workId, currentPageNum, work?.page_count, runGuarded, navigate]);
 
   if (loading) {
     return (
@@ -475,11 +467,7 @@ const Workspace: React.FC = () => {
   const getReturnUrl = () => sessionStorage.getItem('vutt_return_url') || '/';
   const handleNavigateBack = () => {
     const returnUrl = getReturnUrl();
-    if (hasUnsavedChanges) {
-      setPendingNavigation(() => () => navigate(returnUrl));
-      return;
-    }
-    navigate(returnUrl);
+    runGuarded(() => navigate(returnUrl));
   };
 
   // Navigeerimine otsingusse (selle teose piires)
@@ -490,45 +478,8 @@ const Workspace: React.FC = () => {
     if (workCollection && !workCollections.includes(selectedCollection ?? '')) {
       setSelectedCollection(workCollection);
     }
-    if (hasUnsavedChanges) {
-      setPendingNavigation(() => () => navigate(`/search?work=${workId}`));
-      return;
-    }
-    navigate(`/search?work=${workId}`);
+    runGuarded(() => navigate(`/search?work=${workId}`));
   };
-
-  // Kinnitusdialoogi käsitlejad
-  const handleConfirmLeave = () => {
-    if (isBlocked) {
-      proceed();
-    } else if (pendingNavigation) {
-      pendingNavigation();
-      setPendingNavigation(null);
-    }
-  };
-
-  const handleSaveAndLeave = async () => {
-    const pendingLoc = blockedLocation;
-    const navCallback = pendingNavigation;
-
-    if (isBlocked) reset();
-    setPendingNavigation(null);
-
-    if (editorSaveRef.current) {
-      try { await editorSaveRef.current(); } catch { /* alert on juba TextEditoris */ }
-    }
-
-    // Blocker bypass: navigeerimisel ei pea hasUnsavedChanges kontrollima
-    skipBlockerRef.current = true;
-    if (pendingLoc) {
-      navigate(pendingLoc.pathname + pendingLoc.search + pendingLoc.hash);
-    } else if (navCallback) {
-      navCallback();
-    }
-    requestAnimationFrame(() => { skipBlockerRef.current = false; });
-  };
-
-  const showLeaveConfirm = isBlockerActive || pendingNavigation !== null;
 
   // COinS (ContextObjects in Spans) Zotero jaoks
   const generateCoins = () => {
@@ -778,17 +729,8 @@ const Workspace: React.FC = () => {
         />
       )}
 
-      {/* Salvestamata muudatuste kinnitusdialoog */}
-      <ConfirmModal
-        isOpen={showLeaveConfirm}
-        title={t('editor.unsavedChanges')}
-        message={t('confirm.unsavedChangesPrompt')}
-        confirmText={t('confirm.saveAndLeave')}
-        cancelText={t('confirm.leaveWithoutSaving')}
-        onConfirm={handleSaveAndLeave}
-        onCancel={handleConfirmLeave}
-        variant="warning"
-      />
+      {/* Salvestamata muudatuste dialoog */}
+      <UnsavedChangesDialog {...dialogProps} />
 
       {/* Login modaal (sessioon aegunud või käsitsi avatud) */}
       {loginModal}

--- a/src/pages/admin/Places.tsx
+++ b/src/pages/admin/Places.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { isAtLeast } from '../../utils/roleUtils';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +14,8 @@ import PlacesTree from './PlacesTree';
 import PlacesDetail from './PlacesDetail';
 import PlacesGroupPanel from './PlacesGroupPanel';
 import AddPlaceModal from '../../prosopography/components/AddPlaceModal';
+import UnsavedChangesDialog from '../../components/UnsavedChangesDialog';
+import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard';
 
 const MAX_PERSON_SAMPLE = 5;
 
@@ -38,7 +40,17 @@ const Places: React.FC = () => {
   const [showAddModal, setShowAddModal] = useState(false);
   const [showGroupPanel, setShowGroupPanel] = useState(false);
   const [isDirty, setIsDirty] = useState(false);
-  const [pendingKey, setPendingKey] = useState<string | null>(null);
+  const placeSaveRef = useRef<(() => Promise<boolean>) | null>(null);
+
+  const handleGuardSave = useCallback(async (): Promise<boolean> => {
+    if (!placeSaveRef.current) return true;
+    return placeSaveRef.current();
+  }, []);
+
+  const { dialogProps, runGuarded } = useUnsavedChangesGuard({
+    isDirty,
+    onSave: handleGuardSave,
+  });
 
   const [personCounts, setPersonCounts] = useState<Record<string, number>>({});
   const [personSamples, setPersonSamples] = useState<
@@ -129,12 +141,9 @@ const Places: React.FC = () => {
   }, []);
 
   const handleSelectKey = useCallback((key: string | null) => {
-    if (isDirty && key !== selectedKey) {
-      setPendingKey(key);
-    } else {
-      setSelectedKey(key);
-    }
-  }, [isDirty, selectedKey]);
+    if (key === selectedKey) return;
+    runGuarded(() => setSelectedKey(key));
+  }, [runGuarded, selectedKey]);
 
   if (userLoading || !user) {
     return (
@@ -256,8 +265,9 @@ const Places: React.FC = () => {
                     onUpdated={handleUpdated}
                     onMerged={handleMerged}
                     onDeleted={handleDeleted}
-                    onSelectKey={setSelectedKey}
+                    onSelectKey={handleSelectKey}
                     onDirtyChange={setIsDirty}
+                    saveRef={placeSaveRef}
                   />
                 ) : (
                   <div className="flex items-center justify-center h-full text-sm text-gray-400 italic">
@@ -279,34 +289,15 @@ const Places: React.FC = () => {
           onAdd={(key, entry) => {
             setPlaces(prev => ({ ...prev, [key]: entry }));
             setShowAddModal(false);
-            setSelectedKey(key);
+            // Ka uue koha loomine vahetab valikut — see peab käima guardist läbi,
+            // muidu kaoks pooleliolev muudatus vaikselt.
+            handleSelectKey(key);
           }}
           onClose={() => setShowAddModal(false)}
         />
       )}
 
-      {pendingKey !== null && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl shadow-xl p-6 max-w-sm w-full mx-4">
-            <h3 className="font-semibold text-gray-900 mb-2">{t('places.unsavedTitle')}</h3>
-            <p className="text-sm text-gray-600 mb-5">{t('places.unsavedBody')}</p>
-            <div className="flex gap-2 justify-end">
-              <button
-                onClick={() => setPendingKey(null)}
-                className="px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-lg"
-              >
-                {t('places.unsavedStay')}
-              </button>
-              <button
-                onClick={() => { setSelectedKey(pendingKey); setPendingKey(null); }}
-                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700"
-              >
-                {t('places.unsavedLeave')}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <UnsavedChangesDialog {...dialogProps} />
     </div>
   );
 };

--- a/src/pages/admin/PlacesDetail.tsx
+++ b/src/pages/admin/PlacesDetail.tsx
@@ -34,6 +34,58 @@ function resolveLabel(labels: Record<string, string> | null | undefined, lang: s
   return labels[lang] ?? labels.et ?? labels.en ?? Object.values(labels)[0] ?? '';
 }
 
+/** Vormi mustand — üks objekt, et baasseisuga võrdlemine oleks üks võrdlus. */
+interface PlaceFormDraft {
+  labels: Record<string, string>;
+  placeType: string;
+  qCode: string;
+  parentKey: string;
+  group: string;
+  historicalNames: string[];
+  lat: string;
+  lon: string;
+  notes: string;
+}
+
+/**
+ * Normaliseerib mustandi võrdluseks. Ilma selleta annaks `undefined` vs tühi string,
+ * puuduv võti vs tühi objekt ja trimmimata sisestus valepositiivse dirty-lipu.
+ */
+function normalizeDraft(d: PlaceFormDraft): string {
+  const labels = Object.fromEntries(
+    Object.entries(d.labels)
+      .map(([k, v]) => [k, v.trim()])
+      .filter(([, v]) => v !== '')
+      .sort(([a], [b]) => a.localeCompare(b)),
+  );
+  return JSON.stringify({
+    labels,
+    placeType: d.placeType.trim(),
+    qCode: d.qCode.trim(),
+    parentKey: d.parentKey.trim(),
+    group: d.group.trim(),
+    historicalNames: d.historicalNames.map(n => n.trim()).filter(n => n !== ''),
+    lat: d.lat.trim(),
+    lon: d.lon.trim(),
+    notes: d.notes.trim(),
+  });
+}
+
+/** Baasseis kirjest: sama kuju, mis vorm avamisel saab. */
+function draftFromEntry(entry: PlaceEntry): PlaceFormDraft {
+  return {
+    labels: { ...(entry.labels ?? {}) },
+    placeType: entry.type ?? '',
+    qCode: entry.id ?? '',
+    parentKey: entry.parent_key ?? '',
+    group: entry.group ?? '',
+    historicalNames: [...(entry.historical_names ?? [])],
+    lat: entry.coordinates?.lat != null ? String(entry.coordinates.lat) : '',
+    lon: entry.coordinates?.lon != null ? String(entry.coordinates.lon) : '',
+    notes: entry.notes ?? '',
+  };
+}
+
 interface PlacesDetailProps {
   placeKey: string;
   entry: PlaceEntry;
@@ -48,11 +100,13 @@ interface PlacesDetailProps {
   onDeleted: (key: string) => void;
   onSelectKey: (key: string) => void;
   onDirtyChange?: (dirty: boolean) => void;
+  /** Vanem paneb siia salvestusfunktsiooni, et dialoog saaks seda kutsuda. */
+  saveRef?: React.MutableRefObject<(() => Promise<boolean>) | null>;
 }
 
 const PlacesDetail: React.FC<PlacesDetailProps> = ({
   placeKey, entry, places, meta, personCount, personSample,
-  token, lang, onUpdated, onMerged, onDeleted, onSelectKey, onDirtyChange,
+  token, lang, onUpdated, onMerged, onDeleted, onSelectKey, onDirtyChange, saveRef,
 }) => {
   const { t } = useTranslation('admin');
   const [editing, setEditing] = useState(false);
@@ -107,9 +161,19 @@ const PlacesDetail: React.FC<PlacesDetailProps> = ({
     setEditing(false);
   }, [placeKey]);
 
+  // Baasseis: viimati laaditud või edukalt salvestatud väärtused. Dirty = mustand
+  // erineb sellest. `editing` ise EI tee vormi dirty'ks — muidu hüppaks salvestamata
+  // muudatuste dialoog ette iga kord, kui kasutaja on koha andmeid lihtsalt vaadanud.
+  const [baseline, setBaseline] = useState<string>('');
+
+  const currentDraft: PlaceFormDraft = {
+    labels, placeType, qCode, parentKey, group, historicalNames, lat, lon, notes,
+  };
+  const isDirty = editing && normalizeDraft(currentDraft) !== baseline;
+
   useEffect(() => {
-    onDirtyChange?.(editing);
-  }, [editing]);
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
 
   useEffect(() => {
     if (editing) {
@@ -126,6 +190,7 @@ const PlacesDetail: React.FC<PlacesDetailProps> = ({
       setLat(entry.coordinates?.lat != null ? String(entry.coordinates.lat) : '');
       setLon(entry.coordinates?.lon != null ? String(entry.coordinates.lon) : '');
       setNotes(entry.notes ?? '');
+      setBaseline(normalizeDraft(draftFromEntry(entry)));
       setSaveError(null);
     }
   }, [editing]);
@@ -142,7 +207,11 @@ const PlacesDetail: React.FC<PlacesDetailProps> = ({
     })
     .slice(0, 8);
 
-  const handleSave = async () => {
+  /**
+   * Tagastab `true` ainult siis, kui salvestus õnnestus. Salvestamata muudatuste
+   * dialoog sõltub sellest: `false` korral ei tohi kohta vahetada ega lahkuda.
+   */
+  const handleSave = async (): Promise<boolean> => {
     setSaving(true);
     setSaveError(null);
     try {
@@ -166,13 +235,22 @@ const PlacesDetail: React.FC<PlacesDetailProps> = ({
 
       const result = await updatePlace(placeKey, data, token);
       onUpdated(result.key, result.entry);
+      // Edukas salvestamine teeb praegustest väärtustest uue baasseisu.
+      setBaseline(normalizeDraft(currentDraft));
       setEditing(false);
+      return true;
     } catch (e: any) {
       setSaveError(e.message ?? t('places.saveError'));
+      return false;
     } finally {
       setSaving(false);
     }
   };
+
+  // Vanem vajab salvestust, et salvestamata muudatuste dialoog saaks seda kutsuda.
+  useEffect(() => {
+    if (saveRef) saveRef.current = handleSave;
+  });
 
   const coords = entry.coordinates;
   const hasCoords = coords && typeof coords.lat === 'number' && typeof coords.lon === 'number';

--- a/src/prosopography/pages/PersonEditPage.tsx
+++ b/src/prosopography/pages/PersonEditPage.tsx
@@ -26,7 +26,7 @@ import { formatRelationOwnerName, formatRelationTypeLabel } from '../utils/eston
 import { getVocabularies } from '../../services/collectionService';
 import type { VocabularySeisusItem } from '../../services/collectionService';
 import { useUnsavedChangesGuard } from '../../hooks/useUnsavedChangesGuard';
-import ConfirmModal from '../../components/ConfirmModal';
+import UnsavedChangesDialog from '../../components/UnsavedChangesDialog';
 
 const PersonEditPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -184,11 +184,16 @@ const PersonEditPage: React.FC = () => {
 
   const set = (patch: Partial<FormDraft>) => { setIsDirty(true); setDraft(d => ({ ...d, ...patch })); };
 
-  const skipGuardRef = useRef(false);
-  const { isBlocked, proceed, reset } = useUnsavedChangesGuard(isDirty, skipGuardRef);
+  // Uue isiku ID tekib alles salvestamisel — hoiame selle navigeerimiseks alles.
+  const createdIdRef = useRef<string | null>(null);
 
-  const handleSave = async () => {
-    if (!draft.name_label.trim()) { setError(t('form.nameRequired')); return; }
+  /**
+   * Salvestab isiku. EI navigeeri — sihtkoha valib kutsuja (nupp läheb profiilile,
+   * salvestamata muudatuste dialoog jätkab kasutaja algatatud üleminekut).
+   * Tagastab `true` ainult siis, kui kõik on püsivalt salvestatud.
+   */
+  const savePerson = async (): Promise<boolean> => {
+    if (!draft.name_label.trim()) { setError(t('form.nameRequired')); return false; }
     setSaving(true);
     setError(null);
     try {
@@ -204,23 +209,38 @@ const PersonEditPage: React.FC = () => {
         );
         const payload = draftToPayload(draft, created, seisused, konfessioonid);
         await updatePerson(created.id, { ...payload, updated_at: created.updated_at }, token);
-        skipGuardRef.current = true;
-        navigate(`/persons/${created.id}`);
+        createdIdRef.current = created.id;
       } else {
         const payload = draftToPayload(draft, original ?? undefined, seisused, konfessioonid);
         await updatePerson(id!, payload, token);
-        skipGuardRef.current = true;
-        navigate(`/persons/${id!}`);
       }
+      setIsDirty(false);
+      return true;
     } catch (e: any) {
       if (e?.conflict) {
         setError(t('form.conflictError'));
       } else {
         setError(t('form.saveError'));
       }
+      return false;
     } finally {
       setSaving(false);
     }
+  };
+
+  const { dialogProps, allowNextNavigation } = useUnsavedChangesGuard({
+    isDirty,
+    onSave: savePerson,
+  });
+
+  /** Lehe oma SALVESTA nupp: salvestab ja läheb profiilile. */
+  const handleSave = async () => {
+    const ok = await savePerson();
+    if (!ok) return;
+    // Guard ei tohi seda navigatsiooni blokeerida: `isDirty` on Reacti järgmise
+    // renderduseni tõenäoliselt veel `true`.
+    allowNextNavigation();
+    navigate(`/persons/${createdIdRef.current ?? id!}`);
   };
 
   // ── Loading ──────────────────────────────────────────────
@@ -946,16 +966,7 @@ const PersonEditPage: React.FC = () => {
       </div>
     </div>
 
-    <ConfirmModal
-      isOpen={isBlocked}
-      title={t('common:unsavedChanges.title')}
-      message={t('common:unsavedChanges.message')}
-      confirmText={t('common:unsavedChanges.leave')}
-      cancelText={t('common:unsavedChanges.stay')}
-      onConfirm={proceed}
-      onCancel={reset}
-      variant="warning"
-    />
+    <UnsavedChangesDialog {...dialogProps} />
     </>
   );
 };


### PR DESCRIPTION
Neli erinevat salvestamata muudatuste hoiatust on nüüd üks dialoog, millel on kolm
valikut ja üks ettearvatav käitumismudel.

## Probleem

| Koht | Enne |
|---|---|
| Tekstiredaktor | *Ei, lahku* / **Jah, salvesta** — "jää lehele" varianti ei olnud üldse |
| Prosopograafia | *Jää* / **Lahku ilma salvestamata** — hävitav valik oli sinine primary-nupp |
| Kohtade register | oma käsitsi modaal, ainult koha vahetusel; **lahkumiskaitse puudus täielikult** |
| Lehekülgede haldus | natiivsed `window.confirm` dialoogid; lahkumiskaitse puudus |

## Lahendus

Üks dialoog `UnsavedChangesDialog`: **Loobu muudatustest** (punane) / **Jää siia**
(hall) / **Salvesta ja jätka** (kollane). Samad sõnad, sama järjekord, samad värvid
kõikjal — ka lehepöördel, mitte ainult lahkumisel.

Kollane `bg-amber-600` ei ole uus signaal: sama värv tähendab rakenduses juba
"siin on salvestamata töö" (`EditorHeader.tsx:76`, `MetadataModal.tsx:922`).

Kolm kihti:
- `unsavedChangesFlow.ts` — puhas olekumasin, ei Reacti ega DOM-i. Kõik otsused siin, 15 testi.
- `useUnsavedChangesGuard.ts` — Router `useBlocker`, `beforeunload`, async salvestus, ühekordne möödapääs.
- `UnsavedChangesDialog.tsx` — puhas presentatsioon: renderdus, fookus, klahvid.

## Kolm varjatud viga, mis said koos parandatud

1. **Salvestusvea korral kadus töö.** `useEditorSave.ts:76` püüdis vea kinni ja
   promise **resolvis**, seega `Workspace.tsx:518` navigeeris alati ära; veabanner
   renderdus komponendis, mis oli kohe lahkumas. Nüüd `Promise<boolean>` ja dialoog
   jääb vea korral avatuks — midagi ei kao.
2. **Kohtade registris puudus lahkumiskaitse.** Ei `useUnsavedChangesGuard` ega
   `beforeunload` — muudatused kadusid vaikselt.
3. **Kohtade dirty-lipp oli vale.** `PlacesDetail.tsx:111` tegi
   `onDirtyChange?.(editing)` — lipp oli püsti alati, kui redigeerimisrežiim oli
   lahti. Nüüd normaliseeritud võrdlus baasseisuga (`undefined` vs tühi string,
   trimmimine, võtmete järjestus ei anna valepositiivset).

## Invariandid

1. Kollane nupp ei vii sihtkohta enne, kui salvestamine on **tegelikult** õnnestunud
2. Salvestamise ajal on nupud disabled, kollasel spinner
3. Esc ja taustaklõps = "Jää siia" — aga salvestamise ajal blokeeritud
4. Fookus avanemisel "Jää siia" peal; Enter ei tee midagi hävitavat
5. Nupud kõikjal identsed, sihtkohta sildid ei nimeta
6. Kolm nuppu alati (`onSave` kohustuslik)
7. "Loobu muudatustest" taastab baasseisu enne ootel tegevust
8. Esimene ootel tegevus võidab; uus `runGuarded` ei asenda seda

## Leitud implementatsiooni käigus

- `AddPlaceModal` vahetas valitud kohta guardist mööda — suunatud `handleSelectKey` kaudu
- **Möödapääsu leke:** `blocker.proceed()` ei käivita `shouldBlock`-i, seega ühekordne
  luba jäi tarbimata ja oleks lekkinud järgmisse navigatsiooni. Praegu päästis unmount,
  aga oleks vaikselt murdunud, kui keegi lisaks sama komponendi sisse `<Link>`-i.

## Kontroll

- `npm run typecheck` ✓
- `npm run test` ✓ 666 testi (sh 15 uut olekumasina testi)
- `npm run lint:ci` ✓ 55 hoiatust, lävi langetatud 56 → 55
- Käsitsi kontrollitud kõigis neljas kohas, deploy'tud ja testitud vutt.utlib.ut.ee-l

## Ulatusest väljas

- Jagatud `DialogShell` (`ConfirmModal`-il ei ole fookuselõksu ega aria-sidumist, seega
  praegu ei dubleeriks midagi)
- Kollase nupu kontrasti parandus: `amber-600` + valge = 3,18:1, AA nõuaks `amber-700`
  (5,02:1) **kõigil kuuel kollasel nupul korraga** — omaette ülesanne, ei aja ühte
  dialoogi ülejäänutest lahku

Disain: `docs/superpowers/specs/2026-07-28-uhtne-salvestamata-muudatuste-dialoog-design.md`
Plaan: `docs/superpowers/plans/2026-07-28-uhtne-salvestamata-muudatuste-dialoog.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
