### PR TITLE
fix(prosopo): ära ravi kohanimesid ega mitte-inglise kokkulangevusi

### DIFF
--- a/server/entity_labels_ops.py
+++ b/server/entity_labels_ops.py
@@ -78,33 +78,35 @@ def _collect_qcodes(metadata):
     return qcodes
 
 
-# Entiteedi-pesad: (id-võti, labels-võti). Kasutatakse nii Q-koodide
-# kogumiseks kui inline labels täitmiseks.
+# Entiteedi-pesad: (obj, id-võti, labels-võti, is_place). Kasutatakse nii
+# Q-koodide kogumiseks kui inline labels täitmiseks. `is_place` märgib
+# kohanime-pesad, kus AJALOOLINE nimi (Reval, Dorpat, Elbing) on tahtlik
+# ega tohi Wikidata moodsa nimega asenduda.
 def _entity_slots(person):
-    """Tagastab [(obj, id_key, labels_key)] kõigi entiteedi-pesade kohta."""
+    """Tagastab [(obj, id_key, labels_key, is_place)] kõigi entiteedi-pesade kohta."""
     slots = []
     for parent_key in ("birth", "death"):
         parent = person.get(parent_key)
         if isinstance(parent, dict) and isinstance(parent.get("place"), dict):
-            slots.append((parent["place"], "id", "labels"))
+            slots.append((parent["place"], "id", "labels", True))
     origin = person.get("origin")
     if isinstance(origin, dict):
-        slots.append((origin, "place_id", "place_labels"))
+        slots.append((origin, "place_id", "place_labels", True))
     for key in ("statuses", "confessions", "tags"):
         for item in person.get(key) or []:
             if isinstance(item, dict):
-                slots.append((item, "id", "labels"))
+                slots.append((item, "id", "labels", False))
     for occ in person.get("occupations") or []:
         if isinstance(occ, dict):
-            slots.append((occ, "id", "labels"))
-            slots.append((occ, "institution_id", "institution_labels"))
+            slots.append((occ, "id", "labels", False))
+            slots.append((occ, "institution_id", "institution_labels", False))
     for edu in person.get("education") or []:
         if isinstance(edu, dict):
-            slots.append((edu, "institution_id", "institution_labels"))
-            slots.append((edu, "id", "labels"))
+            slots.append((edu, "institution_id", "institution_labels", False))
+            slots.append((edu, "id", "labels", False))
     for rel in person.get("relations") or []:
         if isinstance(rel, dict):
-            slots.append((rel, "type", "type_labels"))
+            slots.append((rel, "type", "type_labels", False))
     return slots
 
 
@@ -118,7 +120,7 @@ def _slot_qcode(obj, id_key):
 def collect_entity_qcodes(person):
     """Kogub kõik Q-koodid prosopograafia kirje entiteedi-väljadelt."""
     qcodes = set()
-    for obj, id_key, _labels_key in _entity_slots(person):
+    for obj, id_key, _labels_key, _is_place in _entity_slots(person):
         qid = _slot_qcode(obj, id_key)
         if qid:
             qcodes.add(qid)
@@ -126,21 +128,26 @@ def collect_entity_qcodes(person):
 
 
 def _heal_stub_labels(merged, existing, reg):
-    """Asendab pseudo-tõlked registri omadega (kohapeal, `merged` sees).
+    """Asendab INGLISKEELSE koopia registri tõlkega (kohapeal, `merged` sees).
 
-    Kui inline `labels[lang]` on täht-täheline koopia mõne teise keele
-    labelist (nt EntityPicker kirjutas `et`-sse ingliskeelse otsingutulemuse,
-    sest Wikidatas polnud tol hetkel eestikeelset silti) ja registris on
-    selle keele jaoks päris tõlge, võtab registri väärtuse. Gap-fill üksi
-    ei paranda seda KUNAGI, sest väli ei ole tühi.
+    EntityPicker kirjutas Wikidata-valikul teise keele pessa (nt `et`)
+    ingliskeelse otsingutulemuse, kui Wikidatas polnud tol hetkel selle
+    keele silti. Gap-fill ei paranda seda KUNAGI, sest väli ei ole tühi.
+
+    Rangelt ainult ingliskeelne koopia: kahe MITTE-inglise keele kokkulangevus
+    on tavaline ja tahtlik (sv „Reval" = de „Reval", sv „Elbing" = et „Elbing")
+    ning selle „parandamine" hävitaks ajaloolise nimekuju.
     """
+    english = existing.get("en")
+    if not isinstance(english, str) or not english.strip():
+        return
     for lang, reg_val in reg.items():
+        if lang == "en":
+            continue
         current = merged.get(lang)
         if not current or current.lower() == reg_val.lower():
             continue
-        others = [v for other_lang, v in existing.items()
-                  if other_lang != lang and isinstance(v, str)]
-        if any(current.lower() == other.lower() for other in others):
+        if current.lower() == english.lower():
             merged[lang] = reg_val
 
 
@@ -150,7 +157,7 @@ def fill_entity_labels(person, registry, heal_stubs=False):
     `heal_stubs=True` lisaks parandab pseudo-tõlked (vt `_heal_stub_labels`).
     """
     changed = 0
-    for obj, id_key, labels_key in _entity_slots(person):
+    for obj, id_key, labels_key, is_place in _entity_slots(person):
         qid = _slot_qcode(obj, id_key)
         if not qid or qid not in registry:
             continue
@@ -163,7 +170,9 @@ def fill_entity_labels(person, registry, heal_stubs=False):
         # Registri väärtused täidavad AUGUD; olemasolevad keeled jäävad peale
         merged = {**reg, **{k: v for k, v in existing.items()
                             if isinstance(v, str) and v.strip()}}
-        if heal_stubs:
+        # Kohanime-pesi EI ravita: seal on ajalooline nimi (Reval, Dorpat)
+        # tahtlik ja Wikidata moodne nimi oleks vale.
+        if heal_stubs and not is_place:
             _heal_stub_labels(merged, existing, reg)
         if merged != existing:
             obj[labels_key] = merged

--- a/tests/test_entity_labels.py
+++ b/tests/test_entity_labels.py
@@ -174,3 +174,46 @@ def test_sync_prosopography_inline_labels_noop_without_changes(tmp_path, monkeyp
 
     assert elo.sync_prosopography_inline_labels(
         registry={"Q1": {"et": "iks", "en": "X"}}) == {"files": 0, "slots": 0}
+
+
+# --- heal_stubs: mida EI TOHI puutuda (päris andmete regressioonid) -------
+
+def test_heal_stubs_never_touches_place_labels():
+    """Ajalooline kohanimi (Reval, Elbing) EI tohi Wikidata moodsaks muutuda."""
+    person = {
+        "origin": {"place": "Reval", "place_id": "Q1770",
+                   "place_labels": {"et": "Tallinn", "en": "Tallinn",
+                                    "de": "Reval", "la": "Revalia", "sv": "Reval"}},
+        "birth": {"place": {"id": "Q104712",
+                            "labels": {"et": "Elbing", "en": "Elbląg",
+                                       "de": "Elbląg", "sv": "Elbing"}}},
+    }
+    registry = {
+        "Q1770": {"et": "Tallinn", "en": "Tallinn", "de": "Tallinn", "la": "Revalia"},
+        "Q104712": {"et": "Elbląg", "en": "Elbląg", "de": "Elbląg"},
+    }
+    changed = elo.fill_entity_labels(person, registry, heal_stubs=True)
+    assert person["origin"]["place_labels"]["de"] == "Reval"
+    assert person["origin"]["place_labels"]["sv"] == "Reval"
+    assert person["birth"]["place"]["labels"]["et"] == "Elbing"
+    assert changed == 0
+
+
+def test_heal_stubs_ignores_non_english_coincidence():
+    """sv == de kokkulangevus ei ole pseudo-tõlge — ei paranda."""
+    person = {"occupations": [{"id": "Q1",
+                               "labels": {"et": "kroonik", "en": "chronicler",
+                                          "de": "Chronist", "sv": "Chronist"}}]}
+    registry = {"Q1": {"et": "kroonik", "en": "chronicler", "de": "Chronist", "sv": "krönikör"}}
+    changed = elo.fill_entity_labels(person, registry, heal_stubs=True)
+    assert person["occupations"][0]["labels"]["sv"] == "Chronist"
+    assert changed == 0
+
+
+def test_heal_stubs_needs_inline_english():
+    """Ilma inline `en`-ita pole võrdlusalust — ei muuda midagi."""
+    person = {"occupations": [{"id": "Q1", "labels": {"et": "Professor of medicine"}}]}
+    registry = {"Q1": {"et": "meditsiiniprofessor", "en": "professor of medicine"}}
+    elo.fill_entity_labels(person, registry, heal_stubs=True)
+    # gap-fill lisab en, aga et jääb (pole tõestust, et see on koopia)
+    assert person["occupations"][0]["labels"]["et"] == "Professor of medicine"


### PR DESCRIPTION
Järelparandus PR #213-le.

## Mis läks valesti

#213 heal-reegel luges pseudo-tõlkeks iga juhu, kus inline `labels[lang]` langes kokku MÕNE teise keele väärtusega. Kohanimede juures on see kokkulangevus tavaline ja tahtlik:

- `sv: "Reval"` == `de: "Reval"` → reegel kirjutas `de`-sse Wikidata moodsa `"Tallinn"`
- `sv: "Elbing"` == `et: "Elbing"` → `"Elbląg"`

Produktsioonis puudutas see 29 kaarti. Andmed on serveris taastatud (`data`-repo commit `91480ddd9`, `git revert`).

## Parandus

- heal võrdleb ainult inline `en` väärtusega — täpselt see muster, mille EntityPicker tekitas (ingliskeelne otsingutulemus `et`-pessa)
- kohanime-pesad (`birth`/`death` place, `origin.place_labels`) on healist täielikult väljas
- `_entity_slots` tagastab 4-korteeži `is_place` lipuga
- regressioonitestid Revali, Elbingi ja sv/de kokkulangevuse peale

## Kontroll

Kuivkäivitus kõigi 2353 produktsioonikaardi ja päris `labels.json` vastu: **3 kaarti, 7 välja** — 6 tühja välja täitmist (Firenze, Rooma, katoliku preester …) + `"Professor of medicine"` → `"meditsiiniprofessor"`. Kohanimede muudatusi ei ole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)