### PR TITLE
feat(prosopo): mainimise link viib lehele, kus isikut mainitakse

### DIFF
--- a/server/prosopography/indices.py
+++ b/server/prosopography/indices.py
@@ -9,6 +9,53 @@ from typing import Any, Optional
 
 from . import state
 from ._compat import sync_from_facade
+from ..meili_doc import enumerate_page_images
+
+
+def collect_page_person_mentions(work_dir: str) -> dict[str, list[int]]:
+    """Kogub teose leheküljefailidest isiku-tägid: { person_id: [leheküljenumbrid] }.
+
+    Leheküljenumber on 1-põhine positsioon `enumerate_page_images` järjekorras —
+    sama numeratsioon, mida kasutavad vaade /work/{id}/{nr} ja Meilisearch.
+    Ilma pildita .json (orb) loeb isiku ikka mainituks, aga numbrita.
+    """
+    mentions: dict[str, list[int]] = {}
+    try:
+        page_nums = {
+            os.path.splitext(img)[0]: idx
+            for idx, img in enumerate(enumerate_page_images(work_dir), start=1)
+        }
+    except Exception:
+        page_nums = {}
+
+    try:
+        page_files = sorted(os.listdir(work_dir))
+    except Exception:
+        return mentions
+
+    for page_fname in page_files:
+        if not page_fname.endswith('.json') or page_fname == '_metadata.json':
+            continue
+        try:
+            with open(os.path.join(work_dir, page_fname), 'r', encoding='utf-8') as f:
+                page_data = json.load(f)
+        except Exception:
+            continue
+        source = page_data.get('meta_content', page_data)
+        page_num = page_nums.get(os.path.splitext(page_fname)[0])
+        for tag in source.get('page_tags') or []:
+            if not isinstance(tag, dict):
+                continue
+            pid = tag.get('id') or ''
+            if not pid.startswith('vutt:P'):
+                continue
+            pages = mentions.setdefault(pid, [])
+            if page_num is not None and page_num not in pages:
+                pages.append(page_num)
+
+    for pages in mentions.values():
+        pages.sort()
+    return mentions
 
 
 def _load_json_or_default(path: str, default: Any) -> Any:
@@ -298,27 +345,10 @@ def rebuild_indices():
                 if pid.startswith("vutt:P"):
                     ptw.setdefault(pid, []).append({"work_id": work_id, "role": "publisher"})
 
-            mentioned_ids: set[str] = set()
-            try:
-                for page_fname in os.listdir(entry.path):
-                    if not page_fname.endswith('.json') or page_fname == '_metadata.json':
-                        continue
-                    page_fpath = os.path.join(entry.path, page_fname)
-                    try:
-                        with open(page_fpath, 'r', encoding='utf-8') as pf:
-                            page_data = json.load(pf)
-                        source = page_data.get('meta_content', page_data)
-                        for tag in source.get('page_tags', []):
-                            if isinstance(tag, dict):
-                                pid = tag.get('id') or ''
-                                if pid.startswith('vutt:P'):
-                                    mentioned_ids.add(pid)
-                    except Exception:
-                        pass
-            except Exception:
-                pass
-            for pid in mentioned_ids:
-                ptw.setdefault(pid, []).append({'work_id': work_id, 'role': 'mentioned'})
+            for pid, pages in collect_page_person_mentions(entry.path).items():
+                ptw.setdefault(pid, []).append(
+                    {'work_id': work_id, 'role': 'mentioned', 'pages': pages}
+                )
 
     with state._works_lock:
         state.atomic_write_json(state.PERSON_TO_WORKS_FILE, ptw)

--- a/server/prosopography/relations.py
+++ b/server/prosopography/relations.py
@@ -7,7 +7,7 @@ import time
 from typing import Optional
 
 from . import state
-from .indices import _load_index, _load_person_to_works
+from .indices import _load_index, _load_person_to_works, collect_page_person_mentions
 from .person_crud import get_person
 from ._compat import sync_from_facade
 
@@ -129,23 +129,8 @@ def update_page_person_mentions(work_id: str, work_dir: str):
         return
     sync_from_facade()
 
-    person_ids: set[str] = set()
     try:
-        for fname in os.listdir(work_dir):
-            if not fname.endswith('.json') or fname == '_metadata.json':
-                continue
-            fpath = os.path.join(work_dir, fname)
-            try:
-                with open(fpath, 'r', encoding='utf-8') as f:
-                    page = json.load(f)
-                source = page.get('meta_content', page)
-                for tag in source.get('page_tags', []):
-                    if isinstance(tag, dict):
-                        pid = tag.get('id') or ''
-                        if pid.startswith('vutt:P'):
-                            person_ids.add(pid)
-            except Exception:
-                pass
+        mentions = collect_page_person_mentions(work_dir)
     except Exception as e:
         print(f"update_page_person_mentions viga: {e}")
         return
@@ -159,10 +144,10 @@ def update_page_person_mentions(work_id: str, work_dir: str):
                 if not (e.get('work_id') == work_id and e.get('role') == 'mentioned')
             ]
         # Lisa uued.
-        for pid in person_ids:
+        for pid, pages in mentions.items():
             if pid not in data:
                 data[pid] = []
-            data[pid].append({'work_id': work_id, 'role': 'mentioned'})
+            data[pid].append({'work_id': work_id, 'role': 'mentioned', 'pages': pages})
         state.atomic_write_json(state.PERSON_TO_WORKS_FILE, data)
 
 

--- a/src/prosopography/pages/PersonDetailPage.tsx
+++ b/src/prosopography/pages/PersonDetailPage.tsx
@@ -404,7 +404,7 @@ const PersonDetailPage: React.FC = () => {
     const range = parseYearDisplayRange(null, meta?.year_display);
     return range ? Math.floor((range.start + range.end) / 2) : 9999;
   };
-  const works: { work_id: string; role: string }[] = [...(person.works ?? [])].sort(
+  const works: { work_id: string; role: string; pages?: number[] }[] = [...(person.works ?? [])].sort(
     (a, b) => sortYear(a.work_id) - sortYear(b.work_id)
   );
   const identifiers = (person.identifiers ?? []).filter(i => i.id);
@@ -690,8 +690,10 @@ const PersonDetailPage: React.FC = () => {
               </div>
             )}
             <div className="space-y-1">
-              {displayedWorks.map(({ work_id, role }) => {
+              {displayedWorks.map(({ work_id, role, pages }) => {
                 const roleLabel = t(`workspace:metadata.roles.${role}`, { defaultValue: role });
+                // Mainimise puhul vii lehele, kus isikut mainitakse (muidu esimene lehekülg)
+                const targetPage = pages?.[0] ?? 1;
                 const meta = workTitles[work_id];
                 const title = meta?.title ?? work_id;
                 // Eelista kuvatavat aastat (nt "ca. 1750"); muidu number-aasta, kui see pole 0
@@ -724,7 +726,7 @@ const PersonDetailPage: React.FC = () => {
                 return (
                   <Link
                     key={`${work_id}-${role}`}
-                    to={`/work/${work_id}/1`}
+                    to={`/work/${work_id}/${targetPage}`}
                     className={`flex items-center justify-between py-2 -mx-1 px-1 rounded group transition-colors ${inCollection ? `${colorClasses?.bg} hover:opacity-90` : 'hover:bg-gray-50'}`}
                   >
                     <div className="flex items-center gap-2 min-w-0">

--- a/src/prosopography/types.ts
+++ b/src/prosopography/types.ts
@@ -190,5 +190,5 @@ export interface ProsopoRecord {
   image_url: string | null;
   source_data: Record<string, any>;
   // lisatakse GET /prosopography/{id} vastuses
-  works?: { work_id: string; role: string }[];
+  works?: { work_id: string; role: string; pages?: number[] }[];
 }

--- a/tests/test_backend_smoke.py
+++ b/tests/test_backend_smoke.py
@@ -277,9 +277,9 @@ def test_update_page_person_mentions(tmp_path, monkeypatch):
     assert "subject" in roles_a, f"subject peab säilima: {data['vutt:Paaa']}"
     assert "mentioned" in roles_a, f"mentioned peab lisanduma: {data['vutt:Paaa']}"
 
-    # Isik B: ainult 'mentioned'
+    # Isik B: ainult 'mentioned'. Pildifaile pole → lehenumbrit ei saa tuletada.
     assert "vutt:Pbbb" in data
-    assert data["vutt:Pbbb"] == [{"work_id": work_id, "role": "mentioned"}]
+    assert data["vutt:Pbbb"] == [{"work_id": work_id, "role": "mentioned", "pages": []}]
 
     # Q-kood ei tohi olla lisatud
     assert "Q99999" not in data
@@ -347,6 +347,82 @@ def test_rebuild_indices_includes_page_person_mentions(tmp_path, monkeypatch):
     # Sama isik mitmel lehel — ainult üks 'mentioned' kirje teose kohta
     mentioned_entries = [e for e in data["vutt:Pxxx"] if e["role"] == "mentioned"]
     assert len(mentioned_entries) == 1, f"Peaks olema täpselt 1 'mentioned' kirje, sain: {mentioned_entries}"
+
+
+def test_page_mentions_record_page_numbers(tmp_path, monkeypatch):
+    """
+    'mentioned' kirje peab kandma leheküljenumbreid, et isikukaardi link
+    viiks lehele, kus isikut mainitakse (/work/{id}/{nr}).
+    Numeratsioon = enumerate_page_images järjekord (sequence, siis failinimi).
+    """
+    import server.prosopography.ops as prosopo_ops
+
+    work_id = "workAAA"
+    work_dir = tmp_path / "teos1"
+    work_dir.mkdir()
+    (work_dir / "_metadata.json").write_text(json.dumps({"id": work_id}), encoding="utf-8")
+
+    # Kolm lehte; sequence määrab järjekorra, failinimi on tahtlikult teises järjekorras
+    for name, seq, tags in [
+        ("Page_02", 100, []),
+        ("Page_03", 200, [{"id": "vutt:Pmmm", "label": "Isik", "entity_type": "person"}]),
+        ("Page_04", 300, [{"id": "vutt:Pmmm", "label": "Isik", "entity_type": "person"}]),
+    ]:
+        (work_dir / f"{name}.jpg").write_bytes(b"fake")
+        (work_dir / f"{name}.json").write_text(
+            json.dumps({"sequence": seq, "page_tags": tags}), encoding="utf-8"
+        )
+
+    ptw_file = tmp_path / "person_to_works.json"
+    ptw_file.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(prosopo_ops, "PERSON_TO_WORKS_FILE", str(ptw_file))
+
+    prosopo_ops.update_page_person_mentions(work_id, str(work_dir))
+
+    data = json.loads(ptw_file.read_text(encoding="utf-8"))
+    entries = data.get("vutt:Pmmm") or []
+    assert len(entries) == 1, f"üks 'mentioned' kirje teose kohta: {entries}"
+    assert entries[0]["work_id"] == work_id
+    assert entries[0]["role"] == "mentioned"
+    assert entries[0].get("pages") == [2, 3], f"lehenumbrid peavad olema [2, 3], sain: {entries[0]}"
+
+
+def test_rebuild_indices_records_mention_page_numbers(tmp_path, monkeypatch):
+    """rebuild_indices() peab 'mentioned' kirjetele samamoodi lehenumbrid andma."""
+    import server.prosopography.ops as prosopo_ops
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    teos1 = data_dir / "teos1"
+    teos1.mkdir()
+    (teos1 / "_metadata.json").write_text(json.dumps({
+        "id": "workAAA", "creators": [], "tags": [], "publisher": None,
+    }), encoding="utf-8")
+    for name, seq, tags in [
+        ("Page_02", 100, []),
+        ("Page_03", 200, [{"id": "vutt:Pxxx", "label": "Test Isik", "entity_type": "person"}]),
+    ]:
+        (teos1 / f"{name}.jpg").write_bytes(b"fake")
+        (teos1 / f"{name}.json").write_text(
+            json.dumps({"sequence": seq, "page_tags": tags}), encoding="utf-8"
+        )
+
+    prosopo_dir = tmp_path / "prosopography"
+    prosopo_dir.mkdir()
+    ptw_file = tmp_path / "person_to_works.json"
+
+    monkeypatch.setattr(prosopo_ops, "PERSON_TO_WORKS_FILE", str(ptw_file))
+    monkeypatch.setattr(prosopo_ops, "PROSOPOGRAPHY_INDEX_FILE", str(tmp_path / "index.json"))
+    monkeypatch.setattr(prosopo_ops, "PERSON_ALIASES_FILE", str(tmp_path / "aliases.json"))
+    monkeypatch.setattr(prosopo_ops, "PROSOPOGRAPHY_DIR", str(prosopo_dir))
+    monkeypatch.setattr(prosopo_ops, "BASE_DIR", str(data_dir))
+
+    prosopo_ops.rebuild_indices()
+
+    data = json.loads(ptw_file.read_text(encoding="utf-8"))
+    entries = [e for e in data.get("vutt:Pxxx", []) if e["role"] == "mentioned"]
+    assert len(entries) == 1, f"üks 'mentioned' kirje: {entries}"
+    assert entries[0].get("pages") == [2], f"lehenumber peab olema [2], sain: {entries[0]}"
 
 
 def test_update_person_to_works_preserves_mentioned(tmp_path, monkeypatch):


### PR DESCRIPTION
## Probleem

Isikukaardil viis mainitud teose link alati teose esimesele leheküljele: `/persons/vutt:Pleo1zy` → `/work/occgcn/1`, kuigi isikut mainitakse leheküljel 2.

Põhjus: `person_to_works.json` `mentioned`-kirje kandis ainult `work_id`-d, mitte lehenumbrit, ja `PersonDetailPage` linkis kõvakodeeritult `/work/{id}/1`.

## Muudatused

**Backend**
- Uus jagatud helper `collect_page_person_mentions(work_dir)` (`indices.py`) → `{person_id: [lehenumbrid]}`
- Lehenumeratsioon tuleb `enumerate_page_images`-ist (sequence, siis failinimi) — sama järjekord, mida kasutavad vaade `/work/{id}/{nr}` ja Meilisearch, seega numbrid ei saa lahku minna
- Nii jooksev uuendus (`update_page_person_mentions`) kui täisehitus (`rebuild_indices`) kasutavad sama helperit; kirje kuju: `{"work_id": ..., "role": "mentioned", "pages": [2, 5]}`
- Pildita `.json` (orb) → isik loeb ikka mainituks, `pages: []`

**Frontend**
- `PersonDetailPage`: `to={/work/${work_id}/${pages?.[0] ?? 1}}`
- `ProsopoRecord.works` tüüpi lisatud `pages?: number[]`

## Test

- 2 uut backend-testi (lehenumbrid jooksval uuendusel ja täisehitusel), mõlemad kukkusid enne parandust
- `.venv/bin/pytest tests/ -q` → 1052 passed
- `npm run typecheck` puhas, `npm test` → 682 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)