### PR TITLE
fix(prosopo): seose tüübi Q-kood on type_id, mitte type

### DIFF
--- a/server/entity_labels_ops.py
+++ b/server/entity_labels_ops.py
@@ -106,14 +106,18 @@ def _entity_slots(person):
             slots.append((edu, "id", "labels", False))
     for rel in person.get("relations") or []:
         if isinstance(rel, dict):
-            slots.append((rel, "type", "type_labels", False))
+            # Q-kood on `type_id`; vanades kirjetes võib olla `type` sees.
+            slots.append((rel, ("type_id", "type"), "type_labels", False))
     return slots
 
 
 def _slot_qcode(obj, id_key):
-    qid = obj.get(id_key)
-    if isinstance(qid, str) and qid.startswith("Q"):
-        return qid
+    """Pesa Q-kood. `id_key` võib olla korteež — võetakse esimene, mis on Q-kood."""
+    keys = id_key if isinstance(id_key, tuple) else (id_key,)
+    for key in keys:
+        qid = obj.get(key)
+        if isinstance(qid, str) and qid.startswith("Q"):
+            return qid
     return None
 
 
@@ -185,43 +189,83 @@ def fill_person_labels_from_registry(person):
     return fill_entity_labels(person, load_entity_labels())
 
 
-def sync_prosopography_inline_labels(registry=None, username="Automaatne"):
+def _load_prosopography_records(prosopo_dir):
+    """Loeb kõik kaardid: [(path, person)]. Vigased failid jäetakse vahele."""
+    records = []
+    for name in sorted(os.listdir(prosopo_dir)):
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(prosopo_dir, name)
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                records.append((path, json.load(f)))
+        except Exception as e:
+            print(f"LABELS: {name} lugemine ebaõnnestus: {e}")
+    return records
+
+
+def _fetch_missing_into_registry(records, registry):
+    """Toob Wikidatast Q-koodid, mida registris pole või kus mõni sihtkeel puudub.
+
+    Ilma selleta ei jõua kaartidel esinev, aga registrisse kunagi sattumata
+    Q-kood sinna KUNAGI: `refresh_all_entity_labels` värskendab ainult neid
+    koode, mis registris juba on.
+    """
+    qcodes = set()
+    for _path, person in records:
+        qcodes |= collect_entity_qcodes(person)
+    to_fetch = {q for q in qcodes
+                if q not in registry or any(l not in registry[q] for l in _TARGET_LANGS)}
+    if not to_fetch:
+        return 0
+    print(f"LABELS: pärin {len(to_fetch)} puuduvat/poolikut Q-koodi Wikidatast")
+    fetched = _fetch_wikidata_labels(to_fetch)
+    if not fetched:
+        return 0
+    with _LABELS_LOCK:
+        current = load_entity_labels()
+        current.update(fetched)
+        registry.update(fetched)
+        atomic_write_json(LABELS_FILE, current)
+    return len(fetched)
+
+
+def sync_prosopography_inline_labels(registry=None, username="Automaatne", fetch_missing=True):
     """Kannab värske labels.json registri prosopograafia kaartide inline labels'itesse.
 
     Registri värskendamine ÜKSI ei muuda kuvatavat teksti: frontend loeb
     kaardi inline `labels[lang]`-i, mitte registrit. Ilma selle sammuta
     jääb „Värskenda sildid Wikidatast" kasutajale nähtamatuks.
 
+    `fetch_missing=True` toob enne täitmist Wikidatast need kaartidel
+    esinevad Q-koodid, mida registris pole või mis on poolikud.
+
     Kõik muudetud kaardid lähevad ÜHE git-commitiga.
-    Tagastab {"files": n, "slots": m}.
+    Tagastab {"files": n, "slots": m, "fetched": k}.
     """
     from .config import PROSOPOGRAPHY_DIR
     from .git_ops import save_with_git
 
     if registry is None:
         registry = load_entity_labels()
-    if not registry or not os.path.isdir(PROSOPOGRAPHY_DIR):
-        return {"files": 0, "slots": 0}
+    if not os.path.isdir(PROSOPOGRAPHY_DIR):
+        return {"files": 0, "slots": 0, "fetched": 0}
+
+    records = _load_prosopography_records(PROSOPOGRAPHY_DIR)
+    fetched = _fetch_missing_into_registry(records, registry) if fetch_missing else 0
+    if not registry:
+        return {"files": 0, "slots": 0, "fetched": fetched}
 
     changed_files = []
     slots = 0
-    for name in sorted(os.listdir(PROSOPOGRAPHY_DIR)):
-        if not name.endswith(".json"):
-            continue
-        path = os.path.join(PROSOPOGRAPHY_DIR, name)
-        try:
-            with open(path, "r", encoding="utf-8") as f:
-                person = json.load(f)
-        except Exception as e:
-            print(f"LABELS: {name} lugemine ebaõnnestus: {e}")
-            continue
+    for path, person in records:
         n = fill_entity_labels(person, registry, heal_stubs=True)
         if n:
             slots += n
             changed_files.append((path, json.dumps(person, ensure_ascii=False, indent=2)))
 
     if not changed_files:
-        return {"files": 0, "slots": 0}
+        return {"files": 0, "slots": 0, "fetched": fetched}
 
     first_path, first_content = changed_files[0]
     save_with_git(
@@ -230,7 +274,7 @@ def sync_prosopography_inline_labels(registry=None, username="Automaatne"):
         additional_files=changed_files[1:],
     )
     print(f"LABELS: prosopograafia sünk — {len(changed_files)} kaarti, {slots} välja")
-    return {"files": len(changed_files), "slots": slots}
+    return {"files": len(changed_files), "slots": slots, "fetched": fetched}
 
 
 def _collect_qcodes_from_person(person):

--- a/server/routers/public_registries.py
+++ b/server/routers/public_registries.py
@@ -45,7 +45,12 @@ def admin_refresh_entity_labels(user=Depends(require_role("admin"))):
     """
     count = refresh_all_entity_labels()
     synced = sync_prosopography_inline_labels(username=user.get("username", "Automaatne"))
-    return {"updated": count, "persons_updated": synced["files"], "slots_updated": synced["slots"]}
+    return {
+        "updated": count,
+        "persons_updated": synced["files"],
+        "slots_updated": synced["slots"],
+        "fetched_new": synced["fetched"],
+    }
 
 
 # sync def → threadpool: skannib kõiki lehekülje-JSON-e (raske faililugemine)

--- a/tests/test_entity_labels.py
+++ b/tests/test_entity_labels.py
@@ -143,6 +143,8 @@ def test_sync_prosopography_inline_labels_writes_and_commits(tmp_path, monkeypat
 
     monkeypatch.setattr("server.config.PROSOPOGRAPHY_DIR", str(tmp_path), raising=False)
     monkeypatch.setattr("server.git_ops.save_with_git", fake_save, raising=False)
+    # Ükski test ei tohi Wikidatasse minna
+    monkeypatch.setattr(elo, "_fetch_wikidata_labels", lambda q: {})
 
     result = elo.sync_prosopography_inline_labels(
         registry={"Q107555801": {"et": "meditsiiniprofessor", "en": "professor of medicine"},
@@ -150,7 +152,7 @@ def test_sync_prosopography_inline_labels_writes_and_commits(tmp_path, monkeypat
         username="meelis",
     )
 
-    assert result == {"files": 1, "slots": 2}
+    assert result == {"files": 1, "slots": 2, "fetched": 0}
     assert saved["path"] == str(card)
     assert saved["username"] == "meelis"
     assert saved["extra"] == []
@@ -171,9 +173,10 @@ def test_sync_prosopography_inline_labels_noop_without_changes(tmp_path, monkeyp
 
     monkeypatch.setattr("server.config.PROSOPOGRAPHY_DIR", str(tmp_path), raising=False)
     monkeypatch.setattr("server.git_ops.save_with_git", boom, raising=False)
+    monkeypatch.setattr(elo, "_fetch_wikidata_labels", lambda q: {})
 
     assert elo.sync_prosopography_inline_labels(
-        registry={"Q1": {"et": "iks", "en": "X"}}) == {"files": 0, "slots": 0}
+        registry={"Q1": {"et": "iks", "en": "X"}}) == {"files": 0, "slots": 0, "fetched": 0}
 
 
 # --- heal_stubs: mida EI TOHI puutuda (päris andmete regressioonid) -------
@@ -217,3 +220,76 @@ def test_heal_stubs_needs_inline_english():
     elo.fill_entity_labels(person, registry, heal_stubs=True)
     # gap-fill lisab en, aga et jääb (pole tõestust, et see on koopia)
     assert person["occupations"][0]["labels"]["et"] == "Professor of medicine"
+
+
+# --- seose tüüp: Q-kood on type_id, mitte type ---------------------------
+
+def test_collect_qcodes_reads_relation_type_id():
+    """Seose Q-kood elab `type_id`-s; `type` on inimloetav string."""
+    person = {"relations": [{"name": "X", "type": "nephew", "type_id": "Q15224724"}]}
+    assert elo.collect_entity_qcodes(person) == {"Q15224724"}
+
+
+def test_collect_qcodes_relation_legacy_qcode_in_type():
+    """Vanad kirjed hoidsid Q-koodi `type` väljal — jääb toetatuks."""
+    person = {"relations": [{"type": "Q100"}]}
+    assert elo.collect_entity_qcodes(person) == {"Q100"}
+
+
+def test_relation_type_labels_healed_from_registry():
+    """`type_labels.et` == `en` (ingliskeelne koopia) → registri tõlge."""
+    person = {"relations": [{"name": "Jakob Friedrich Below", "type": "nephew",
+                             "type_id": "Q15224724",
+                             "type_labels": {"et": "nephew", "en": "nephew",
+                                             "de": "Neffe", "la": "nepos"}}]}
+    registry = {"Q15224724": {"et": "vennapoeg", "en": "nephew",
+                              "de": "Neffe", "la": "nepos"}}
+    changed = elo.fill_entity_labels(person, registry, heal_stubs=True)
+    assert person["relations"][0]["type_labels"]["et"] == "vennapoeg"
+    assert changed == 1
+
+
+def test_sync_fetches_qcodes_missing_from_registry(tmp_path, monkeypatch):
+    """Kaardil olev, registrist puuduv Q-kood tuuakse Wikidatast."""
+    import json as _json
+    card = tmp_path / "abc.json"
+    card.write_text(_json.dumps({
+        "relations": [{"type": "nephew", "type_id": "Q15224724",
+                       "type_labels": {"et": "nephew", "en": "nephew"}}],
+    }, ensure_ascii=False), encoding="utf-8")
+
+    asked = {}
+
+    def fake_fetch(qcodes):
+        asked["qcodes"] = set(qcodes)
+        return {"Q15224724": {"et": "vennapoeg", "en": "nephew", "de": "Neffe", "la": "nepos"}}
+
+    written = {}
+    monkeypatch.setattr("server.config.PROSOPOGRAPHY_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(elo, "_fetch_wikidata_labels", fake_fetch)
+    monkeypatch.setattr(elo, "load_entity_labels", lambda: {})
+    monkeypatch.setattr(elo, "atomic_write_json", lambda path, data: written.update({"data": data}))
+    monkeypatch.setattr("server.git_ops.save_with_git",
+                        lambda path, content, username, message=None, additional_files=None:
+                        open(path, "w", encoding="utf-8").write(content), raising=False)
+
+    result = elo.sync_prosopography_inline_labels(registry={}, username="meelis")
+
+    assert asked["qcodes"] == {"Q15224724"}
+    assert written["data"]["Q15224724"]["et"] == "vennapoeg"
+    assert result["fetched"] == 1
+    assert result["files"] == 1
+    assert _json.loads(card.read_text(encoding="utf-8"))["relations"][0]["type_labels"]["et"] == "vennapoeg"
+
+
+def test_sync_skips_fetch_when_disabled(tmp_path, monkeypatch):
+    import json as _json
+    (tmp_path / "abc.json").write_text(_json.dumps({"relations": [{"type_id": "Q1"}]}), encoding="utf-8")
+
+    def boom(_qcodes):
+        raise AssertionError("fetch_missing=False ei tohi Wikidatasse minna")
+
+    monkeypatch.setattr("server.config.PROSOPOGRAPHY_DIR", str(tmp_path), raising=False)
+    monkeypatch.setattr(elo, "_fetch_wikidata_labels", boom)
+    assert elo.sync_prosopography_inline_labels(
+        registry={}, fetch_missing=False) == {"files": 0, "slots": 0, "fetched": 0}


### PR DESCRIPTION
Miks Below'l on endiselt „Jakob Friedrich Below (nephew)", kuigi Wikidatas on eestikeelne „vennapoeg" olemas.

## Kaks viga ühes

1. **`_entity_slots` luges seose Q-koodi väljalt `type`**, kus on inimloetav string („nephew"), mitte `type_id`. Seose sildid jäid seetõttu iga täitmise/ravi juurest vahele.
2. **Q-kood ei jõudnud kunagi `labels.json`-i** — `collect_entity_qcodes` kasutab sama pesade nimekirja, ja `refresh_all_entity_labels` värskendab ainult koode, mis registris juba on. `Q15224724` puudus registrist täielikult.

Nii jäi „nephew" alles ka pärast seda, kui Wikidatasse eestikeelne silt lisati.

## Parandus

- `_slot_qcode` võtab korteeži: `("type_id", "type")`. Vanad kirjed, kus Q-kood oli `type` sees, jäävad toetatuks (test olemas).
- `sync_prosopography_inline_labels(fetch_missing=True)` toob enne täitmist Wikidatast kaartidel esinevad, registrist puuduvad või poolikud Q-koodid. Endpoint tagastab `fetched_new`.
- Kaks vana testi patchivad nüüd `_fetch_wikidata_labels` — üks neist tegi enne päris võrgupäringu Wikidatasse (CI-s samuti).

## Kuivkäivitus päris andmetel (2353 kaarti)

- Q-koode kaartidel: 260, neist registrist puudu/poolik **136** → Wikidatast saadi 129 (peamiselt seosetüübid, mis polnud kunagi kogutud)
- kaartidel muutub **1 väli**: `relations[0].type_labels.et: "nephew" → "vennapoeg"`
- kohanimesid ega muid kureeritud silte ei puutu

🤖 Generated with [Claude Code](https://claude.com/claude-code)