### PR TITLE
fix(i18n): eemalda kõvakodeeritud eesti stringid kasutajaliidesest

### DIFF
--- a/src/components/AdvancedFilters.tsx
+++ b/src/components/AdvancedFilters.tsx
@@ -71,6 +71,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
   searchPlaceholder,
   getUnselectedClass
 }) => {
+  const { t } = useTranslation(['dashboard', 'common']);
   const [searchQuery, setSearchQuery] = useState('');
   const showSearch = items.length > 8;
 
@@ -107,7 +108,7 @@ const FilterSection: React.FC<FilterSectionProps> = ({
       <div className="max-h-32 overflow-y-auto custom-scrollbar pr-1">
         <div className="flex flex-wrap gap-2">
           {filteredItems.length === 0 ? (
-            <span className="text-sm text-gray-400 italic py-1">Ei leitud vasteid</span>
+            <span className="text-sm text-gray-400 italic py-1">{t('common:labels.noMatches')}</span>
           ) : (
             filteredItems.map(({ value, label, count }) => {
               const isSelected = selectedValues.includes(value);

--- a/src/components/CollectionEditor.tsx
+++ b/src/components/CollectionEditor.tsx
@@ -57,7 +57,7 @@ function renderTreeOptions(nodes: CollectionTreeNode[], depth = 0): React.ReactN
 
 
 const CollectionEditor: React.FC = () => {
-  const { t } = useTranslation('admin');
+  const { t } = useTranslation(['admin', 'common']);
   const { authToken } = useUser();
   const { collections, refreshCollections } = useCollection();
 
@@ -345,7 +345,7 @@ const CollectionEditor: React.FC = () => {
 
           {/* Nähtavus */}
           <div>
-            <p className="text-sm font-semibold text-gray-700 mb-2">Nähtavus</p>
+            <p className="text-sm font-semibold text-gray-700 mb-2">{t('collections.visibility')}</p>
             <div className="flex items-center gap-4">
               <label className="flex items-center gap-1.5 cursor-pointer">
                 <input
@@ -356,7 +356,7 @@ const CollectionEditor: React.FC = () => {
                   onChange={() => setEditVisibility('public')}
                   className="text-primary-600"
                 />
-                <span className="text-sm">Avalik</span>
+                <span className="text-sm">{t('collections.visibilityPublic')}</span>
               </label>
               <label className="flex items-center gap-1.5 cursor-pointer">
                 <input
@@ -367,23 +367,23 @@ const CollectionEditor: React.FC = () => {
                   onChange={() => setEditVisibility('restricted')}
                   className="text-primary-600"
                 />
-                <span className="text-sm text-amber-700">Piiratud</span>
+                <span className="text-sm text-amber-700">{t('collections.visibilityRestricted')}</span>
               </label>
             </div>
             <p className="text-xs text-gray-400 mt-1">
-              Piiratud kollektsiooni teosed on ligipääsetavad ainult antud kasutajatele ja adminidele.
+              {t('collections.visibilityHint')}
             </p>
 
             {editVisibility === 'restricted' && (
               <div className="mt-3 border border-amber-200 bg-amber-50 rounded-lg p-3">
-                <p className="text-sm font-medium text-gray-700 mb-2">Ligipääsuga kasutajad:</p>
+                <p className="text-sm font-medium text-gray-700 mb-2">{t('collections.allowedUsers')}</p>
                 {usersLoading ? (
                   <Loader2 size={14} className="animate-spin text-gray-400" />
                 ) : (
                   <>
                     <div className="flex flex-wrap gap-1 mb-2">
                       {allowedUsers.length === 0 && (
-                        <span className="text-xs text-gray-400">Pole ligipääsuga kasutajaid</span>
+                        <span className="text-xs text-gray-400">{t('collections.noAllowedUsers')}</span>
                       )}
                       {allowedUsers.map(username => {
                         const u = allUsers.find(x => x.username === username);
@@ -427,22 +427,22 @@ const CollectionEditor: React.FC = () => {
             <p className="text-sm font-semibold text-gray-700 mb-3">{t('collections.description')}</p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">Eesti keeles</label>
+                <label className="block text-xs font-medium text-gray-500 mb-1">{t('collections.langEt')}</label>
                 <textarea
                   value={descEt}
                   onChange={e => setDescEt(e.target.value)}
                   rows={3}
-                  placeholder="Lühikirjeldus eesti keeles..."
+                  placeholder={t('collections.descriptionPlaceholderEt')}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-primary-400"
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">In English</label>
+                <label className="block text-xs font-medium text-gray-500 mb-1">{t('collections.langEn')}</label>
                 <textarea
                   value={descEn}
                   onChange={e => setDescEn(e.target.value)}
                   rows={3}
-                  placeholder="Short description in English..."
+                  placeholder={t('collections.descriptionPlaceholderEn')}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-primary-400"
                 />
               </div>
@@ -455,22 +455,22 @@ const CollectionEditor: React.FC = () => {
             <p className="text-sm font-semibold text-gray-700 mb-3">{t('collections.descriptionLong')}</p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">Eesti keeles</label>
+                <label className="block text-xs font-medium text-gray-500 mb-1">{t('collections.langEt')}</label>
                 <textarea
                   value={descLongEt}
                   onChange={e => setDescLongEt(e.target.value)}
                   rows={6}
-                  placeholder="Pikem tutvustus eesti keeles..."
+                  placeholder={t('collections.descriptionLongPlaceholderEt')}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-primary-400"
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-gray-500 mb-1">In English</label>
+                <label className="block text-xs font-medium text-gray-500 mb-1">{t('collections.langEn')}</label>
                 <textarea
                   value={descLongEn}
                   onChange={e => setDescLongEn(e.target.value)}
                   rows={6}
-                  placeholder="Longer introduction in English..."
+                  placeholder={t('collections.descriptionLongPlaceholderEn')}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-primary-400"
                 />
               </div>
@@ -540,7 +540,7 @@ const CollectionEditor: React.FC = () => {
                   onClick={() => { setDeleteConfirming(false); setDeleteInput(''); setDeleteError(null); }}
                   className="px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50"
                 >
-                  Tühista
+                  {t('common:buttons.cancel')}
                 </button>
               </div>
             </div>
@@ -594,7 +594,7 @@ const CollectionEditor: React.FC = () => {
                   type="text"
                   value={newNameEt}
                   onChange={e => setNewNameEt(e.target.value)}
-                  placeholder="Nimi eesti keeles"
+                  placeholder={t('collections.createNameEt')}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-400"
                 />
               </div>
@@ -604,7 +604,7 @@ const CollectionEditor: React.FC = () => {
                   type="text"
                   value={newNameEn}
                   onChange={e => setNewNameEn(e.target.value)}
-                  placeholder="Name in English"
+                  placeholder={t('collections.createNameEn')}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-400"
                 />
               </div>

--- a/src/components/EntityPicker.tsx
+++ b/src/components/EntityPicker.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Globe, User, MapPin, BookOpen, Tag, X, Loader2, ExternalLink, Database, Library, BookMarked, UserPlus, Users, IdCard } from 'lucide-react';
 import { searchWikidata, getEntityLabels, WikidataSearchResult } from '../services/wikidataService';
@@ -83,6 +84,7 @@ const EntityPicker: React.FC<EntityPickerProps> = ({
   defaultPersonSearch = false,
   token,
 }) => {
+  const { t } = useTranslation('common');
   const [inputValue, setInputValue] = useState('');
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -528,7 +530,7 @@ const EntityPicker: React.FC<EntityPickerProps> = ({
           <Link
             to={`/persons/${entityId}`}
             className="absolute right-9 top-1/2 -translate-y-1/2 text-gray-400 hover:text-primary-600 p-0.5 rounded-full hover:bg-primary-50 transition-colors"
-            title="Vaata isiku profiili"
+            title={t('entityPicker.viewPersonProfile')}
             onClick={(e) => e.stopPropagation()}
           >
             <IdCard size={14} />
@@ -539,7 +541,7 @@ const EntityPicker: React.FC<EntityPickerProps> = ({
             target="_blank"
             rel="noopener noreferrer"
             className="absolute right-9 top-1/2 -translate-y-1/2 text-gray-400 hover:text-blue-600 p-0.5 rounded-full hover:bg-blue-50 transition-colors"
-            title="Vaata andmebaasis"
+            title={t('entityPicker.viewInDatabase')}
             onClick={(e) => e.stopPropagation()}
           >
             <ExternalLink size={14} />
@@ -785,7 +787,7 @@ const EntityPicker: React.FC<EntityPickerProps> = ({
             <span className="text-[10px] text-gray-400 font-medium uppercase tracking-wider flex items-center gap-2">
               {isPersonSearch ? (
                 <>
-                  <span className="flex items-center gap-1"><User size={10} className="text-indigo-400" /> Prosopograafia</span>
+                  <span className="flex items-center gap-1"><User size={10} className="text-indigo-400" /> {t('entityPicker.prosopographySource')}</span>
                   {showExternalSearch && <>
                     <span className="flex items-center gap-1"><Globe size={10} /> Wikidata</span>
                     <span className="flex items-center gap-1"><BookMarked size={10} className="text-orange-500" /> GND</span>

--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { AlertCircle, X } from 'lucide-react';
 
 interface ErrorBannerProps {
@@ -11,18 +12,21 @@ interface ErrorBannerProps {
  * Inline veabänner — asendab alert() kõnesid.
  * Ei blokeeri UI-d, toetab sulgemist.
  */
-export const ErrorBanner: React.FC<ErrorBannerProps> = ({ message, onClose, className = '' }) => (
-  <div className={`flex items-start gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800 ${className}`}>
-    <AlertCircle size={16} className="text-red-500 flex-shrink-0 mt-0.5" />
-    <span className="flex-1">{message}</span>
-    {onClose && (
-      <button
-        onClick={onClose}
-        className="text-red-400 hover:text-red-600 flex-shrink-0"
-        aria-label="Sulge"
-      >
-        <X size={14} />
-      </button>
-    )}
-  </div>
-);
+export const ErrorBanner: React.FC<ErrorBannerProps> = ({ message, onClose, className = '' }) => {
+  const { t } = useTranslation('common');
+  return (
+    <div className={`flex items-start gap-3 px-4 py-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-800 ${className}`}>
+      <AlertCircle size={16} className="text-red-500 flex-shrink-0 mt-0.5" />
+      <span className="flex-1">{message}</span>
+      {onClose && (
+        <button
+          onClick={onClose}
+          className="text-red-400 hover:text-red-600 flex-shrink-0"
+          aria-label={t('buttons.close')}
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/src/components/ImageViewer.tsx
+++ b/src/components/ImageViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ZoomIn, ZoomOut, Maximize2, Download, LayoutGrid, Scissors } from 'lucide-react';
 import { fetchWithTimeout } from '../utils/fetchWithTimeout';
 import { panOffsetForTop } from '../utils/imageViewerGeometry';
@@ -40,6 +41,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, skipFade = fals
   const isHoveredRef = useRef(false);
   const imgRef = useRef<HTMLImageElement>(null);
   const controlsRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation('workspace');
 
   // Lehe vahetusel hoiab brauser <img>-is eelmise lehe dekodeeritud pilti kuni
   // uus on laetud. Tekst vahetub aga kohe, nii et vana skaneering jääks hetkeks
@@ -274,21 +276,21 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, skipFade = fals
           <button
             onClick={() => handleZoom(0.25)}
             className="p-2 text-white hover:bg-white/20 rounded transition-colors"
-            title="Suumi sisse"
+            title={t('imageViewer.zoomIn')}
           >
             <ZoomIn size={20} />
           </button>
           <button
             onClick={() => handleZoom(-0.25)}
             className="p-2 text-white hover:bg-white/20 rounded transition-colors"
-            title="Suumi välja"
+            title={t('imageViewer.zoomOut')}
           >
             <ZoomOut size={20} />
           </button>
           <button
             onClick={handleReset}
             className="p-2 text-white hover:bg-white/20 rounded transition-colors"
-            title="Taasta vaade"
+            title={t('imageViewer.resetView')}
           >
             <Maximize2 size={20} />
           </button>
@@ -298,7 +300,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, skipFade = fals
               <button
                 onClick={onGridView}
                 className="p-2 text-white hover:bg-white/20 rounded transition-colors"
-                title="Kõik leheküljed"
+                title={t('imageViewer.allPages')}
               >
                 <LayoutGrid size={20} />
               </button>
@@ -308,7 +310,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, skipFade = fals
             <button
               onClick={onManage}
               className="p-2 text-white hover:bg-white/20 rounded transition-colors"
-              title="Halda lehte"
+              title={t('imageViewer.managePage')}
             >
               <Scissors size={20} />
             </button>
@@ -317,7 +319,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, skipFade = fals
           <button
             onClick={handleDownload}
             className="p-2 text-white hover:bg-white/20 rounded transition-colors"
-            title="Lae pilt alla"
+            title={t('imageViewer.downloadImage')}
           >
             <Download size={20} />
           </button>
@@ -349,7 +351,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({ src, pageNum, skipFade = fals
           <img
             ref={imgRef}
             src={src}
-            alt="Faksiimile"
+            alt={t('imageViewer.facsimileAlt')}
             className="max-w-none shadow-2xl sepia-[0.3] pointer-events-none"
             style={{
               maxHeight: '85vh',

--- a/src/components/MetadataModal.tsx
+++ b/src/components/MetadataModal.tsx
@@ -562,9 +562,9 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
                       ))}
                       {!vocabularies && (
                         <>
-                          <option value="praeses">Praeses</option>
-                          <option value="respondens">Respondens</option>
-                          <option value="auctor">Autor</option>
+                          <option value="praeses">{t('metadata.roles.praeses')}</option>
+                          <option value="respondens">{t('metadata.roles.respondens')}</option>
+                          <option value="auctor">{t('metadata.roles.auctor')}</option>
                         </>
                       )}
                     </select>
@@ -702,7 +702,7 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
                 type="topic"
                 value={metaForm.type}
                 onChange={val => setMetaForm({ ...metaForm, type: val })}
-                placeholder="nt: trükis, käsikiri"
+                placeholder={t('metadata.typePlaceholder')}
                 lang={lang}
                 localSuggestions={suggestions.types}
               />
@@ -735,7 +735,7 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
               <label className="block text-xs font-medium text-gray-500 mb-2">{t('metadata.tags')}</label>
               
               <div className="flex flex-wrap gap-2 mb-3">
-                {metaForm.tags.length === 0 && <span className="text-xs text-gray-400 italic">Märksõnad puuduvad</span>}
+                {metaForm.tags.length === 0 && <span className="text-xs text-gray-400 italic">{t('info.noTags')}</span>}
                 {metaForm.tags.map((tag, idx) => {
                   const tagObj = typeof tag !== 'string' ? tag as any : null;
                   const url = tagObj ? getEntityUrl(tagObj.id, tagObj.source) : null;
@@ -749,7 +749,7 @@ const MetadataModal: React.FC<MetadataModalProps> = ({
                     }`}>
                       {getLabel(tag, lang)}
                       {personId && (
-                        <Link to={`/persons/${personId}`} target="_blank" rel="noopener noreferrer" className="opacity-50 hover:opacity-100" title="Vaata isiku lehte" onClick={e => e.stopPropagation()}>
+                        <Link to={`/persons/${personId}`} target="_blank" rel="noopener noreferrer" className="opacity-50 hover:opacity-100" title={t('metadata.viewPersonPage')} onClick={e => e.stopPropagation()}>
                           <UserRound size={10} />
                         </Link>
                       )}

--- a/src/components/ThumbnailGrid.tsx
+++ b/src/components/ThumbnailGrid.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { X, Loader2, ZoomIn, ZoomOut } from 'lucide-react';
 import type { Work } from '../types';
 
@@ -29,6 +30,7 @@ const ThumbnailGrid: React.FC<ThumbnailGridProps> = ({
   cols,
   onColsChange,
 }) => {
+  const { t } = useTranslation(['workspace', 'common']);
   const MIN_COLS = 3;
   const MAX_COLS = 10;
 
@@ -93,7 +95,7 @@ const ThumbnailGrid: React.FC<ThumbnailGridProps> = ({
             onClick={() => onColsChange(Math.min(cols + 1, MAX_COLS))}
             disabled={cols >= MAX_COLS}
             className="p-1 text-white/40 hover:text-white/80 hover:bg-white/10 rounded transition-colors disabled:opacity-20 disabled:cursor-not-allowed"
-            title="Väiksemad pisipildid"
+            title={t('thumbnails.smaller')}
           >
             <ZoomOut size={14} />
           </button>
@@ -105,13 +107,13 @@ const ThumbnailGrid: React.FC<ThumbnailGridProps> = ({
             value={sliderValue}
             onChange={handleSlider}
             className="w-24 accent-white/50 cursor-pointer"
-            title="Thumbnailide suurus"
+            title={t('thumbnails.size')}
           />
           <button
             onClick={() => onColsChange(Math.max(cols - 1, MIN_COLS))}
             disabled={cols <= MIN_COLS}
             className="p-1 text-white/40 hover:text-white/80 hover:bg-white/10 rounded transition-colors disabled:opacity-20 disabled:cursor-not-allowed"
-            title="Suuremad pisipildid"
+            title={t('thumbnails.larger')}
           >
             <ZoomIn size={14} />
           </button>
@@ -120,12 +122,12 @@ const ThumbnailGrid: React.FC<ThumbnailGridProps> = ({
         {/* Paremal: lehtede arv + sulge */}
         <div className="flex items-center gap-3 shrink-0">
           <span className="text-white/30 text-xs tabular-nums">
-            {loading ? '…' : `${pages.length} lk`}
+            {loading ? '…' : `${pages.length} ${t('common:labels.pages')}`}
           </span>
           <button
             onClick={onClose}
             className="p-1.5 text-white/60 hover:text-white hover:bg-white/15 rounded transition-colors"
-            title="Sulge (ESC)"
+            title={t('thumbnails.closeEsc')}
           >
             <X size={18} />
           </button>

--- a/src/components/UploadMetaForm.tsx
+++ b/src/components/UploadMetaForm.tsx
@@ -358,9 +358,9 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
                         ))
                       : (
                         <>
-                          <option value="praeses">Praeses</option>
-                          <option value="respondens">Respondens</option>
-                          <option value="auctor">Autor</option>
+                          <option value="praeses">{t('workspace:metadata.roles.praeses')}</option>
+                          <option value="respondens">{t('workspace:metadata.roles.respondens')}</option>
+                          <option value="auctor">{t('workspace:metadata.roles.auctor')}</option>
                         </>
                       )}
                   </select>
@@ -502,7 +502,7 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
               type="topic"
               value={form.type}
               onChange={(val) => setForm({ ...form, type: val })}
-              placeholder="nt: trükis, käsikiri"
+              placeholder={t('workspace:metadata.typePlaceholder')}
               lang={lang}
               localSuggestions={suggestions.types}
             />
@@ -540,7 +540,7 @@ const UploadMetaForm: React.FC<UploadMetaFormProps> = ({
             </label>
             <div className="flex flex-wrap gap-2 mb-2">
               {form.tags.length === 0 && (
-                <span className="text-xs text-gray-400 italic">Märksõnad puuduvad</span>
+                <span className="text-xs text-gray-400 italic">{t('workspace:info.noTags')}</span>
               )}
               {form.tags.map((tag, i) => (
                 <span

--- a/src/components/editor/HistoryTab.tsx
+++ b/src/components/editor/HistoryTab.tsx
@@ -578,7 +578,7 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
         <div className="mt-6 bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
           <div className="flex items-center gap-2 px-5 py-3 border-b border-gray-100">
             <Link size={15} className="text-gray-400" />
-            <span className="text-xs font-semibold uppercase tracking-wider text-gray-400">Jagamine</span>
+            <span className="text-xs font-semibold uppercase tracking-wider text-gray-400">{t('sharing.title')}</span>
           </div>
           <div className="px-5 py-4">
             <div className="flex items-center gap-6">
@@ -591,7 +591,7 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
                   disabled={shareableSaving}
                   className="text-primary-600"
                 />
-                <span className="text-sm text-gray-700">Privaatne</span>
+                <span className="text-sm text-gray-700">{t('sharing.private')}</span>
               </label>
               <label className="flex items-center gap-1.5 cursor-pointer">
                 <input
@@ -602,7 +602,7 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
                   disabled={shareableSaving}
                   className="text-primary-600"
                 />
-                <span className="text-sm text-gray-700">Jagatav (otselingiga)</span>
+                <span className="text-sm text-gray-700">{t('sharing.shareable')}</span>
               </label>
               {shareableSaving && <Loader2 size={13} className="animate-spin text-gray-400" />}
             </div>
@@ -620,7 +620,7 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
                   className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-600 border border-gray-200 bg-gray-50 hover:bg-gray-100 rounded transition-colors"
                 >
                   {linkCopied ? <Check size={12} className="text-emerald-600" /> : <Copy size={12} />}
-                  {linkCopied ? 'Kopeeritud' : 'Kopeeri'}
+                  {linkCopied ? t('sharing.copied') : t('sharing.copy')}
                 </button>
               </div>
             )}
@@ -665,7 +665,7 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
           {slug && (
             <div className="px-5 py-4 flex items-center justify-between gap-4 border-b border-gray-100">
               <div className="min-w-0">
-                <p className="text-xs text-gray-400 mb-1">Kataloog</p>
+                <p className="text-xs text-gray-400 mb-1">{t('manage.directory')}</p>
                 <code className="text-xs font-mono text-gray-700 truncate block">data/{slug}/</code>
               </div>
               <button

--- a/src/components/editor/PageTagsPanel.tsx
+++ b/src/components/editor/PageTagsPanel.tsx
@@ -135,7 +135,7 @@ const PageTagsPanel: React.FC<PageTagsPanelProps> = ({
                   ? navigate(`/search?pageTags=${encodeURIComponent(tagId)}`, { state: { pageTagsLabels: { [tagId]: label } } })
                   : navigate(`/search?q=${encodeURIComponent(label)}&scope=annotation`)}
                 className="pl-2.5 pr-1.5 py-1 hover:text-primary-600 flex items-center gap-1"
-                title="Otsi seda märksõna kogu korpusest"
+                title={t('info.searchTagInCorpus')}
               >
                 {label}
                 <Search size={12} className="opacity-0 group-hover:opacity-50" />

--- a/src/components/editor/WorkInfoPanel.tsx
+++ b/src/components/editor/WorkInfoPanel.tsx
@@ -190,7 +190,7 @@ const WorkInfoPanel: React.FC<WorkInfoPanelProps> = ({ work, lang, onOpenMetaMod
                             <button
                               onClick={() => navigate(`/?printer=${encodeURIComponent(pubId && isQCode(pubId) ? pubId : getLabel(work.publisher, lang))}`)}
                               className="text-gray-400 hover:text-amber-600 transition-colors shrink-0"
-                              title="Filtreeri trükkali järgi"
+                              title={t('info.filterByPrinter')}
                             >
                               <BookDown size={14} />
                             </button>
@@ -347,7 +347,7 @@ const WorkInfoPanel: React.FC<WorkInfoPanelProps> = ({ work, lang, onOpenMetaMod
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 hover:underline"
-                  title="Ava ESTER-i kirje"
+                  title={t('info.openEsterRecord')}
                 >
                   <ExternalLink size={16} />
                   {t('info.viewInEster')}
@@ -371,7 +371,7 @@ const WorkInfoPanel: React.FC<WorkInfoPanelProps> = ({ work, lang, onOpenMetaMod
                 <button
                   onClick={onOpenMetaModal}
                   className="flex items-center gap-2 text-sm text-amber-600 hover:text-amber-800 hover:underline"
-                  title="Muuda teose metaandmeid"
+                  title={t('info.editWorkMetadata')}
                 >
                   <FileSliders size={16} />
                   {t('metadata.editMetadata')}

--- a/src/components/mobile/WorkspaceMobileView.tsx
+++ b/src/components/mobile/WorkspaceMobileView.tsx
@@ -278,7 +278,7 @@ const WorkspaceMobileView: React.FC<WorkspaceMobileViewProps> = ({
               <ImageViewer src={imageSrc} pageNum={page.page_number} skipFade={skipImageFade} onGridView={handleOpenGrid} />
             ) : (
               <div className="flex items-center justify-center h-full text-white/50">
-                Pilt puudub
+                {t('info.noImage')}
               </div>
             )}
           </div>

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -203,11 +203,11 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         applySettings(settings);
         return { success: true };
       } else {
-        return { success: false, error: data.message || 'Sisselogimine ebaõnnestus' };
+        return { success: false, error: data.message || i18n.t('common:errors.loginFailed') };
       }
     } catch (e: any) {
       console.error('Login error:', e);
-      return { success: false, error: 'Serveriga ühendamine ebaõnnestus' };
+      return { success: false, error: i18n.t('common:errors.connectionFailed') };
     }
   }, [applySettings, setUserToken]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
+import { useTranslation } from 'react-i18next';
 import App from './App';
 import 'leaflet/dist/leaflet.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
@@ -13,10 +14,19 @@ if (!rootElement) {
 
 const root = ReactDOM.createRoot(rootElement);
 
+/**
+ * Laisa route-chunki ootamise vaade. Komponendina (mitte `i18n.t` kutsena
+ * render'i hetkel), et hilisem keelevahetus jõuaks ka siia teksti kohale.
+ */
+const LoadingFallback: React.FC = () => {
+  const { t } = useTranslation('common');
+  return <div className="h-screen flex items-center justify-center">{t('labels.loading')}</div>;
+};
+
 const render = () => {
   root.render(
     <React.StrictMode>
-      <Suspense fallback={<div className="h-screen flex items-center justify-center">Laadin...</div>}>
+      <Suspense fallback={<LoadingFallback />}>
         <App />
       </Suspense>
     </React.StrictMode>

--- a/src/locales/__tests__/translationKeysResolve.test.ts
+++ b/src/locales/__tests__/translationKeysResolve.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { NAMESPACES } from '../namespaces';
+
+/**
+ * Kontrollib, et iga koodis kirjutatud `t('võti')` päriselt lahenduks.
+ *
+ * **Miks eraldi `localeParity.test.ts`-ist:** pariteeditest hoiab et/en
+ * võtmestikud identsena, aga ei märka võtit, mis puudub MÕLEMAS keeles.
+ * Selline kutse ei katkesta ei build'i ega tüübikontrolli — i18next lihtsalt
+ * renderdab `defaultValue`'i (tavaliselt eestikeelse → ka ingliskeelses UI-s)
+ * või, kui vaikeväärtust pole, TOORE VÕTME ("common:actions.cancel") otse
+ * kasutajale. `fallbackLng: false` (ADR 0011) tähendab, et varuvõrku pole.
+ *
+ * Kontrollitakse ainult staatilisi ülakomadega literaale — dünaamiliselt
+ * kokku pandud võtmed (`t(\`places.types.${x}\`)`) jäetakse teadlikult välja.
+ */
+const srcDir = resolve(__dirname, '../..');
+const localesDir = resolve(__dirname, '..');
+const LANGUAGES = ['et', 'en'] as const;
+
+// i18next mitmuse-järelliited: `pagesCount` katab `pagesCount_one` jne.
+const PLURAL_SUFFIXES = ['', '_one', '_other', '_zero', '_two', '_few', '_many'];
+
+const resources = Object.fromEntries(
+  LANGUAGES.map(lang => [
+    lang,
+    Object.fromEntries(
+      NAMESPACES.map(ns => [
+        ns,
+        JSON.parse(readFileSync(resolve(localesDir, lang, `${ns}.json`), 'utf8')),
+      ]),
+    ),
+  ]),
+) as Record<string, Record<string, unknown>>;
+
+function lookup(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>(
+    (acc, part) => (acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[part] : undefined),
+    obj,
+  );
+}
+
+const keyExists = (lang: string, ns: string, key: string): boolean =>
+  PLURAL_SUFFIXES.some(suffix => typeof lookup(resources[lang][ns], key + suffix) === 'string');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) return entry === '__tests__' ? [] : sourceFiles(full);
+    return /\.tsx?$/.test(full) ? [full] : [];
+  });
+}
+
+interface Unresolved {
+  file: string;
+  line: number;
+  key: string;
+  reason: string;
+}
+
+function findUnresolved(): Unresolved[] {
+  const found: Unresolved[] = [];
+
+  for (const file of sourceFiles(srcDir)) {
+    const source = readFileSync(file, 'utf8');
+
+    // Faili nimeruumid — kõigi useTranslation(...) kutsete ühend. Ühend on
+    // tahtlikult leebe: alamkomponentide eristamine annaks valepositiivseid.
+    const namespaces = new Set<string>();
+    for (const call of source.matchAll(/useTranslation\(\s*(\[[^\]]*\]|'[^']*'|"[^"]*")/g)) {
+      for (const quoted of call[1].matchAll(/['"]([a-zA-Z]+)['"]/g)) namespaces.add(quoted[1]);
+    }
+    if (namespaces.size === 0) continue;
+    const defaultNs = [...namespaces][0];
+
+    for (const call of source.matchAll(/\bt\(\s*'([^'\n]+)'/g)) {
+      const raw = call[1];
+      // Interpoleeritud või dünaamiline võti — ei saa staatiliselt kontrollida.
+      if (raw.includes('${') || raw.includes('{{')) continue;
+
+      const separator = raw.indexOf(':');
+      const [ns, key] =
+        separator === -1 ? [defaultNs, raw] : [raw.slice(0, separator), raw.slice(separator + 1)];
+
+      // Nimeruumita eesliide (nt `t('some:thing')` mõnes muus tähenduses) —
+      // kontrollime ainult päris nimeruume.
+      if (!(NAMESPACES as readonly string[]).includes(ns)) continue;
+
+      const line = source.slice(0, call.index).split('\n').length;
+
+      if (!namespaces.has(ns)) {
+        found.push({ file, line, key: raw, reason: `nimeruum '${ns}' puudub useTranslation-listis` });
+        continue;
+      }
+      const missing = LANGUAGES.filter(lang => !keyExists(lang, ns, key));
+      if (missing.length > 0) {
+        found.push({ file, line, key: `${ns}:${key}`, reason: `võti puudub: ${missing.join(', ')}` });
+      }
+    }
+  }
+  return found;
+}
+
+describe('tõlkevõtmete lahenduvus', () => {
+  it('iga staatiline t() kutse lahendub mõlemas keeles', () => {
+    const unresolved = findUnresolved().map(u => `${u.file.replace(srcDir, 'src')}:${u.line} — ${u.key} (${u.reason})`);
+    expect(unresolved).toEqual([]);
+  });
+});

--- a/src/locales/en/admin.json
+++ b/src/locales/en/admin.json
@@ -24,7 +24,10 @@
     "inviteLinkGenerated": "Invite link generated",
     "copyLink": "Copy link",
     "linkCopied": "Link copied!",
-    "sendEmail": "Send email"
+    "sendEmail": "Send email",
+    "loadError": "Error loading registration requests",
+    "approveError": "Approval failed",
+    "rejectError": "Rejection failed"
   },
   "users": {
     "title": "Users",
@@ -110,7 +113,19 @@
     "creating": "Adding...",
     "createSuccess": "Collection added",
     "createError": "Failed to add",
-    "createErrorDuplicateId": "ID \"{{id}}\" already exists"
+    "createErrorDuplicateId": "ID \"{{id}}\" already exists",
+    "visibility": "Visibility",
+    "visibilityPublic": "Public",
+    "visibilityRestricted": "Restricted",
+    "visibilityHint": "Works in a restricted collection are accessible only to the listed users and to admins.",
+    "allowedUsers": "Users with access:",
+    "noAllowedUsers": "No users have access",
+    "descriptionPlaceholderEt": "Short description in Estonian...",
+    "descriptionPlaceholderEn": "Short description in English...",
+    "langEt": "In Estonian",
+    "langEn": "In English",
+    "descriptionLongPlaceholderEt": "Longer introduction in Estonian...",
+    "descriptionLongPlaceholderEn": "Longer introduction in English..."
   },
   "cards": {
     "registrations": "Registrations",
@@ -218,7 +233,13 @@
     "groupDeleting": "Deleting…",
     "groupDeleteError": "Delete failed",
     "groupCancel": "Cancel",
-    "groupEdit": "Edit"
+    "groupEdit": "Edit",
+    "clearSearch": "Clear search",
+    "noSearchResults": "No results found",
+    "parentSearchPlaceholder": "Search for a parent region…",
+    "historicalNamePlaceholder": "Add a name + Enter",
+    "groupKeyPlaceholder": "e.g. gotaland",
+    "treeEmpty": "No places"
   },
   "trash": {
     "tab": "Trash",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -58,7 +58,8 @@
     "genre": "Genre",
     "tags": "Tags",
     "loading": "Loading...",
-    "noData": "No data available"
+    "noData": "No data available",
+    "noMatches": "No matches found"
   },
   "errors": {
     "connectionFailed": "Failed to connect to server",
@@ -69,7 +70,8 @@
     "boundaryDescription": "An unexpected error occurred in the application. Try reloading the page.",
     "boundaryReload": "Reload",
     "boundaryHome": "Go to Home",
-    "boundaryDetails": "Error details"
+    "boundaryDetails": "Error details",
+    "notLoggedIn": "Sign in"
   },
   "language": {
     "switchTo": "Switch language to {{lang}}",
@@ -220,5 +222,10 @@
     "emptyPreview": "Nothing to preview",
     "boldPlaceholder": "bold text",
     "italicPlaceholder": "italic"
+  },
+  "entityPicker": {
+    "viewPersonProfile": "View person profile",
+    "viewInDatabase": "View in external database",
+    "prosopographySource": "Prosopography"
   }
 }

--- a/src/locales/en/dashboard.json
+++ b/src/locales/en/dashboard.json
@@ -55,7 +55,11 @@
     "openWorkspace": "Open workspace",
     "viewPerson": "View person page",
     "searchAuthor": "Search by author",
-    "showMetadata": "Show metadata"
+    "showMetadata": "Show metadata",
+    "select": "Select work",
+    "deselect": "Deselect",
+    "copied": "Copied",
+    "filterByCollection": "Filter by this collection"
   },
   "bulkAssign": {
     "select": "Select",

--- a/src/locales/en/prosopography.json
+++ b/src/locales/en/prosopography.json
@@ -260,7 +260,8 @@
     "showAllCollections": "Show all collections",
     "year": "Map year",
     "applyYear": "Apply",
-    "yearHelp": "Year shown on the historical map. The midpoint is used by default when a year range is selected."
+    "yearHelp": "Year shown on the historical map. The midpoint is used by default when a year range is selected.",
+    "openPlace": "Show on map"
   },
   "place": {
     "searchPlaceholder": "Search city, parish, region…",
@@ -288,5 +289,15 @@
     "add": "Add",
     "wikidataError": "Wikidata query failed",
     "addError": "Adding failed"
-  }
+  },
+  "historyPanel": {
+    "original": "Original",
+    "restoreTitle": "Restore this version",
+    "restoreConfirm": "Are you sure you want to restore this version?",
+    "restoreError": "Restore failed",
+    "diffError": "Failed to load the diff",
+    "noChanges": "No changes found",
+    "empty": "No history yet"
+  },
+  "loadingVocab": "Loading…"
 }

--- a/src/locales/en/register.json
+++ b/src/locales/en/register.json
@@ -51,6 +51,9 @@
       "passwordMismatch": "Passwords do not match",
       "tokenInvalid": "Invite link is expired or invalid",
       "saveFailed": "Failed to save password"
-    }
+    },
+    "yourUsername": "Your username:",
+    "usernameHint": "Use this username when signing in",
+    "goToLogin": "Go to the sign-in page"
   }
 }

--- a/src/locales/en/review.json
+++ b/src/locales/en/review.json
@@ -51,11 +51,18 @@
   "actions": {
     "openPage": "Open page",
     "openWork": "Open work",
-    "continue": "Continue working"
+    "continue": "Continue working",
+    "openPerson": "Open person record"
   },
   "changeType": {
     "metadata": "Metadata",
-    "import": "New work"
+    "import": "New work",
+    "personCreated": "New person",
+    "person": "Person",
+    "personDeleted": "Deleted",
+    "personMerged": "Merge",
+    "personRestored": "Restore",
+    "personMigrated": "Migration"
   },
   "loadMore": "Load more",
   "loadingMore": "Loading...",

--- a/src/locales/en/upload.json
+++ b/src/locales/en/upload.json
@@ -97,7 +97,8 @@
     "label": "Replace existing work",
     "warning": "Replacement will delete all existing pages and replace them with new ones.",
     "selected": "Work to replace:",
-    "replaceBtn": "Replace: {{title}}"
+    "replaceBtn": "Replace: {{title}}",
+    "remove": "Remove replacement"
   },
   "status": {
     "pending": "Pending",

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -60,7 +60,9 @@
     "accessDenied": "Access denied.",
     "sessionExpiredProtectedWork": "Your session has expired. Please sign in again to view this work.",
     "loginRequiredProtectedWork": "This work belongs to a restricted collection. Please sign in to view it.",
-    "pageNotFound": "Page not found. The pages of this document may have been reordered or deleted. Try going to the beginning of the work."
+    "pageNotFound": "Page not found. The pages of this document may have been reordered or deleted. Try going to the beginning of the work.",
+    "workIdMissing": "Work ID is missing.",
+    "loadFailed": "Error loading data. Please check the Meilisearch connection."
   },
   "management": {
     "title": "Work management",
@@ -223,7 +225,11 @@
       "dragPanel": "Drag buttons elsewhere",
       "applyError": "Operation failed",
       "close": "Close"
-    }
+    },
+    "replaceHint": "Upload a new scan. Metadata is preserved automatically.",
+    "replaceWarning": "Replacing deletes all current pages and replaces them with newly OCR-processed pages.",
+    "openUploadWizard": "Open the upload wizard",
+    "directory": "Directory"
   },
   "metadata": {
     "title": "Metadata",
@@ -277,7 +283,11 @@
     "classification": "Classification",
     "type": "Type",
     "genre": "Genre",
-    "languages": "Languages"
+    "languages": "Languages",
+    "typePlaceholder": "e.g. print, manuscript",
+    "viewPersonPage": "View person page",
+    "noGenres": "No genres",
+    "genrePlaceholder": "Add a genre..."
   },
   "download": {
     "title": "Download",
@@ -326,7 +336,11 @@
     "noDeletedComments": "No deleted comments found",
     "noOlderVersions": "No earlier versions",
     "historyTruncated": "Showing history of the last 100 commits.",
-    "restoreError": "Restore failed"
+    "restoreError": "Restore failed",
+    "searchTagInCorpus": "Search for this tag across the whole corpus",
+    "openEsterRecord": "Open the ESTER record",
+    "editWorkMetadata": "Edit work metadata",
+    "noImage": "No image"
   },
   "zotero": {
     "hint": "Zotero: use the browser extension's \"Save to Zotero\" button"
@@ -402,5 +416,28 @@
     "annotationLabel": "Annotation",
     "addComment": "Add comment",
     "deleteAnchor": "Delete anchor"
+  },
+  "imageViewer": {
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "resetView": "Reset view",
+    "allPages": "All pages",
+    "managePage": "Manage page",
+    "downloadImage": "Download image",
+    "facsimileAlt": "Facsimile"
+  },
+  "thumbnails": {
+    "smaller": "Smaller thumbnails",
+    "larger": "Larger thumbnails",
+    "size": "Thumbnail size",
+    "columns": "Number of columns",
+    "closeEsc": "Close (ESC)"
+  },
+  "sharing": {
+    "title": "Sharing",
+    "private": "Private",
+    "shareable": "Shareable (via direct link)",
+    "copied": "Copied",
+    "copy": "Copy"
   }
 }

--- a/src/locales/et/admin.json
+++ b/src/locales/et/admin.json
@@ -24,7 +24,10 @@
     "inviteLinkGenerated": "Kutse link on loodud",
     "copyLink": "Kopeeri link",
     "linkCopied": "Link kopeeritud!",
-    "sendEmail": "Saada e-kiri"
+    "sendEmail": "Saada e-kiri",
+    "loadError": "Viga taotluste laadimisel",
+    "approveError": "Kinnitamine ebaõnnestus",
+    "rejectError": "Tagasilükkamine ebaõnnestus"
   },
   "users": {
     "title": "Kasutajad",
@@ -110,7 +113,19 @@
     "creating": "Lisan...",
     "createSuccess": "Kollektsioon lisatud",
     "createError": "Lisamine ebaõnnestus",
-    "createErrorDuplicateId": "ID \"{{id}}\" on juba olemas"
+    "createErrorDuplicateId": "ID \"{{id}}\" on juba olemas",
+    "visibility": "Nähtavus",
+    "visibilityPublic": "Avalik",
+    "visibilityRestricted": "Piiratud",
+    "visibilityHint": "Piiratud kollektsiooni teosed on ligipääsetavad ainult antud kasutajatele ja adminidele.",
+    "allowedUsers": "Ligipääsuga kasutajad:",
+    "noAllowedUsers": "Pole ligipääsuga kasutajaid",
+    "descriptionPlaceholderEt": "Lühikirjeldus eesti keeles...",
+    "descriptionPlaceholderEn": "Short description in English...",
+    "langEt": "Eesti keeles",
+    "langEn": "In English",
+    "descriptionLongPlaceholderEt": "Pikem tutvustus eesti keeles...",
+    "descriptionLongPlaceholderEn": "Longer introduction in English..."
   },
   "cards": {
     "registrations": "Taotlused",
@@ -218,7 +233,13 @@
     "groupDeleting": "Kustutan…",
     "groupDeleteError": "Kustutamine ebaõnnestus",
     "groupCancel": "Tühista",
-    "groupEdit": "Redigeeri"
+    "groupEdit": "Redigeeri",
+    "clearSearch": "Tühista otsing",
+    "noSearchResults": "Tulemusi ei leitud",
+    "parentSearchPlaceholder": "Otsi ülempiirkonda…",
+    "historicalNamePlaceholder": "Lisa nimi + Enter",
+    "groupKeyPlaceholder": "nt gootaland",
+    "treeEmpty": "Kohti pole"
   },
   "trash": {
     "tab": "Prügikast",

--- a/src/locales/et/common.json
+++ b/src/locales/et/common.json
@@ -58,7 +58,8 @@
     "genre": "Žanr",
     "tags": "Märksõnad",
     "loading": "Laadin...",
-    "noData": "Andmed puuduvad"
+    "noData": "Andmed puuduvad",
+    "noMatches": "Ei leitud vasteid"
   },
   "errors": {
     "connectionFailed": "Serveriga ühendamine ebaõnnestus",
@@ -69,7 +70,8 @@
     "boundaryDescription": "Rakenduses tekkis ootamatu viga. Proovige lehekülge uuesti laadida.",
     "boundaryReload": "Lae uuesti",
     "boundaryHome": "Avalehele",
-    "boundaryDetails": "Veateade"
+    "boundaryDetails": "Veateade",
+    "notLoggedIn": "Logi sisse"
   },
   "language": {
     "switchTo": "Vaheta keeleks {{lang}}",
@@ -220,5 +222,10 @@
     "emptyPreview": "Pole midagi näidata",
     "boldPlaceholder": "paks tekst",
     "italicPlaceholder": "kursiiv"
+  },
+  "entityPicker": {
+    "viewPersonProfile": "Vaata isiku profiili",
+    "viewInDatabase": "Vaata andmebaasis",
+    "prosopographySource": "Prosopograafia"
   }
 }

--- a/src/locales/et/dashboard.json
+++ b/src/locales/et/dashboard.json
@@ -55,7 +55,11 @@
     "openWorkspace": "Ava töölaud",
     "viewPerson": "Vaata isiku lehte",
     "searchAuthor": "Otsi autorit",
-    "showMetadata": "Näita metaandmeid"
+    "showMetadata": "Näita metaandmeid",
+    "select": "Vali teos",
+    "deselect": "Eemalda valikust",
+    "copied": "Kopeeritud",
+    "filterByCollection": "Filtreeri selle kollektsiooni järgi"
   },
   "bulkAssign": {
     "select": "Vali",

--- a/src/locales/et/prosopography.json
+++ b/src/locales/et/prosopography.json
@@ -260,7 +260,8 @@
     "showAllCollections": "Näita kõiki kollektsioone",
     "year": "Kaardi aasta",
     "applyYear": "Rakenda",
-    "yearHelp": "Ajaloolise kaardi aasta. Aastavahemiku korral kasutatakse vaikimisi selle keskpunkti."
+    "yearHelp": "Ajaloolise kaardi aasta. Aastavahemiku korral kasutatakse vaikimisi selle keskpunkti.",
+    "openPlace": "Näita kaardil"
   },
   "place": {
     "searchPlaceholder": "Otsi linna, kihelkonda, piirkonda…",
@@ -288,5 +289,15 @@
     "add": "Lisa",
     "wikidataError": "Wikidata päring ebaõnnestus",
     "addError": "Lisamine ebaõnnestus"
-  }
+  },
+  "historyPanel": {
+    "original": "Originaal",
+    "restoreTitle": "Taasta see versioon",
+    "restoreConfirm": "Kas oled kindel, et soovid taastada selle versiooni?",
+    "restoreError": "Taastamine ebaõnnestus",
+    "diffError": "Diff laadimine ebaõnnestus",
+    "noChanges": "Muudatusi ei leitud",
+    "empty": "Ajalugu puudub"
+  },
+  "loadingVocab": "Laadin…"
 }

--- a/src/locales/et/register.json
+++ b/src/locales/et/register.json
@@ -51,6 +51,9 @@
       "passwordMismatch": "Paroolid ei ühti",
       "tokenInvalid": "Kutse link on aegunud või vigane",
       "saveFailed": "Parooli salvestamine ebaõnnestus"
-    }
+    },
+    "yourUsername": "Sinu kasutajanimi:",
+    "usernameHint": "Kasuta seda kasutajanime sisselogimisel",
+    "goToLogin": "Mine sisselogimise lehele"
   }
 }

--- a/src/locales/et/review.json
+++ b/src/locales/et/review.json
@@ -51,11 +51,18 @@
   "actions": {
     "openPage": "Ava lehekülg",
     "openWork": "Ava teos",
-    "continue": "Jätka tööd"
+    "continue": "Jätka tööd",
+    "openPerson": "Ava isiku kaart"
   },
   "changeType": {
     "metadata": "Metaandmed",
-    "import": "Uus teos"
+    "import": "Uus teos",
+    "personCreated": "Uus isik",
+    "person": "Isik",
+    "personDeleted": "Kustutatud",
+    "personMerged": "Liitmine",
+    "personRestored": "Taastamine",
+    "personMigrated": "Migratsioon"
   },
   "loadMore": "Laadi veel",
   "loadingMore": "Laadin...",

--- a/src/locales/et/upload.json
+++ b/src/locales/et/upload.json
@@ -97,7 +97,8 @@
     "label": "Asenda olemasolevat teost",
     "warning": "Asendamine kustutab kõik olemasolevad leheküljed ja asendab need uutega.",
     "selected": "Asendatav teos:",
-    "replaceBtn": "Asenda: {{title}}"
+    "replaceBtn": "Asenda: {{title}}",
+    "remove": "Eemalda asendus"
   },
   "status": {
     "pending": "Ootel",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -60,7 +60,9 @@
     "accessDenied": "Ligipääs keelatud.",
     "sessionExpiredProtectedWork": "Sinu sessioon on aegunud. Selle teose vaatamiseks logi uuesti sisse.",
     "loginRequiredProtectedWork": "See teos asub piiratud ligipääsuga kollektsioonis. Vaatamiseks logi sisse.",
-    "pageNotFound": "Lehekülge ei leitud. Võimalik, et dokumendi lehekülgi on vahepeal ümber tõstetud või kustutatud. Proovi minna teose avalehele."
+    "pageNotFound": "Lehekülge ei leitud. Võimalik, et dokumendi lehekülgi on vahepeal ümber tõstetud või kustutatud. Proovi minna teose avalehele.",
+    "workIdMissing": "Töö ID on puudu.",
+    "loadFailed": "Viga andmete laadimisel. Palun kontrolli Meilisearchi ühendust."
   },
   "management": {
     "title": "Teose haldus",
@@ -223,7 +225,11 @@
       "dragPanel": "Lohista nupud teise kohta",
       "applyError": "Toiming ebaõnnestus",
       "close": "Sulge"
-    }
+    },
+    "replaceHint": "Lae üles uus skänn. Metaandmed säilitatakse automaatselt.",
+    "replaceWarning": "Asendamine kustutab kõik praegused leheküljed ja asendab need uute OCR-itud lehekülgedega.",
+    "openUploadWizard": "Ava üleslaadimise viisard",
+    "directory": "Kataloog"
   },
   "metadata": {
     "title": "Metaandmed",
@@ -277,7 +283,11 @@
     "classification": "Klassifikatsioon",
     "type": "Tüüp",
     "genre": "Žanr",
-    "languages": "Keeled"
+    "languages": "Keeled",
+    "typePlaceholder": "nt: trükis, käsikiri",
+    "viewPersonPage": "Vaata isiku lehte",
+    "noGenres": "Žanrid puuduvad",
+    "genrePlaceholder": "Lisa žanr..."
   },
   "download": {
     "title": "Lae alla",
@@ -326,7 +336,11 @@
     "noDeletedComments": "Kustutatud kommentaare ei leitud",
     "noOlderVersions": "Varasemaid versioone ei ole",
     "historyTruncated": "Näidatakse viimase 100 commiti ajalugu.",
-    "restoreError": "Taastamine ebaõnnestus"
+    "restoreError": "Taastamine ebaõnnestus",
+    "searchTagInCorpus": "Otsi seda märksõna kogu korpusest",
+    "openEsterRecord": "Ava ESTER-i kirje",
+    "editWorkMetadata": "Muuda teose metaandmeid",
+    "noImage": "Pilt puudub"
   },
   "zotero": {
     "hint": "Zotero: kasuta brauserilaiendi \"Save to Zotero\" nuppu"
@@ -402,5 +416,28 @@
     "annotationLabel": "Märge",
     "addComment": "Lisa kommentaar",
     "deleteAnchor": "Kustuta ankur"
+  },
+  "imageViewer": {
+    "zoomIn": "Suumi sisse",
+    "zoomOut": "Suumi välja",
+    "resetView": "Taasta vaade",
+    "allPages": "Kõik leheküljed",
+    "managePage": "Halda lehte",
+    "downloadImage": "Lae pilt alla",
+    "facsimileAlt": "Faksiimile"
+  },
+  "thumbnails": {
+    "smaller": "Väiksemad pisipildid",
+    "larger": "Suuremad pisipildid",
+    "size": "Pisipiltide suurus",
+    "columns": "Veergude arv",
+    "closeEsc": "Sulge (ESC)"
+  },
+  "sharing": {
+    "title": "Jagamine",
+    "private": "Privaatne",
+    "shareable": "Jagatav (otselingiga)",
+    "copied": "Kopeeritud",
+    "copy": "Kopeeri"
   }
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -575,7 +575,7 @@ const Dashboard: React.FC = () => {
                     onClick={() => setInputValue('')}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
                     tabIndex={-1}
-                    aria-label="Tühjenda otsing"
+                    aria-label={t('common:form.clearSearch')}
                   >
                     <X size={18} />
                   </button>

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -97,7 +97,7 @@ interface DiffData {
 }
 
 const Review: React.FC = () => {
-  const { t } = useTranslation(['review', 'common']);
+  const { t } = useTranslation(['review', 'common', 'workspace']);
   const { user, authToken: token, isLoading: userLoading } = useUser();
   const navigate = useNavigate();
 
@@ -420,7 +420,7 @@ const Review: React.FC = () => {
     if (result.length === 0) {
       return (
         <div className="p-4 text-center text-gray-400 italic text-sm">
-          Ainult tehnilised muudatused (ajatempleid uuendatud)
+          {t('workspace:history.onlyTimestampChanges')}
         </div>
       );
     }
@@ -812,22 +812,22 @@ const Review: React.FC = () => {
                             <>
                               <span className="text-sm text-gray-700 truncate">{commit.person_name || commit.message}</span>
                               {commit.message.startsWith('Prosopo loomine:') && (
-                                <span className="text-xs text-green-700 bg-green-100 px-1.5 py-0.5 rounded flex-shrink-0">Uus isik</span>
+                                <span className="text-xs text-green-700 bg-green-100 px-1.5 py-0.5 rounded flex-shrink-0">{t('changeType.personCreated')}</span>
                               )}
                               {commit.message.startsWith('Prosopo muudatus:') && (
-                                <span className="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded flex-shrink-0">Isik</span>
+                                <span className="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded flex-shrink-0">{t('changeType.person')}</span>
                               )}
                               {commit.message.startsWith('Prosopo kustutamine:') && (
-                                <span className="text-xs text-red-700 bg-red-100 px-1.5 py-0.5 rounded flex-shrink-0">Kustutatud</span>
+                                <span className="text-xs text-red-700 bg-red-100 px-1.5 py-0.5 rounded flex-shrink-0">{t('changeType.personDeleted')}</span>
                               )}
                               {commit.message.startsWith('Prosopo liitmine:') && (
-                                <span className="text-xs text-purple-700 bg-purple-100 px-1.5 py-0.5 rounded flex-shrink-0">Liitmine</span>
+                                <span className="text-xs text-purple-700 bg-purple-100 px-1.5 py-0.5 rounded flex-shrink-0">{t('changeType.personMerged')}</span>
                               )}
                               {commit.message.startsWith('Prosopo taastamine:') && (
-                                <span className="text-xs text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded flex-shrink-0">Taastamine</span>
+                                <span className="text-xs text-blue-700 bg-blue-100 px-1.5 py-0.5 rounded flex-shrink-0">{t('changeType.personRestored')}</span>
                               )}
                               {commit.message.startsWith('Prosopo migratsioon:') && (
-                                <span className="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded flex-shrink-0">Migratsioon</span>
+                                <span className="text-xs text-gray-500 bg-gray-100 px-1.5 py-0.5 rounded flex-shrink-0">{t('changeType.personMigrated')}</span>
                               )}
                             </>
                           ) : (
@@ -866,7 +866,7 @@ const Review: React.FC = () => {
                             <Link
                               to={`/persons/${commit.person_id}`}
                               className="inline-flex items-center gap-1 p-2 text-indigo-600 hover:text-indigo-700 hover:bg-indigo-50 rounded-lg transition-colors"
-                              title="Ava isiku kaart"
+                              title={t('actions.openPerson')}
                               onClick={(e) => e.stopPropagation()}
                             >
                               <ExternalLink size={18} />

--- a/src/pages/SetPassword.tsx
+++ b/src/pages/SetPassword.tsx
@@ -182,17 +182,17 @@ const SetPassword: React.FC = () => {
           </div>
           <h1 className="text-2xl font-bold text-gray-900 mb-2">{isReset ? t('setPassword.resetSuccess') : t('setPassword.success')}</h1>
           <p className="text-gray-600 mb-2">
-            Sinu kasutajanimi: <strong className="text-primary-700">{createdUsername}</strong>
+            {t('setPassword.yourUsername')} <strong className="text-primary-700">{createdUsername}</strong>
           </p>
           <p className="text-sm text-gray-500 mb-6">
-            Kasuta seda kasutajanime sisselogimisel
+            {t('setPassword.usernameHint')}
           </p>
           <Link
             to="/"
             className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
           >
             <ArrowLeft size={18} />
-            Mine sisselogimise lehele
+            {t('setPassword.goToLogin')}
           </Link>
         </div>
       </div>

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -700,7 +700,7 @@ const WorkManage: React.FC = () => {
                     onClick={() => setGridCols((c) => Math.min(c + 1, MAX_COLS))}
                     disabled={gridCols >= MAX_COLS}
                     className="px-2 py-0.5 border rounded disabled:opacity-40"
-                    title="Väiksemad pisipildid"
+                    title={t('thumbnails.smaller')}
                   >−</button>
                   <input
                     type="range"
@@ -708,13 +708,13 @@ const WorkManage: React.FC = () => {
                     max={MAX_COLS}
                     value={MAX_COLS + MIN_COLS - gridCols}
                     onChange={(e) => setGridCols(MAX_COLS + MIN_COLS - Number(e.target.value))}
-                    aria-label="Veergude arv"
+                    aria-label={t('thumbnails.columns')}
                   />
                   <button
                     onClick={() => setGridCols((c) => Math.max(c - 1, MIN_COLS))}
                     disabled={gridCols <= MIN_COLS}
                     className="px-2 py-0.5 border rounded disabled:opacity-40"
-                    title="Suuremad pisipildid"
+                    title={t('thumbnails.larger')}
                   >+</button>
                 </div>
                 <div
@@ -1037,12 +1037,12 @@ const WorkManage: React.FC = () => {
             </div>
             <div className="p-5 space-y-4">
               <p className="text-sm text-gray-600">
-                Lae üles uus skänn. Metaandmed säilitatakse automaatselt.
+                {t('manage.replaceHint')}
               </p>
               <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg">
                 <AlertTriangle size={15} className="text-amber-600 shrink-0 mt-0.5" />
                 <p className="text-sm text-amber-800">
-                  Asendamine kustutab kõik praegused leheküljed ja asendab need uute OCR-itud lehekülgedega.
+                  {t('manage.replaceWarning')}
                 </p>
               </div>
               <button
@@ -1052,7 +1052,7 @@ const WorkManage: React.FC = () => {
                 className="flex items-center gap-2 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-colors"
               >
                 <Upload size={15} />
-                Ava üleslaadimise viisard
+                {t('manage.openUploadWizard')}
               </button>
             </div>
           </div>

--- a/src/pages/Workspace.tsx
+++ b/src/pages/Workspace.tsx
@@ -173,7 +173,7 @@ const Workspace: React.FC = () => {
     if (authInitializing) return;
     const loadData = async () => {
       if (!workId) {
-        setError("Töö ID on puudu.");
+        setError(t('errors.workIdMissing'));
         setLoading(false);
         return;
       }
@@ -235,7 +235,7 @@ const Workspace: React.FC = () => {
         }
       } catch (e: any) {
         console.error("Failed to load page", e);
-        setError(e.message || "Viga andmete laadimisel. Palun kontrolli Meilisearchi ühendust.");
+        setError(e.message || t('errors.loadFailed'));
       } finally {
         setLoading(false);
         setPageLoading(false);
@@ -653,7 +653,7 @@ const Workspace: React.FC = () => {
             />
           ) : (
             <div className="flex items-center justify-center h-full text-white/50">
-              Pilt puudub
+              {t('info.noImage')}
             </div>
           )}
         </div>

--- a/src/pages/admin/Places.tsx
+++ b/src/pages/admin/Places.tsx
@@ -181,7 +181,7 @@ const Places: React.FC = () => {
               <button
                 onClick={() => setSearchQuery('')}
                 className="text-gray-400 hover:text-gray-600 shrink-0"
-                aria-label="Tühista otsing"
+                aria-label={t('places.clearSearch')}
               >
                 <X size={14} />
               </button>
@@ -224,7 +224,7 @@ const Places: React.FC = () => {
                 {searchResults ? (
                   <div className="py-2">
                     {searchResults.length === 0 ? (
-                      <p className="px-3 py-4 text-sm text-gray-400 italic">Tulemusi ei leitud</p>
+                      <p className="px-3 py-4 text-sm text-gray-400 italic">{t('places.noSearchResults')}</p>
                     ) : (
                       searchResults.map(([k, e]) => (
                         <button

--- a/src/pages/admin/PlacesDetail.tsx
+++ b/src/pages/admin/PlacesDetail.tsx
@@ -322,7 +322,7 @@ const PlacesDetail: React.FC<PlacesDetailProps> = ({
             onFocus={() => { if (!parentKey) setParentDropOpen(true); }}
             onBlur={() => setTimeout(() => setParentDropOpen(false), 150)}
             readOnly={!!parentKey}
-            placeholder="Otsi ülempiirkonda…"
+            placeholder={t('places.parentSearchPlaceholder')}
             className={`w-full px-2 py-1.5 text-sm border rounded focus:ring-1 focus:ring-primary-500 outline-none
               ${parentKey ? 'border-green-300 bg-green-50 text-green-800' : 'border-gray-300'}`}
           />
@@ -402,7 +402,7 @@ const PlacesDetail: React.FC<PlacesDetailProps> = ({
                   setNewHistName('');
                 }
               }}
-              placeholder="Lisa nimi + Enter"
+              placeholder={t('places.historicalNamePlaceholder')}
               className="flex-1 px-2 py-1 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-primary-500 outline-none"
             />
             <button

--- a/src/pages/admin/PlacesGroupPanel.tsx
+++ b/src/pages/admin/PlacesGroupPanel.tsx
@@ -117,7 +117,7 @@ const PlacesGroupPanel: React.FC<PlacesGroupPanelProps> = ({
               type="text"
               value={newKey}
               onChange={e => setNewKey(e.target.value)}
-              placeholder="nt gootaland"
+              placeholder={t('places.groupKeyPlaceholder')}
               className="mt-0.5 w-full border border-gray-300 rounded px-2 py-1 text-sm font-mono"
             />
           </div>

--- a/src/pages/admin/PlacesTree.tsx
+++ b/src/pages/admin/PlacesTree.tsx
@@ -81,7 +81,7 @@ function TreeNode({
           <span className="text-xs text-gray-400 shrink-0">{t(`places.types.${node.entry.type}`, node.entry.type)}</span>
         )}
         {!hasQCode && (
-          <span title="Q-kood puudub"><AlertTriangle size={11} className="text-amber-400 shrink-0" /></span>
+          <span title={t('places.noQCode')}><AlertTriangle size={11} className="text-amber-400 shrink-0" /></span>
         )}
       </button>
       {hasChildren && open && (
@@ -138,7 +138,7 @@ const PlacesTree: React.FC<PlacesTreeProps> = ({ groups, selectedKey, onSelect, 
   const { t } = useTranslation('admin');
 
   if (groups.length === 0) {
-    return <p className="px-3 py-4 text-sm text-gray-400 italic">Kohti pole</p>;
+    return <p className="px-3 py-4 text-sm text-gray-400 italic">{t('places.treeEmpty')}</p>;
   }
 
   return (

--- a/src/pages/admin/Registrations.tsx
+++ b/src/pages/admin/Registrations.tsx
@@ -86,11 +86,11 @@ const Registrations: React.FC = () => {
       if (data.status === 'success') {
         setRegistrations(data.registrations || []);
       } else {
-        setError(data.message || 'Viga taotluste laadimisel');
+        setError(data.message || t('registrations.loadError'));
       }
     } catch (e) {
       console.error('Load registrations error:', e);
-      setError('Serveriga ühendamine ebaõnnestus');
+      setError(t('common:errors.connectionFailed'));
     } finally {
       setIsLoading(false);
     }
@@ -116,11 +116,11 @@ const Registrations: React.FC = () => {
         });
         await loadRegistrations();
       } else {
-        setError(data.message || 'Kinnitamine ebaõnnestus');
+        setError(data.message || t('registrations.approveError'));
       }
     } catch (e) {
       console.error('Approve error:', e);
-      setError('Serveriga ühendamine ebaõnnestus');
+      setError(t('common:errors.connectionFailed'));
     } finally {
       setProcessingId(null);
     }
@@ -137,11 +137,11 @@ const Registrations: React.FC = () => {
       if (data.status === 'success') {
         await loadRegistrations();
       } else {
-        setError(data.message || 'Tagasilükkamine ebaõnnestus');
+        setError(data.message || t('registrations.rejectError'));
       }
     } catch (e) {
       console.error('Reject error:', e);
-      setError('Serveriga ühendamine ebaõnnestus');
+      setError(t('common:errors.connectionFailed'));
     } finally {
       setProcessingId(null);
     }
@@ -386,7 +386,7 @@ const Registrations: React.FC = () => {
             className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 disabled:opacity-50"
           >
             {isLoading ? <Loader2 size={14} className="animate-spin" /> : <UserPlus size={14} />}
-            {t('common:actions.refresh')}
+            {t('common:buttons.refresh')}
           </button>
         </div>
       </div>

--- a/src/pages/search/SearchableFilterList.tsx
+++ b/src/pages/search/SearchableFilterList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
 
 interface SearchableFilterListProps {
@@ -15,6 +16,7 @@ interface SearchableFilterListProps {
 const SearchableFilterList: React.FC<SearchableFilterListProps> = ({
     items, selectedValues, onToggle, placeholder, isRadio = false, renderItem
 }) => {
+    const { t } = useTranslation('common');
     const [searchQuery, setSearchQuery] = useState('');
     const showSearch = items.length > 10;
 
@@ -40,7 +42,7 @@ const SearchableFilterList: React.FC<SearchableFilterListProps> = ({
             )}
             <div className={`space-y-1 overflow-y-scroll custom-scrollbar pr-1 ${showSearch ? 'h-60' : ''}`}>
                 {filteredItems.length === 0 ? (
-                    <div className="text-xs text-gray-400 italic py-2 px-1">Ei leitud vasteid</div>
+                    <div className="text-xs text-gray-400 italic py-2 px-1">{t('labels.noMatches')}</div>
                 ) : (
                     filteredItems.map((item) => {
                         const isSelected = selectedValues.includes(item.value);

--- a/src/pages/upload/components/UploadStepMeta.tsx
+++ b/src/pages/upload/components/UploadStepMeta.tsx
@@ -85,7 +85,7 @@ const UploadStepMeta: React.FC<UploadStepMetaProps> = ({
               type="button"
               onClick={onReplaceDismiss}
               className="p-0.5 text-amber-600 hover:text-red-600 transition-colors shrink-0"
-              title="Eemalda asendus"
+              title={t('replaceWork.remove')}
             >
               <X size={14} />
             </button>

--- a/src/prosopography/components/MergePersonsModal.tsx
+++ b/src/prosopography/components/MergePersonsModal.tsx
@@ -116,7 +116,7 @@ const MergePersonsModal: React.FC<MergePersonsModalProps> = ({
             disabled={loading}
             className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
           >
-            {t('common:cancel', 'Tühista')}
+            {t('common:buttons.cancel')}
           </button>
           <button
             onClick={() => onConfirm(source.id, target.id)}

--- a/src/prosopography/components/personForm/EnrichExistingSection.tsx
+++ b/src/prosopography/components/personForm/EnrichExistingSection.tsx
@@ -132,7 +132,7 @@ const EnrichExistingSection: React.FC<Props> = ({ personId, wikidataId, gndId, a
         className="w-full flex items-center gap-2 px-3 py-2 bg-blue-50/60 hover:bg-blue-50 text-left transition-colors"
       >
         <RefreshCw size={12} className="text-blue-400 shrink-0" />
-        <span className="text-xs font-medium text-blue-700">Välisallikatest rikastamine</span>
+        <span className="text-xs font-medium text-blue-700">{t('enrich.sectionTitle')}</span>
         <span className="ml-auto text-blue-300">{open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}</span>
       </button>
 

--- a/src/prosopography/components/personForm/ProsopoPersonPicker.tsx
+++ b/src/prosopography/components/personForm/ProsopoPersonPicker.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Loader2, Link2, X } from 'lucide-react';
 import { listPersons } from '../../services/prosopographyService';
 import type { ProsopoIndexEntry } from '../../types';
@@ -10,6 +11,7 @@ const ProsopoPersonPicker: React.FC<{
   token: string;
   currentId?: string;  // välistab iseenda tulemi
 }> = ({ value, onChange, token, currentId }) => {
+  const { t } = useTranslation('prosopography');
   const [query, setQuery] = useState(value.name);
   const [results, setResults] = useState<ProsopoIndexEntry[]>([]);
   const [open, setOpen] = useState(false);
@@ -66,7 +68,7 @@ const ProsopoPersonPicker: React.FC<{
               search(e.target.value);
             }}
             onFocus={() => { if (query) setOpen(true); }}
-            placeholder="Isiku nimi…"
+            placeholder={t('enrich.searchPlaceholder')}
             className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none pr-6"
           />
           {loading && <Loader2 size={12} className="absolute right-2 top-2.5 animate-spin text-gray-400" />}

--- a/src/prosopography/pages/PersonDetailPage.tsx
+++ b/src/prosopography/pages/PersonDetailPage.tsx
@@ -288,14 +288,14 @@ const PersonDetailPage: React.FC = () => {
 
   const handleRestore = async (commitHash: string) => {
     if (!id || !token) return;
-    if (!window.confirm('Kas oled kindel, et soovid taastada selle versiooni?')) return;
+    if (!window.confirm(t('historyPanel.restoreConfirm'))) return;
     setRestoring(commitHash);
     try {
       await restorePerson(id, commitHash, token);
       window.location.reload();
     } catch (e) {
       console.error('Taastamine ebaõnnestus:', e);
-      alert('Taastamine ebaõnnestus');
+      alert(t('historyPanel.restoreError'));
     } finally {
       setRestoring(null);
     }
@@ -770,7 +770,7 @@ const PersonDetailPage: React.FC = () => {
                 )}
               </div>
               <div className="flex items-center gap-2">
-                {historyLoading && <span className="text-xs text-gray-400">{t('common:loading')}</span>}
+                {historyLoading && <span className="text-xs text-gray-400">{t('common:labels.loading')}</span>}
                 {historyOpen ? <ChevronDown size={16} className="text-gray-400" /> : <ChevronRight size={16} className="text-gray-400" />}
               </div>
             </button>
@@ -800,7 +800,7 @@ const PersonDetailPage: React.FC = () => {
                         <span className="text-xs text-gray-500 flex-shrink-0">{commit.author}</span>
                         <span className="text-sm text-gray-700 truncate">{commit.message}</span>
                         {commit.is_original && (
-                          <span className="text-xs text-green-700 bg-green-50 px-1.5 py-0.5 rounded flex-shrink-0">Originaal</span>
+                          <span className="text-xs text-green-700 bg-green-50 px-1.5 py-0.5 rounded flex-shrink-0">{t('historyPanel.original')}</span>
                         )}
                       </div>
                       {!commit.is_original && (
@@ -808,10 +808,10 @@ const PersonDetailPage: React.FC = () => {
                           onClick={(e) => { e.stopPropagation(); handleRestore(commit.full_hash); }}
                           disabled={restoring === commit.full_hash}
                           className="text-xs text-red-600 hover:text-red-700 px-2 py-1 rounded hover:bg-red-50 transition-colors disabled:opacity-50 flex items-center gap-1 flex-shrink-0"
-                          title="Taasta see versioon"
+                          title={t('historyPanel.restoreTitle')}
                         >
                           <RotateCcw size={12} />
-                          Taasta
+                          {t('common:buttons.restore')}
                         </button>
                       )}
                     </div>
@@ -819,10 +819,10 @@ const PersonDetailPage: React.FC = () => {
                     {expandedCommit === commit.hash && (
                       <div className="border-t border-gray-200 bg-gray-50 px-5 py-3">
                         {diffCache[commit.hash] === 'error' ? (
-                          <p className="text-xs text-red-400 italic">Diff laadimine ebaõnnestus</p>
+                          <p className="text-xs text-red-400 italic">{t('historyPanel.diffError')}</p>
                         ) : diffCache[commit.hash] ? (
                           (diffCache[commit.hash] as { field: string; old: unknown; new: unknown }[]).length === 0 ? (
-                            <p className="text-xs text-gray-400 italic">Muudatusi ei leitud</p>
+                            <p className="text-xs text-gray-400 italic">{t('historyPanel.noChanges')}</p>
                           ) : (
                             <div className="space-y-1">
                               {(diffCache[commit.hash] as { field: string; old: unknown; new: unknown }[]).map((change, i) => (
@@ -836,7 +836,7 @@ const PersonDetailPage: React.FC = () => {
                             </div>
                           )
                         ) : (
-                          <p className="text-xs text-gray-400 italic">Laadin…</p>
+                          <p className="text-xs text-gray-400 italic">{t('loading')}</p>
                         )}
                       </div>
                     )}
@@ -847,7 +847,7 @@ const PersonDetailPage: React.FC = () => {
 
             {historyOpen && history.length === 0 && !historyLoading && (
               <div className="border-t border-gray-100 px-5 py-4 text-sm text-gray-400 italic">
-                Ajalugu puudub
+                {t('historyPanel.empty')}
               </div>
             )}
           </div>

--- a/src/prosopography/pages/PersonEditPage.tsx
+++ b/src/prosopography/pages/PersonEditPage.tsx
@@ -368,7 +368,7 @@ const PersonEditPage: React.FC = () => {
               }}
             >
               {imageUrl ? (
-                <img src={imageUrl} alt="Profiilipilt" className="w-full h-full object-cover" />
+                <img src={imageUrl} alt={t('form.profilePhoto')} className="w-full h-full object-cover" />
               ) : (
                 <ImagePlus size={24} className="text-gray-300" />
               )}
@@ -955,7 +955,7 @@ const PersonEditPage: React.FC = () => {
                     onClick={() => { setDeleteOpen(false); setDeleteError(null); }}
                     className="px-3 py-1.5 text-sm border border-gray-300 text-gray-600 rounded hover:bg-gray-50 transition-colors"
                   >
-                    {t('common:actions.cancel')}
+                    {t('common:buttons.cancel')}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
Ingliskeelses UI-s kuvati mitmel pool eestikeelset teksti — nt `/persons/:id` **Muudatuste ajalugu** all `Originaal` ja `Taasta`. Süstemaatiline otsing leidis kaks eraldi põhjust.

> **NB:** haru on PR #203 otsas (skann käis selle puu peal; WorkManage/Workspace/Places kattuvad). Merge'ida pärast #203.

## 1. Kõvakodeeritud stringid JSX-is (~50 kohta)

Tekstisõlmed, `title`/`placeholder`/`aria-label`/`alt`, `confirm`/`alert` teated.

Komponendid, kus `useTranslation` puudus üldse ja on nüüd lisatud: `ImageViewer`, `ThumbnailGrid`, `ErrorBanner`, `EntityPicker`, `SearchableFilterList`, `ProsopoPersonPicker`, `AdvancedFilters` (alamkomponent `FilterSection`), `index.tsx` (Suspense fallback).

Ülejäänud puudutatud: `PersonDetailPage` (ajaloopaneel — algne leid), `CollectionEditor`, `Review`, `WorkManage`, `Workspace`, `Dashboard`, `SetPassword`, `HistoryTab`, `WorkspaceMobileView`, `MetadataModal`, `UploadMetaForm`, `PageTagsPanel`, `WorkInfoPanel`, `UploadStepMeta`, `EnrichExistingSection`, `UserContext`, admin `Places`/`PlacesDetail`/`PlacesTree`/`PlacesGroupPanel`/`Registrations`.

## 2. `t()` kutsed puuduva võtmega (17 kutset)

`fallbackLng: false` (ADR 0011) tõttu kuvati eestikeelne `defaultValue` ka ingliskeelses UI-s. **Kolmel juhul puudus ka vaikeväärtus** ja ekraanile renderdus toores võti:

| Fail | Võti | Kuvati |
|---|---|---|
| `PersonDetailPage.tsx:773` | `common:loading` | `common:loading` — **samas ajaloopaneelis** |
| `PersonEditPage.tsx:958` | `common:actions.cancel` | `common:actions.cancel` |
| `Registrations.tsx:389` | `common:actions.refresh` | `common:actions.refresh` |

Olemasoleva vastega kutsed suunatud õigele võtmele (`buttons.*`), ülejäänutele lisatud võtmed mõlemasse keelde.

## Regressioonikaitse

Uus `src/locales/__tests__/translationKeysResolve.test.ts`: `localeParity` hoiab et/en võtmestikud identsena, aga **ei märka võtit, mis puudub mõlemas keeles**. Uus test kontrollib iga staatilise `t()` literaali lahenduvust ja raporteerib faili+rea. Kontrollitud, et test päriselt kukub (ajutise vigase võtmega), mitte ei läbi tühjalt.

## Tahtlikult puutumata

Pärisnimed ja brändid (Wikidata, GND, VIAF, Album Academicum, OpenHistoricalMap), keelevalija enda keelenimed (`Eesti`/`English`), näidisnimed kohatäidetes (`von Münchhausen`), `console.*` arendajateated.

## Kontroll

- `npm run typecheck` — puhas
- `npx vitest run` — 667 testi (61 faili) läbivad
- `npm run build` — õnnestub
- ESLint 55 warningut (baastase 55, lävi 56) — uusi ei lisandunud

Skannerid: JSX-tekstisõlmed, kõik `title`/`placeholder`/`aria-label`/`alt` literaalid ning `t()`-lahenduvus; kõik kolm jooksevad nüüd puhtalt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)