### PR TITLE
Re-OCR avaldab pildid .tmp+rename-ga (#220)

### DIFF
--- a/docs/decisions/0017-poolitamine-enne-ocr.md
+++ b/docs/decisions/0017-poolitamine-enne-ocr.md
@@ -162,8 +162,13 @@ kasutajat hoiatust eirama — see on halvem kui hoiatuse puudumine.
 tuleks veeru skoori **suhtena lehe enda veergude jaotusesse** (kas x on tugev
 lokaalne miinimum või maksimum), mitte fikseeritud protsentiili vastu.
 
-## Teadaolev, siin mitte parandatud
+## Järeltöö: aatomiline avaldamine on nüüd jagatud (#220)
 
-`reocr_ops.start_reocr_batch` kirjutab OCR-serverisse otse sihtnimega, ilma
-`.tmp`+rename-ta, ja jagab sedasama võistlusolukorda. Vt issue #220.
+`reocr_ops` kirjutas OCR-serverisse otse sihtnimega ja jagas sedasama
+võistlusolukorda. 2026-08-08 tõsteti `publish_atomic` `prepress_apply.py`-st
+`upload/ocr_client.py`-sse ja mõlemad re-OCR teed (partii + üksik) kutsuvad
+nüüd sama teostust. `prepress_apply.publish_atomic` jäi re-ekspordiks.
+
+Valvur: `tests/test_reocr_atomic_publish.py` kontrollib nii mustrit ennast kui
+seda, et `reocr_ops` lähtekoodis ei oleks enam ühtki otse `sftp.put()` kutset.
 

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Tuple
 from .config import BASE_DIR, OCR_SERVER_PATH, REOCR_LOG_FILE, UPLOAD_ENABLED, get_logger
 from .utils import atomic_write_json, generate_nanoid
 from .upload_ops import _sftp_open, close_ssh
+from .upload.ocr_client import publish_atomic
 from . import reocr_state
 from .heartbeat import mark_error, mark_success, register_job
 
@@ -204,7 +205,8 @@ def start_reocr_batch(work_id: str, slug: str, work_path: str,
                     sftp.mkdir(d)
             for entry in page_entries:
                 src = os.path.join(work_path, entry["page_filename"])
-                sftp.put(src, f"{work_abs}/{entry['remote_img_name']}")
+                # .tmp+rename: valvur ei kontrolli piltide stabiilsust (#220)
+                publish_atomic(sftp, src, f"{work_abs}/{entry['remote_img_name']}")
                 with _reocr_batch_jobs_lock:
                     current = _reocr_batch_jobs.get(job_id)
                     if current and current.get("status") == "uploading":
@@ -642,7 +644,8 @@ def start_reocr_job(work_id: str, slug: str, img_path: str, page_filename: str =
                 except FileNotFoundError:
                     sftp.mkdir(d)
             img_abs = f"{OCR_SERVER_PATH}/{remote_work}/{remote_img_name}"
-            sftp.put(img_path, img_abs)
+            # .tmp+rename: valvur ei kontrolli piltide stabiilsust (#220)
+            publish_atomic(sftp, img_path, img_abs)
             sftp.close()
             with _reocr_jobs_lock:
                 current = _reocr_jobs.get(job_id)

--- a/server/upload/ocr_client.py
+++ b/server/upload/ocr_client.py
@@ -149,6 +149,25 @@ def ensure_remote_dirs(sftp, remote_dirs):
             sftp.mkdir(remote_dir)
 
 
+def publish_atomic(sftp, local_path: str, remote_path: str) -> None:
+    """Laeb üles .tmp nimega ja nimetab alles siis ümber.
+
+    OCR-serveri valvuril EI OLE piltide jaoks stabiilsuskontrolli —
+    wait_for_file_stable() kutsutakse seal ainult PDF-ide peale. Pildid
+    korjatakse rglob-iga, filtrina EXTENSIONS = {".jpg", ".jpeg", ...}.
+    Poolik JPG satuks OCR-i; .jpg.tmp jääb filtrist välja.
+
+    Kataloogi tervikuna EI varjata: valvur töötab pildi kaupa, nii et poolik
+    kataloog on konveier, mille me tahame alles jätta.
+
+    Siin, mitte kummagi kutsuja juures: nii prepress (ADR 0017) kui re-OCR
+    (#220) avaldavad OCR-serverisse ja jagavad sama võistlusolukorda.
+    """
+    tmp_remote = remote_path + ".tmp"
+    sftp.put(local_path, tmp_remote)
+    sftp.rename(tmp_remote, remote_path)
+
+
 def close_sftp_and_unlink(sftp, tmp_path: str):
     """Taustalõime finally-puhastus: sulge SFTP seanss ja kustuta ajutine fail."""
     if sftp:

--- a/server/upload/prepress_apply.py
+++ b/server/upload/prepress_apply.py
@@ -24,20 +24,9 @@ def remote_page_name(slug: str, out_index: int) -> str:
     return "{}_pg_{:03d}.jpg".format(slug, out_index)
 
 
-def publish_atomic(sftp, local_path: str, remote_path: str) -> None:
-    """Laeb üles .tmp nimega ja nimetab alles siis ümber.
-
-    OCR-serveri valvuril EI OLE piltide jaoks stabiilsuskontrolli —
-    wait_for_file_stable() kutsutakse seal ainult PDF-ide peale. Pildid
-    korjatakse rglob-iga, filtrina EXTENSIONS = {".jpg", ".jpeg", ...}.
-    Poolik JPG satuks OCR-i; .jpg.tmp jääb filtrist välja.
-
-    Kataloogi tervikuna EI varjata: valvur töötab pildi kaupa, nii et poolik
-    kataloog on konveier, mille me tahame alles jätta.
-    """
-    tmp_remote = remote_path + ".tmp"
-    sftp.put(local_path, tmp_remote)
-    sftp.rename(tmp_remote, remote_path)
+# Aatomiline avaldamine elab ocr_client.py-s — sama teostust kasutab ka re-OCR
+# (#220). Nimi jääb siia re-ekspordina, sest kutsujad ja testid tunnevad seda.
+publish_atomic = ocr_client.publish_atomic
 
 
 def _write_cut(src_img_path: str, x0: int, x1: int, dst: str) -> None:

--- a/tests/test_reocr_atomic_publish.py
+++ b/tests/test_reocr_atomic_publish.py
@@ -1,0 +1,98 @@
+"""Re-OCR avaldab pildid OCR-serverisse aatomiliselt (#220).
+
+OCR-serveri valvur korjab pildid rglob-iga ja filtreerib laiendi järgi;
+stabiilsuskontroll (`wait_for_file_stable`) kutsutakse seal AINULT PDF-ide
+peale. Poolik .jpg satuks seega OCR-i. Prepress lahendas selle
+`.tmp`+rename-ga (ADR 0017); re-OCR kirjutas kaua otse sihtnimega.
+"""
+import pytest
+
+from server.upload import ocr_client
+
+
+class FakeSftp:
+    """Salvestab put/rename järjekorra, et saaks kontrollida avaldamise mustrit."""
+
+    def __init__(self):
+        self.events = []      # ("put", tee) / ("rename", vana, uus)
+        self.dirs = set()
+        self.closed = False
+
+    def put(self, local, remote, callback=None):
+        self.events.append(("put", remote))
+
+    def rename(self, src, dst):
+        self.events.append(("rename", src, dst))
+
+    def stat(self, path):
+        if path not in self.dirs:
+            raise FileNotFoundError(path)
+        return object()
+
+    def mkdir(self, path):
+        self.dirs.add(path)
+
+    def close(self):
+        self.closed = True
+
+
+# --- jagatud abiline ---
+
+def test_publish_atomic_elab_ocr_client_is():
+    """Üks teostus, mida mõlemad teed kutsuvad — mitte koopia kummalgi pool."""
+    assert callable(ocr_client.publish_atomic)
+
+
+def test_publish_atomic_laeb_tmp_nimega_ja_nimetab_ymber(tmp_path):
+    local = tmp_path / "a.jpg"
+    local.write_bytes(b"jpeg")
+    sftp = FakeSftp()
+
+    ocr_client.publish_atomic(sftp, str(local), "/remote/x_pg_001.jpg")
+
+    assert sftp.events == [
+        ("put", "/remote/x_pg_001.jpg.tmp"),
+        ("rename", "/remote/x_pg_001.jpg.tmp", "/remote/x_pg_001.jpg"),
+    ]
+
+
+def test_prepress_kasutab_sama_teostust():
+    """prepress_apply.publish_atomic peab olema SAMA objekt, mitte teine koopia."""
+    from server.upload import prepress_apply
+
+    assert prepress_apply.publish_atomic is ocr_client.publish_atomic
+
+
+# --- re-OCR teed ---
+
+def test_batch_reocr_avaldab_aatomiliselt(monkeypatch, tmp_path):
+    """Partii-re-OCR: iga pilt .tmp-na üles, alles siis õigele nimele."""
+    from server import reocr_ops
+
+    sftp = FakeSftp()
+    src = tmp_path / "001.jpg"
+    src.write_bytes(b"jpeg")
+
+    reocr_ops.publish_atomic(sftp, str(src), "/o/work/slug_pg_001.jpg")
+
+    assert ("put", "/o/work/slug_pg_001.jpg.tmp") in sftp.events
+    assert ("rename", "/o/work/slug_pg_001.jpg.tmp",
+            "/o/work/slug_pg_001.jpg") in sftp.events
+    # Otse sihtnimega ei tohi kirjutada — see on kogu mõte.
+    assert ("put", "/o/work/slug_pg_001.jpg") not in sftp.events
+
+
+def test_reocr_ops_ei_kasuta_enam_otse_put_i():
+    """Valvur: reocr_ops lähtekoodis ei tohi olla sftp.put() sihtnimega.
+
+    See on tekstipõhine kontroll, sest mõlemad üleslaadimisteed elavad
+    taustalõimede sees, mida on kallis tervikuna käivitada.
+    """
+    import inspect
+
+    from server import reocr_ops
+
+    source = inspect.getsource(reocr_ops)
+    assert "sftp.put(" not in source, (
+        "reocr_ops kutsub veel otse sftp.put() — kasuta publish_atomic()"
+    )

--- a/tests/test_reocr_batch.py
+++ b/tests/test_reocr_batch.py
@@ -46,6 +46,9 @@ class _FakeSftp:
     def put(self, local, remote):
         with open(local, "rb") as f:
             self.store[remote] = f.read()
+    def rename(self, src, dst):
+        # Pildid avaldatakse .tmp+rename-ga (#220) — päris SFTPClient oskab seda.
+        self.store[dst] = self.store.pop(src)
     def close(self):
         pass
 


### PR DESCRIPTION
Sulgeb #220. Järeltöö ADR 0017-le: prepress lahendas selle võistlusolukorra, re-OCR mitte.

## Probleem

OCR-serveri valvur korjab pildid `rglob`-iga ja filtreerib laiendi järgi. Stabiilsuskontroll `wait_for_file_stable()` kutsutakse seal **ainult PDF-ide peale** — piltidele mitte. Poolik `.jpg` võib seega sattuda OCR-i, kui valvuri skann tabab üleslaadimise keskele.

Aken on kitsas (üks `put` LAN-is), mistõttu seda pole tootmises kinni püütud — aga see on täpselt sama olukord, mille tõttu prepress-teel tehti `publish_atomic`.

## Lahendus

`publish_atomic` tõsteti `upload/prepress_apply.py`-st `upload/ocr_client.py`-sse — SFTP-kihti, kus ta kuulub, sest **mõlemad** teed avaldavad OCR-serverisse. Mõlemad re-OCR teed (partii `start_reocr_batch` ja üksikleht) kutsuvad nüüd sama teostust. `prepress_apply.publish_atomic` jäi re-ekspordiks, sest kutsujad ja testid tunnevad seda nime.

`.jpg.tmp` jääb valvuri laiendifiltrist välja; rename samas failisüsteemis on aatomiline.

## Testid

Uus `tests/test_reocr_atomic_publish.py` (5 testi):
- avaldamise muster ise (`put` .tmp-le → `rename`)
- **üks teostus**, mitte koopia kummalgi pool (`prepress_apply.publish_atomic is ocr_client.publish_atomic`)
- valvur: `reocr_ops` lähtekoodis ei tohi olla ühtki otse `sftp.put()` kutset

`test_reocr_batch.py` `_FakeSftp` sai `rename`-meetodi — päris `SFTPClient` oskab seda, test-double lihtsalt ei osanud. Selle testi olemasolev lõppkontroll (pilt jõuab õige remote-nimega kohale) käib nüüd renamest läbi.

1170 testi rohelised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)