### PR TITLE
fix(prosopo): metaandmete salvestus ei kustuta enam 'mentioned' seoseid

### DIFF
--- a/server/admin_page_ops.py
+++ b/server/admin_page_ops.py
@@ -22,6 +22,7 @@ from .config import BASE_DIR, get_logger
 from .git_ops import get_or_init_repo, save_with_git, delete_page_from_git, delete_pages_from_git
 from .utils import find_directory_by_id, generate_nanoid
 from .meilisearch_ops import sync_work_to_meilisearch
+from .prosopography.relations import update_page_person_mentions
 
 logger = get_logger(__name__)
 
@@ -1045,5 +1046,10 @@ def delete_pages(work_id, base_names, username):
             raise
 
         sync_work_to_meilisearch(folder_name)
+        # Kustutatud lehe isiku-tägid ei tohi 'mentioned' indeksisse rippuma jääda.
+        try:
+            update_page_person_mentions(work_id, path)
+        except Exception:
+            logger.exception(f"delete_pages: mainimiste indeksi uuendus ebaõnnestus ({work_id})")
         new_page_count = len(get_sorted_images(path))
         return {"status": "success", "deleted": list(base_names), "new_page_count": new_page_count}

--- a/server/prosopography/indices.py
+++ b/server/prosopography/indices.py
@@ -219,9 +219,14 @@ def update_person_to_works(
     with state._works_lock:
         data = _load_person_to_works()
 
-        # Eemalda kõik olemasolevad viited sellele teosele.
+        # Eemalda selle teose metaandmetest tuletatud viited.
+        # 'mentioned' tuleb leheküljefailide page_tags-ist (update_page_person_mentions)
+        # — seda me siin uuesti ei arvuta, seega ei tohi seda ka kustutada.
         for pid_entries in data.values():
-            pid_entries[:] = [e for e in pid_entries if e.get("work_id") != work_id]
+            pid_entries[:] = [
+                e for e in pid_entries
+                if e.get("work_id") != work_id or e.get("role") == "mentioned"
+            ]
 
         # Lisa uued.
         for pid, roles in new_entries.items():

--- a/tests/test_backend_smoke.py
+++ b/tests/test_backend_smoke.py
@@ -349,6 +349,76 @@ def test_rebuild_indices_includes_page_person_mentions(tmp_path, monkeypatch):
     assert len(mentioned_entries) == 1, f"Peaks olema täpselt 1 'mentioned' kirje, sain: {mentioned_entries}"
 
 
+def test_update_person_to_works_preserves_mentioned(tmp_path, monkeypatch):
+    """
+    Teose metaandmete salvestus (update_person_to_works) EI TOHI kustutada
+    lehe-tägidest tuletatud 'mentioned' rolle — need tulevad teisest allikast
+    (leheküljefailid) ja neid see funktsioon uuesti ei arvuta.
+    """
+    import server.prosopography.ops as prosopo_ops
+    import server.prosopography.work_relations_ops as work_relations_ops
+
+    work_id = "workAAA"
+    ptw_file = tmp_path / "person_to_works.json"
+    ptw_file.write_text(json.dumps({
+        # Lehe-täg: ainult 'mentioned' selle teose kohta
+        "vutt:Pmmm": [{"work_id": work_id, "role": "mentioned"}],
+        # Vana loojaroll, mis TULEB üle kirjutada (isik eemaldati creators-ist)
+        "vutt:Pold": [{"work_id": work_id, "role": "auctor"}],
+    }), encoding="utf-8")
+
+    monkeypatch.setattr(prosopo_ops, "PERSON_TO_WORKS_FILE", str(ptw_file))
+    monkeypatch.setattr(
+        work_relations_ops, "WORKS_CREATORS_INDEX_FILE", str(tmp_path / "works_creators_index.json")
+    )
+
+    prosopo_ops.update_person_to_works(
+        work_id,
+        creators=[{"id": "vutt:Pnew", "role": "auctor"}],
+        tags=[{"id": "Q201676", "label": "matus"}],
+        publisher={"id": "vutt:Ppub", "label": "Trükkal"},
+        title="Test",
+        year=1695,
+    )
+
+    data = json.loads(ptw_file.read_text(encoding="utf-8"))
+
+    assert data.get("vutt:Pmmm") == [{"work_id": work_id, "role": "mentioned"}], \
+        f"'mentioned' peab säilima, sain: {data.get('vutt:Pmmm')!r}"
+    assert data.get("vutt:Pold") == [], f"vana loojaroll peab kaduma, sain: {data.get('vutt:Pold')!r}"
+    assert data["vutt:Pnew"] == [{"work_id": work_id, "role": "auctor"}]
+    assert data["vutt:Ppub"] == [{"work_id": work_id, "role": "publisher"}]
+
+
+def test_delete_pages_refreshes_person_mentions(tmp_path, monkeypatch):
+    """
+    Lehekülgede kustutamine peab lehe-tägidest tuletatud 'mentioned' rollid
+    üle arvutama — muidu jääb kustutatud lehe isik indeksisse rippuma.
+    """
+    import server.admin_page_ops as admin_page_ops
+
+    work_id = "workAAA"
+    work_dir = tmp_path / "teos1"
+    work_dir.mkdir()
+    (work_dir / "leht1.jpg").write_bytes(b"fake")
+
+    monkeypatch.setattr(admin_page_ops, "find_directory_by_id", lambda wid: str(work_dir))
+    monkeypatch.setattr(admin_page_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(admin_page_ops, "delete_pages_from_git", lambda *a, **kw: None)
+    monkeypatch.setattr(admin_page_ops, "sync_work_to_meilisearch", lambda *a, **kw: None)
+
+    calls = []
+    monkeypatch.setattr(
+        admin_page_ops, "update_page_person_mentions", lambda wid, wdir: calls.append((wid, wdir))
+    )
+
+    result = admin_page_ops.delete_pages(work_id, ["leht1"], username="admin")
+
+    assert result["status"] == "success", result
+    assert calls == [(work_id, str(work_dir))], \
+        f"update_page_person_mentions peaks olema kutsutud 1 kord, sain: {calls}"
+
+
 def test_save_triggers_page_person_mentions_update(client, login, monkeypatch, tmp_path):
     """
     POST /save peab käivitama update_page_person_mentions background task-i


### PR DESCRIPTION
## Probleem

Isikukaardil (nt Johann Fischer `vutt:Pu837uz`) puudus seos teosega, mille leheküljel isik on tägitud (`179o97`).

Juur: `update_person_to_works()` (`server/prosopography/indices.py`) pühib salvestamisel **kõik** `person_to_works.json` kirjed antud teose kohta, kuid arvutab uuesti ainult `creators` / isiku-`tags` / `publisher` põhjal. `mentioned` roll tuleb hoopis leheküljefailide `page_tags`-ist (`update_page_person_mentions`) → iga teose metaandmete salvestus nullis lehe-tägidest tulnud seosed.

Ajajoon serveris (2026-07-31): lehe salvestus 12:50:45 lisas `mentioned`, metaandmete salvestus 12:50:55 kustutas selle.

## Muudatused

- `update_person_to_works` säilitab `mentioned`-rollis kirjed (neid see funktsioon ei arvuta)
- `delete_pages` kutsub `update_page_person_mentions` — muidu jääb kustutatud lehe isik indeksisse rippuma
- 2 regressioonitesti `tests/test_backend_smoke.py`-s (mõlemad kukkusid enne parandust)

## Test

`.venv/bin/pytest tests/ -q` → 1050 passed

Olemasolevate andmete parandus tuleb ise: `rebuild_indices()` jookseb backendi stardil, seega deploy taastab puuduvad `mentioned` kirjed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)