### PR TITLE
fix(backup): jäta tuletatud vahemälu välja ja säilita pooleli jäänud snapshot

### DIFF
--- a/docs/vutt-backup.md
+++ b/docs/vutt-backup.md
@@ -10,15 +10,42 @@ Eesmärk: varundada VUTT **tervikuna** teisele masinale snapshot'idena:
 `state/` sisaldab paroole/tokeneid/hash'e, seega peab backup-sihtkataloog olema privaatne
 (`chmod 700`) ja seda ei tohi GitHubi ega avalikku pilve krüpteerimata panna.
 
-## Käivituskoht
+## Päris seadistus (loss, alates 2026-08-04)
 
-Käivita backup **sihtmasinas** (nt OCR-serveris), mis tõmbab andmed VUTT serverist SSH/rsync abil:
+Backup **tõmmatakse**, mitte ei lükata: sihtmasin `loss` (füüsiliselt teine masin, ülikooli
+võrgus) võtab VUTT serverist. Nii ei ole VUTT serveril kirjutusõigust backupidesse — kui
+VUTT kompromiteeritakse, ei saa ründaja koopiaid kustutada.
+
+| | |
+|---|---|
+| Sihtmasin | `loss` (`ssh loss`) |
+| Skript sihtmasinas | `/home/mf/bin/vutt_backup.py` (koopia siit repost) |
+| Snapshot'id | `/home/mf/vutt-backups/snapshots/`, `latest` symlink |
+| SSH-alias | `vutt-backup` → `meelisf@193.40.22.30`, võti `~/.ssh/vutt_backup` |
+| Cron | `15 3 * * *`, `--keep-days 365`, `logger -t vutt-backup` |
+| Maht | 39 GB / snapshot, hardlinkidega ~55 GB/aasta (eelarve 200 GB) |
 
 ```bash
-cd ~/VUTT
-./scripts/vutt_backup.py --dest-root ~/vutt-backups --dry-run
-./scripts/vutt_backup.py --dest-root ~/vutt-backups
+# käsitsi jooksutamine loss-is
+~/bin/vutt_backup.py --source-host vutt-backup --source-root . --dest-root ~/vutt-backups
 ```
+
+**`--source-root .` on KOHUSTUSLIK.** VUTT serveri `authorized_keys` piirab võtme
+`command="rrsync -ro /home/meelisf/VUTT",restrict` abil ainult lugevale rsyncile.
+`rrsync` juurib tee ise, seega absoluutne tee (`~/VUTT`) annab `Not allowed`.
+Sama põhjusel ei saa selle võtmega jooksutada `ssh vutt-backup <mis-tahes-käsk>` —
+see on tahtlik.
+
+VUTT serveri `~/.ssh/authorized_keys` rida:
+
+```text
+command="rrsync -ro /home/meelisf/VUTT",restrict ssh-ed25519 AAAA... vutt-backup
+```
+
+Võti PEAB olema **paroolita**. Tavavõti `id_ed25519` on parooliga ja töötab ainult
+interaktiivselt agendiga — cronis vaikselt ei tööta.
+
+### Üldkuju
 
 Vaikimisi loetakse allikas `vutt:~/VUTT/{data,state}`. Vajadusel:
 
@@ -93,9 +120,29 @@ varasemate snapshot'idega ja in-place muudatus muudaks neid kõiki korraga. Loe 
 kirjuta mujale. Sama kehtib snapshot-puu kopeerimisel teisele kettale: **`rsync -aH`**
 (ilma `-H`-ta kaovad hardlingid ja maht kordistub).
 
+## Snapshot on ka LLM-treeningu lähteandmestik
+
+`loss`-is olev qwen-treeningu repo (`~/Dokumendid/LLM/qwen3.5`,
+[qwen-mudeli-treenimine](https://github.com/meelisf/qwen-mudeli-treenimine)) ehitab
+treeningandmestiku **otse snapshot'ist** — `build_vutt_dataset.py` vaikimisi allikas on
+`~/vutt-backups/latest/data`. Eraldi tõmmet (`vutt_sync.py` → `data/vutt-raw/`) enam ei ole;
+see kataloog kustutati 2026-08-04 (36 GB) ja skript on märgitud aegunuks.
+
+Kaks tagajärge, mida tasub teada:
+
+- **Backup on nüüd treeningu eeltingimus.** Kui öine jooks kukub, on järgmine andmestik vana.
+  `journalctl -t vutt-backup --since today` enne ehitamist.
+- **Andmestik on reprodutseeritav.** Ehitus kirjutab `data/vutt/SOURCE.txt`, kus on
+  lahendatud snapshot'i tee (`.../snapshots/20260804T143956Z/data`), ehitusaeg ja lehtede arv.
+  Skript resolvib `latest` symlingi ÜKS kord käivitamisel, seega samal ajal lõppev backup ei
+  vaheta allikat töö keskel.
+
+Vana `vutt_sync.py` jooksis **ilma `--delete`-ita**, seega serverist kustutatud lehed jäid
+kohalikku koopiasse alles ja rändasid vaikselt treeningandmestikku. Snapshot on autoriteetne.
+
 ## Cron
 
-Näide sihtmasina crontab'i:
+Paigaldatud `loss`-is (`crontab -l`). Näide:
 
 ```cron
 # VUTT tervikbackup iga öö kell 03:15
@@ -116,17 +163,25 @@ journalctl -t vutt-backup --since today
 
 ## Restore-test
 
-Osaline restore näiteks ühe isikupildi või ühe teose piltide kontrolliks:
+**Backup, mida ei ole taastatud, ei ole backup.** Tee seda vähemalt korra pärast iga
+seadistusmuudatust. Sisu võrdlus peab käima **räsidega**, mitte failiarvuga.
 
 ```bash
-# Vaata viimast snapshot'i
-ls -la /srv/backups/vutt/latest/data
-ls -la /srv/backups/vutt/latest/state
+# loss-is: taasta üks teos + users.json ajutisse kohta
+W=$(ls ~/vutt-backups/latest/data | grep -v '^config$' | head -1)
+rm -rf /tmp/vutt-restore-test && mkdir -p /tmp/vutt-restore-test
+rsync -a ~/vutt-backups/latest/data/"$W" ~/vutt-backups/latest/state/users.json /tmp/vutt-restore-test/
+cd /tmp/vutt-restore-test/"$W" && find . -type f | LC_ALL=C sort | xargs md5sum | md5sum
 
-# Taasta fail ajutisse kohta
-mkdir -p /tmp/vutt-restore-test
-rsync -a /srv/backups/vutt/latest/state/users.json /tmp/vutt-restore-test/
+# vutt-is: sama teos, sama arvutus
+ssh vutt "cd ~/VUTT/data/$W && find . -type f | LC_ALL=C sort | xargs md5sum | md5sum"
 ```
+
+`LC_ALL=C` on oluline: kahe masina erinev `LC_COLLATE` sorteerib punktiga algavad failid
+(`.vutt-lock`) eri kohta ja summad lahknevad, kuigi sisu on identne. Kui summad ikka
+erinevad, võrdle failikaupa (`diff` kahest `md5sum`-loendist) — nii näeb, KUMB fail lahkneb.
+
+Tehtud 2026-08-04: 47 faili, kõik identsed; `users.json` bait-täpselt sama.
 
 Täisrestore uuele serverile:
 

--- a/docs/vutt-backup.md
+++ b/docs/vutt-backup.md
@@ -41,6 +41,28 @@ VUTT_BACKUP_HEALTHCHECK_URL=https://hc-ping.com/...
 VUTT_BACKUP_KEEP_DAYS=90
 ```
 
+## Eeltingimuse kontroll — loetavus
+
+**`--dry-run` EI tabaks õiguste viga.** rsync ehitab kuivkäitusel ainult failinimekirja
+(`readdir` + `stat`) ega ava faile; `failed to open ... Permission denied` tuleb välja alles
+päris ülekandel. Loetavust kontrolli **allikas**, oma tavavõtmega (backup-võti on rrsync'iga
+piiratud ega saa `find`-i käivitada):
+
+```bash
+ssh vutt 'find ~/VUTT/state ~/VUTT/data ! -readable'
+```
+
+Tühi väljund = korras. Kui midagi tuleb, otsusta iga kirje kohta eraldi:
+
+- **tuletatud vahemälu** (taastub ise) → lisa `DEFAULT_EXCLUDES`-i skriptis;
+- **päris andmed** → paranda õigused allikas, ÄRA excludeeri.
+
+Taust: backend kirjutab Dockerist root'ina. Enamik `state/` faile tuleb moodiga 0644
+(`users.json`, `invite_tokens.json`, `notifications/`) ja on `meelisf`-ile loetavad, aga
+`historical_regions_cache/` tuli 0600 root:root → esimene backup (2026-08-04) kukkus rsync
+exit 23-ga. `data/` sama probleemi ei ole, sest `server_update.sh` teeb selle peale
+`sudo chown -R meelisf:meelisf data/`.
+
 ## Snapshot-mudel
 
 Skript loob kataloogid:
@@ -60,6 +82,16 @@ Skript loob kataloogid:
 Iga uus snapshot kasutab eelmist `--link-dest` allikana: muutumata failid on hardlinkid,
 aga iga snapshot on iseseisvalt taastatav tervikvaade. `--delete` on siin lubatud, sest
 kustutatud failid kaovad ainult uuest snapshot'ist; vanad snapshot'id säilitavad need.
+
+**Pooleli jäänud jooks jäetakse alles.** Ebaõnnestumisel jääb `<ts>.partial` kataloog
+kettale ja **järgmine jooks jätkab sealt** (rsync jätab identsed failid vahele) — 40 GB
+uuesti tõmbamine mõne vea pärast oleks ebaproportsionaalne. Kustutamiseks on
+`--discard-partial`. Kuivkäitus ei kaaperda ega kustuta olemasolevat `.partial`-it.
+
+**Hardlink-hoiatus:** ära muuda faile snapshot'i sees kohapeal — need on jagatud
+varasemate snapshot'idega ja in-place muudatus muudaks neid kõiki korraga. Loe snapshot'ist,
+kirjuta mujale. Sama kehtib snapshot-puu kopeerimisel teisele kettale: **`rsync -aH`**
+(ilma `-H`-ta kaovad hardlingid ja maht kordistub).
 
 ## Cron
 

--- a/docs/vutt-backup.md
+++ b/docs/vutt-backup.md
@@ -140,19 +140,30 @@ Kaks tagajärge, mida tasub teada:
 Vana `vutt_sync.py` jooksis **ilma `--delete`-ita**, seega serverist kustutatud lehed jäid
 kohalikku koopiasse alles ja rändasid vaikselt treeningandmestikku. Snapshot on autoriteetne.
 
-## Cron
+## Cron ja valve
 
-Paigaldatud `loss`-is (`crontab -l`). Näide:
+Paigaldatud `loss`-is (`crontab -l`), üks rida:
 
 ```cron
-# VUTT tervikbackup iga öö kell 03:15
-15 3 * * * cd ~/VUTT && ./scripts/vutt_backup.py --dest-root /srv/backups/vutt --keep-days 120 2>&1 | logger -t vutt-backup
+15 3 * * * VUTT_BACKUP_HEALTHCHECK_URL=https://hc-ping.com/UUID /home/mf/bin/vutt_backup.py --source-host vutt-backup --source-root . --dest-root /home/mf/vutt-backups --keep-days 365 2>&1 | logger -t vutt-backup
 ```
 
-Healthchecks.io kasutamisel:
+Skript pingib healthchecks.io-d kolmes kohas: `/start` alguses, õnnestumisel puhas URL,
+veal `/fail` koos erindi tekstiga. **Ping ei saa backup'i kukutada** — pingiviga ainult
+logitakse.
 
-```cron
-15 3 * * * cd ~/VUTT && VUTT_BACKUP_HEALTHCHECK_URL=https://hc-ping.com/UUID ./scripts/vutt_backup.py --dest-root /srv/backups/vutt --keep-days 120 2>&1 | logger -t vutt-backup
+Seaded healthchecks.io poolel: **Period 1 day, Grace 3 h.** Grace peab katma kõige aeglasema
+realistliku jooksu, mitte tavalise. Esimene täisjooks võttis 57 min (100 Mbit link),
+igapäevane inkrementaalne paar minutit — aga suur upload-partii või eelmisest jooksust
+jäänud `.partial`-i jätkamine venitab. Liiga napp grace annab valehäireid, mis õpetavad
+teate ignoreerima; tund hiljem saabuv päris häire ei muuda öise varunduse puhul midagi.
+
+**Cron-keskkonda testi eraldi.** Kõige tavalisem vaikne rike on see, et käsk töötab sinu
+shellis, aga mitte cron'i minimaalses keskkonnas (PATH, `~/.ssh/config`, agendi puudumine):
+
+```bash
+env -i HOME=/home/mf PATH=/usr/bin:/bin /bin/sh -c \
+  'rsync --list-only vutt-backup:state/users.json'
 ```
 
 Logide kontroll:

--- a/scripts/vutt_backup.py
+++ b/scripts/vutt_backup.py
@@ -27,6 +27,19 @@ DEFAULT_SOURCE_ROOT = "~/VUTT"
 DEFAULT_DEST_ROOT = "~/vutt-backups"
 LOCK_FILENAME = ".vutt_backup.lock"
 
+# Tuletatud vahemälud, mida EI varundata. Need taastuvad ise ega ole andmed.
+#
+# `historical_regions_cache/` on lisaks LOETAMATU: backend kirjutab need Dockerist
+# root'ina moodiga 0600, aga rsync jookseb `meelisf`-ina → "Permission denied" ja
+# rsync exit 23 (2026-08-04 esimene backup kukkus täpselt selle taha).
+#
+# NB: see nimekiri on TAHTLIKULT lühike. Iga uus loetamatu fail state/-is peab
+# backupi katki tegema, mitte vaikselt vahele jääma — muidu ei saa kunagi teada,
+# et midagi jäi varundamata.
+DEFAULT_EXCLUDES = [
+    "historical_regions_cache/",
+]
+
 
 def _expand(path: str) -> Path:
     return Path(path).expanduser().resolve()
@@ -64,6 +77,20 @@ def latest_snapshot(snapshots_dir: Path) -> Path | None:
     return sorted(candidates)[-1] if candidates else None
 
 
+def latest_partial(snapshots_dir: Path) -> Path | None:
+    """Pooleli jäänud snapshot, mille pealt saab jätkata.
+
+    Ebaõnnestunud jooksu `.partial` jäetakse tahtlikult alles: 40 GB uuesti
+    tõmbamine mõne loetamatu faili pärast on ebaproportsionaalne. rsync võrdleb
+    sihtkohas juba olemasolevaid faile ja jätab identsed vahele, seega jätkamine
+    on odav.
+    """
+    if not snapshots_dir.exists():
+        return None
+    candidates = [p for p in snapshots_dir.iterdir() if p.is_dir() and p.name.endswith(".partial")]
+    return sorted(candidates)[-1] if candidates else None
+
+
 def run_rsync(
     *,
     source: str,
@@ -71,6 +98,7 @@ def run_rsync(
     previous_destination: Path | None,
     ssh_command: str | None,
     dry_run: bool,
+    excludes: list[str] | None = None,
 ) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     cmd = [
@@ -81,6 +109,8 @@ def run_rsync(
         "--delete-excluded",
         "--info=stats2,progress2",
     ]
+    for pattern in excludes or []:
+        cmd.append(f"--exclude={pattern}")
     if dry_run:
         cmd.append("--dry-run")
     if ssh_command:
@@ -130,7 +160,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--healthcheck-url", default=os.getenv("VUTT_BACKUP_HEALTHCHECK_URL"))
     parser.add_argument("--keep-days", type=int, default=int(os.getenv("VUTT_BACKUP_KEEP_DAYS", "0")), help="0 = ära kustuta vanu snapshot'e")
     parser.add_argument("--dry-run", action="store_true")
-    parser.add_argument("--keep-partial", action="store_true", help="jäta ebaõnnestunud .partial kataloog alles debugimiseks")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=list(DEFAULT_EXCLUDES),
+        # argparse append+default: antud mustrid LISANDUVAD vaikeväärtustele, ei asenda neid
+        help="rsync exclude-muster; korratav, lisandub vaikeväärtustele (" + ", ".join(DEFAULT_EXCLUDES) + ")",
+    )
+    parser.add_argument(
+        "--discard-partial",
+        action="store_true",
+        help="kustuta ebaõnnestunud .partial kataloog (vaikimisi jäetakse alles, et järgmine jooks saaks jätkata)",
+    )
     return parser.parse_args()
 
 
@@ -150,8 +191,14 @@ def main() -> int:
             return 2
 
         previous = latest_snapshot(snapshots_dir)
-        stamp = _timestamp()
-        partial = snapshots_dir / f"{stamp}.partial"
+        # Dry-run ei tohi päris pooleliolevat snapshot'i kaaperdada ega kustutada.
+        resumed = None if args.dry_run else latest_partial(snapshots_dir)
+        if resumed is not None:
+            partial = resumed
+            stamp = partial.name[: -len(".partial")]
+        else:
+            stamp = _timestamp()
+            partial = snapshots_dir / f"{stamp}.partial"
         final = snapshots_dir / stamp
 
         ping(args.healthcheck_url, "/start")
@@ -162,10 +209,12 @@ def main() -> int:
             else:
                 log("Eelmist snapshot'i pole; teen täiskoopia")
 
-            if partial.exists():
+            if resumed is not None:
+                log(f"Jätkan pooleli jäänud snapshot'ist: {partial}")
+            elif partial.exists():
                 shutil.rmtree(partial)
-            (partial / "data").mkdir(parents=True)
-            (partial / "state").mkdir(parents=True)
+            (partial / "data").mkdir(parents=True, exist_ok=True)
+            (partial / "state").mkdir(parents=True, exist_ok=True)
             chmod_state_private(partial / "state")
 
             run_rsync(
@@ -174,6 +223,7 @@ def main() -> int:
                 previous_destination=(previous / "data") if previous else None,
                 ssh_command=args.ssh_command,
                 dry_run=args.dry_run,
+                excludes=args.exclude,
             )
             run_rsync(
                 source=remote_path(args.source_host, args.source_root, "state"),
@@ -181,6 +231,7 @@ def main() -> int:
                 previous_destination=(previous / "state") if previous else None,
                 ssh_command=args.ssh_command,
                 dry_run=args.dry_run,
+                excludes=args.exclude,
             )
             chmod_state_private(partial / "state")
 
@@ -197,8 +248,11 @@ def main() -> int:
         except Exception as exc:  # noqa: BLE001 - cronis tahame iga vea logida ja pingida
             log(f"VIGA: backup ebaõnnestus: {exc}")
             ping(args.healthcheck_url, "/fail", str(exc))
-            if partial.exists() and not args.keep_partial:
-                shutil.rmtree(partial, ignore_errors=True)
+            if partial.exists():
+                if args.discard_partial:
+                    shutil.rmtree(partial, ignore_errors=True)
+                else:
+                    log(f"Pooleli jäänud snapshot jäetakse alles, järgmine jooks jätkab: {partial}")
             return 1
 
 


### PR DESCRIPTION
## Mis juhtus

Esimene päris backup loss-serverisse (2026-08-04, 40 GB, ~1 h) kukkus lõpus läbi:

```
rsync: [sender] send_files failed to open ".../state/historical_regions_cache/<hash>.json": Permission denied (13)
… ×100
rsync error: some files/attrs were not transferred (code 23)
```

`state/historical_regions_cache/` failid on backendi poolt Dockerist kirjutatud
`-rw------- root root`, rsync jookseb `meelisf`-ina. Ülejäänud root-omanikuga `state/`
failid (`users.json`, `invite_tokens.json`, `notifications/`) on 0644 ja tulid probleemideta;
`data/`-l seda muret ei ole, sest `server_update.sh` teeb `sudo chown -R meelisf:meelisf data/`.

Skript kustutas ebaõnnestumisel `.partial` kataloogi → **59 MB kataloogi õiguste viga
hävitas tunni jagu juba tõmmatud 40 GB-d.**

## Parandused

1. **`DEFAULT_EXCLUDES` + korratav `--exclude`** — vahemälu on tuletatud (Overpass/Wikidata,
   taastub ise) ja loetamatu. Nimekiri on **tahtlikult lühike**: iga uus loetamatu fail peab
   backupi katki tegema, mitte vaikselt vahele jääma, muidu ei saa kunagi teada, et midagi
   jäi varundamata.
2. **`.partial` jäetakse ebaõnnestumisel alles** ja järgmine jooks jätkab sealt — rsync jätab
   sihtkohas juba olemasolevad identsed failid vahele. Kustutamiseks `--discard-partial`.
   Kuivkäitus ei kaaperda ega kustuta päris `.partial`-it.
3. **Dokumentatsioon:** loetavuse eelkontroll allikas.

## Miks `--dry-run` seda ei tabanud

rsync ehitab kuivkäitusel ainult failinimekirja (`readdir` + `stat`) ega **ava** faile —
`failed to open` tuleb välja alles päris ülekandel. Kataloog ise on `drwxr-xr-x`, seega
loetlemine õnnestus. Päris kontroll on:

```bash
ssh vutt 'find ~/VUTT/state ~/VUTT/data ! -readable'
```

Väljund praegu: täpselt 100 faili, kõik excluded kataloogis. Mujal midagi.

## Kontrollitud

- Kuivkäitus uue skriptiga läbib mõlemad sammud (`data/` + `state/`) puhtalt.
- Päris tõmme käivitatud uuesti 17:39, jookseb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)