### PR TITLE
Re-OCR töö katkestamine (#217)

### DIFF
--- a/docs/decisions/0018-reocr-katkestamine.md
+++ b/docs/decisions/0018-reocr-katkestamine.md
@@ -1,0 +1,69 @@
+# ADR 0018 — Re-OCR töö katkestamine
+
+**Kuupäev:** 2026-08-08
+**Staatus:** vastu võetud
+**Issue:** #217 · **Spekk:** `docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md`
+
+## Kontekst
+
+Käimasolevat re-OCR tööd ei saanud katkestada. Valesti käivitatud töö puhul jäi ainsaks
+võimaluseks oodata `REOCR_ABSOLUTE_TIMEOUT` = 12 h täitumist; vahepeal andis
+`get_active_batch_for_work()` uuele batch'ile 409 ja teos oli lukus.
+
+Intsident 2026-08-07: batch käivitati käsikirja-mudelil topeltlehtedega. Käsitsi
+puhastamine nõudis backendi seiskamist ja `reocr_active.json` muutmist — tootmise katkestust.
+
+## Otsus
+
+`DELETE /admin/reocr/{job_id}` katkestab töö. **Semantika: tööd ei olnud.**
+
+## Invariandid
+
+- **Osalisi tulemusi ei säilitata.** OCR jookseb taustal — katkestamine ei võida aega, vaid
+  annab suvalise algusprefiksi valmis lehtedest. Väiksem maht tuleb valida käivitamisel ja
+  lehti hiljem juurde lisada.
+- **`.ocr` omand tuleb `produced_pages`-ist, mitte plaanist.** Batch-mapping ütleb, mida
+  töö PLAANIS teha; `produced_pages` ütleb, mida ta PÄRISELT kirjutas. Kustutamine plaani
+  järgi hävitaks varasema ootel tulemuse lehel, mida katkestatud töö ei jõudnud puutuda.
+- **Ülekirjutamine varundatakse.** `_write_ocr_file` nihutab olemasoleva `.ocr` faili
+  `state/reocr_backups/{job_id}/` alla; katkestamine taastab, normaalne lõpp kustutab.
+  **Varukoopia EI TOHI minna teose kausta:** `data/.gitignore` ignoreerib `*.ocr`, aga
+  varukoopia nimi ei vastaks mustrile ja ilmuks `git status`-isse.
+- **`cancelling` on persisteeritud vaheolek.** `_ACTIVE_STATUSES` sisaldab seda, muidu
+  kaoks pooleli jäänud katkestamine `reocr_active.json`-ist ja muutuks restardi järel
+  taas aktiivseks tööks.
+- **Terminalüleminekud on vastastikku välistavad.** `processing → done` ja
+  `processing → cancelling` käivad sama luku all CAS-ina; katkestamise võidu järel ei tohi
+  ükski worker enam `ready`/`done`/`error` kirjutada.
+- **Workerid vaigistatakse ENNE koristust, aga erineval viisil.** Üleslaadimine on
+  töö-põhine lõim → `Event` + `join`. Poll on **jagatud singleton** (üks iteratsioon iga
+  10 s kõigi tööde üle) → teda ei saa join'ida, teda vaigistab sama CAS. Kui `join` aegub,
+  koristust EI TEHTA: töö jääb `cancelling` olekusse ja jääk kaugserveris on parem kui
+  võistlus.
+- **`200` garanteerib ainult VUTT-i poole.** Pollimist ei ole, teose lukk on vaba, tulemust
+  ei rakendata. Kui LOSSi koristus ebaõnnestus, võib kaugserveris jääk edasi eksisteerida —
+  logikirjes `remote_cleanup: "failed"`.
+- **`cancelled` on LOGI tasandi staatus.** Manage-riba põhineb aktiivsel tööl ja kaob;
+  püsiv ajalugu elab Review-vaates (`reocr_log.json`).
+
+## LOSSi peatamine
+
+Per-töö peatamise mehhanismi OCR-serveris ei ole; ainus tõeline signaal (SIGTERM →
+`shutdown_requested`) peataks terve teenuse. **Piltide kustutamine on peatamismehhanism**:
+`process_batch` avab pildid enne mudeli kutsumist ja väljub, kui ükski ei avane, seega
+kustutamise järel maksab iga järelejäänud batch neli ebaõnnestunud `open()` kutset.
+
+**Kõva piir: `BATCH_SIZE = 4`.** `main_loop` teeb `rglob` üks kord tsükli kohta, seega kuni
+üks lennusolev batch jõuab lõpuni. OCR-serverit ei muudeta (ADR 0017 põhimõte).
+
+Sünkroniseerimine on ühesuunaline: VUTT → LOSS failipõhine, LOSS → VUTT staatust ei ole.
+VUTT ei oota katkestamisel kinnitust — kinnitust ei ole kellelt küsida.
+
+## Tagajärjed
+
+- Teos vabaneb kohe, mitte 12 h pärast.
+- Kuni 4 lehte võib LOSSis lõpuni joosta; nende `.txt` kaob koos kataloogiga.
+- Katkestamine ei ole HTTP mõttes idempotentne: korduv `DELETE` annab 404, sest töö on
+  aktiivregistrist eemaldatud.
+- `_write_ocr_file` võtab nüüd `job_id` argumendi — kutsekohti on neli, sh
+  `reocr_recovery.py` orbude taaste.

--- a/docs/superpowers/plans/2026-08-08-reocr-katkestamine.md
+++ b/docs/superpowers/plans/2026-08-08-reocr-katkestamine.md
@@ -1,0 +1,1443 @@
+# Re-OCR töö katkestamine — teostusplaan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin saab käimasoleva re-OCR töö (üksik või batch) katkestada nii, et seis on võimalikult lähedal seisule enne töö käivitamist ja teos vabaneb kohe lukust.
+
+**Architecture:** Katkestamine on kaheastmeline CAS-üleminek (`aktiivne → cancelling → cancelled`), mis persisteeritakse enne koristust. Töö-põhine üleslaadimislõim peatatakse `threading.Event` + `join`-iga; jagatud poll-lõimi ei saa peatada, seega neid vaigistab sama CAS luku all. Tulemuste omand on jälgitav (`produced_pages`) ja ülekirjutatud `.ocr` failid varundatakse, et katkestamine ei hävitaks varasemat ootel tulemust.
+
+**Tech Stack:** Python 3.9 (FastAPI, threading, paramiko SFTP), pytest; React 19 + TypeScript + i18next.
+
+**Spekk:** `docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md`
+**Issue:** #217 · **Haru:** `feat/reocr-katkestamine`
+
+## Global Constraints
+
+- **Python 3.9 ühilduvus:** `Optional[dict]`, mitte `dict | None`.
+- **Koodikommentaarid eesti keeles.**
+- **Blokeeriv I/O `async def` sees on keelatud** (ADR 0002) — kas sync `def` route või `run_in_threadpool`.
+- **i18n:** uus võti läheb **mõlemasse keelde korraga** (`fallbackLng` väljas, ADR 0011), nimeruum `src/locales/{et,en}/`.
+- **Uus endpoint läheb routerisse** (`server/routers/reocr.py`), MITTE `main.py`-sse.
+- **Kõik prosopo-/reocr-teed tulevad `server/config.py`-st.**
+- **Varukoopiad EI TOHI minna teose kausta:** `data/.gitignore` ignoreerib `*.ocr`, aga `*.ocr.bak.*` ei vastaks mustrile ja ilmuks `git status`-isse. Koht on `state/reocr_backups/{job_id}/`.
+- **Väravad enne igat commitit:** `.venv/bin/pytest tests/ -q`. Frontendi taskides lisaks `npm run typecheck` ja `npm test`.
+
+---
+
+### Task 1: Tulemuse omand — `produced_pages` ja ülekirjutamise varundus
+
+**Files:**
+- Modify: `server/config.py` (uus konstant), `server/reocr_ops.py:73-79` (`_write_ocr_file`)
+- Test: `tests/test_reocr_ownership.py` (uus)
+
+**Interfaces:**
+- Produces:
+  - `config.REOCR_BACKUPS_DIR: str` — `state/reocr_backups`
+  - `reocr_ops._backup_dir(job_id: str) -> str`
+  - `reocr_ops._write_ocr_file(slug: str, page_filename: str, text: str, job_id: str) -> str` (**job_id on uus, kohustuslik**)
+  - `reocr_ops._restore_backups(job_id: str) -> int` — tagastab taastatud failide arvu
+  - `reocr_ops._drop_backups(job_id: str) -> None`
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+Loo `tests/test_reocr_ownership.py`:
+
+```python
+"""Re-OCR tulemuse omand: kes kirjutas, see kustutab (#217).
+
+Plaanitud lehtede nimekiri EI OLE omandi tõend — katkestatud töö ei pruukinud
+jõuda kõiki plaanitud lehti puutuda.
+"""
+import os
+
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture
+def work_dir(tmp_path, monkeypatch):
+    """Teose kaust + eraldatud varukoopiate juur."""
+    slug = "1650-test-abc123"
+    d = tmp_path / slug
+    d.mkdir()
+    monkeypatch.setattr(reocr_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(reocr_ops, "REOCR_BACKUPS_DIR", str(tmp_path / "backups"))
+    return slug, d
+
+
+def test_kirjutamine_loob_ocr_faili(work_dir):
+    slug, d = work_dir
+    path = reocr_ops._write_ocr_file(slug, "001.jpg", "tekst", "job1")
+    assert os.path.basename(path) == "001.ocr"
+    assert open(path, encoding="utf-8").read() == "tekst"
+
+
+def test_olemasolev_ocr_varundatakse_enne_ylekirjutamist(work_dir):
+    """Vana ootel tulemus ei tohi jäljetult kaduda."""
+    slug, d = work_dir
+    (d / "017.ocr").write_text("VANA ootel tulemus", encoding="utf-8")
+
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS tulemus", "job1")
+
+    assert (d / "017.ocr").read_text(encoding="utf-8") == "UUS tulemus"
+    backup = os.path.join(reocr_ops._backup_dir("job1"), "017.ocr")
+    assert open(backup, encoding="utf-8").read() == "VANA ootel tulemus"
+
+
+def test_varundust_ei_tehta_kui_faili_polnud(work_dir):
+    slug, d = work_dir
+    reocr_ops._write_ocr_file(slug, "002.jpg", "tekst", "job1")
+    assert not os.path.exists(os.path.join(reocr_ops._backup_dir("job1"), "002.ocr"))
+
+
+def test_taastamine_toob_vana_sisu_tagasi(work_dir):
+    slug, d = work_dir
+    (d / "017.ocr").write_text("VANA", encoding="utf-8")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS", "job1")
+
+    restored = reocr_ops._restore_backups("job1")
+
+    assert restored == 1
+    assert (d / "017.ocr").read_text(encoding="utf-8") == "VANA"
+    assert not os.path.isdir(reocr_ops._backup_dir("job1"))
+
+
+def test_varukoopiate_kustutamine_ei_puutu_teose_faile(work_dir):
+    slug, d = work_dir
+    (d / "017.ocr").write_text("VANA", encoding="utf-8")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS", "job1")
+
+    reocr_ops._drop_backups("job1")
+
+    assert (d / "017.ocr").read_text(encoding="utf-8") == "UUS"
+    assert not os.path.isdir(reocr_ops._backup_dir("job1"))
+
+
+def test_varukoopia_tee_on_state_all_mitte_teose_kaustas(work_dir):
+    """data/.gitignore ignoreerib *.ocr, aga mitte *.ocr.bak.* — varukoopia
+    teose kaustas ilmuks git status'isse."""
+    slug, d = work_dir
+    assert "backups" in reocr_ops._backup_dir("job1")
+    assert slug not in reocr_ops._backup_dir("job1")
+```
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub**
+
+Run: `.venv/bin/pytest tests/test_reocr_ownership.py -v`
+Expected: FAIL — `_write_ocr_file() takes 3 positional arguments but 4 were given` ja `AttributeError: _backup_dir`.
+
+- [ ] **Step 3: Lisa konstant**
+
+`server/config.py`, `USER_SETTINGS_DIR` / `NOTIFICATIONS_DIR` kõrvale:
+
+```python
+# Re-OCR ülekirjutatud .ocr tulemuste varukoopiad (katkestamisel taastatakse).
+# EI TOHI olla teose kaustas: data/.gitignore ignoreerib *.ocr, aga varukoopia
+# nimi ei vastaks mustrile ja ilmuks git status'isse (#217).
+REOCR_BACKUPS_DIR = os.path.join(_STATE_DIR, "reocr_backups")
+```
+
+- [ ] **Step 4: Teosta varundusloogika**
+
+`server/reocr_ops.py` — impordi konstant real 11 (`from .config import ...` nimekirja lisa `REOCR_BACKUPS_DIR`), seejärel asenda `_write_ocr_file`:
+
+```python
+def _backup_dir(job_id: str) -> str:
+    """Selle töö ülekirjutatud .ocr failide varukoopiad."""
+    return os.path.join(REOCR_BACKUPS_DIR, job_id)
+
+
+def _write_ocr_file(slug: str, page_filename: str, text: str, job_id: str) -> str:
+    """Kirjutab OCR-tulemuse {BASE_DIR}/{slug}/{stem}.ocr failina (püsiv staging).
+
+    Kui sihtkohas on juba ootel tulemus, varundatakse see ENNE ülekirjutamist.
+    Katkestamine taastab varukoopia — muidu hävitaks katkestatud töö varasema
+    kehtiva tulemuse, mida ta ise ei tootnud (#217).
+    """
+    stem = os.path.splitext(os.path.basename(page_filename))[0]
+    ocr_path = os.path.join(BASE_DIR, slug, stem + ".ocr")
+
+    if os.path.exists(ocr_path):
+        bdir = _backup_dir(job_id)
+        os.makedirs(bdir, exist_ok=True)
+        backup_path = os.path.join(bdir, stem + ".ocr")
+        if not os.path.exists(backup_path):
+            # Ainult ESIMENE ülekirjutus varundatakse — muidu kirjutaks sama töö
+            # kordusjooks varukoopia enda tulemusega üle.
+            shutil.copy2(ocr_path, backup_path)
+
+    with open(ocr_path, "w", encoding="utf-8") as f:
+        f.write(text)
+    return ocr_path
+
+
+def _restore_backups(job_id: str) -> int:
+    """Taastab selle töö ülekirjutatud .ocr failid. Tagastab taastatud arvu."""
+    bdir = _backup_dir(job_id)
+    if not os.path.isdir(bdir):
+        return 0
+    restored = 0
+    mapping = reocr_state.load_backup_targets(job_id)
+    for name in os.listdir(bdir):
+        target = mapping.get(name)
+        if not target:
+            logger.warning(f"Re-OCR {job_id}: varukoopial {name} puudub sihtkoht")
+            continue
+        try:
+            shutil.move(os.path.join(bdir, name), target)
+            restored += 1
+        except OSError as e:
+            logger.warning(f"Re-OCR {job_id}: varukoopia taaste {name}: {e}")
+    shutil.rmtree(bdir, ignore_errors=True)
+    reocr_state.remove_backup_targets(job_id)
+    return restored
+
+
+def _drop_backups(job_id: str) -> None:
+    """Kustutab varukoopiad (töö lõppes normaalselt / rakendati / visati ära)."""
+    shutil.rmtree(_backup_dir(job_id), ignore_errors=True)
+    reocr_state.remove_backup_targets(job_id)
+```
+
+Lisa `import shutil` faili päisesse (`import os` kõrvale).
+
+- [ ] **Step 5: Lisa sihtkohtade register `reocr_state.py`-sse**
+
+Varukoopia failinimi (`017.ocr`) ei ütle, MILLISE teose kausta ta kuulub — taastamine vajab
+täisteed. `server/reocr_state.py`, `persist_batch_mapping` kõrvale:
+
+```python
+BACKUP_TARGETS_DIR = os.path.join(STATE_DIR, "reocr_backup_targets")
+
+
+def _backup_targets_path(job_id: str) -> str:
+    return os.path.join(BACKUP_TARGETS_DIR, f"{job_id}.json")
+
+
+def add_backup_target(job_id: str, backup_name: str, target_path: str) -> None:
+    """Seob varukoopia failinime tema teose-kausta sihtteega. Atomaarne."""
+    with _file_lock:
+        os.makedirs(BACKUP_TARGETS_DIR, exist_ok=True)
+        path = _backup_targets_path(job_id)
+        data = {}
+        if os.path.exists(path):
+            try:
+                with open(path, encoding="utf-8") as f:
+                    data = json.load(f)
+            except (OSError, ValueError):
+                data = {}
+        data[backup_name] = target_path
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+
+
+def load_backup_targets(job_id: str) -> dict:
+    """Varukoopia nimi → sihttee. Puuduv fail = tühi dict."""
+    with _file_lock:
+        try:
+            with open(_backup_targets_path(job_id), encoding="utf-8") as f:
+                return json.load(f)
+        except (OSError, ValueError):
+            return {}
+
+
+def remove_backup_targets(job_id: str) -> None:
+    with _file_lock:
+        try:
+            os.remove(_backup_targets_path(job_id))
+        except FileNotFoundError:
+            pass
+```
+
+Kutsu `add_backup_target` `_write_ocr_file`-is kohe pärast `shutil.copy2` rida:
+
+```python
+            reocr_state.add_backup_target(job_id, stem + ".ocr", ocr_path)
+```
+
+- [ ] **Step 6: Käivita testid**
+
+Run: `.venv/bin/pytest tests/test_reocr_ownership.py -v`
+Expected: 6 passed
+
+Run: `.venv/bin/pytest tests/ -q`
+Expected: FAIL kahes kohas — `_write_ocr_file` kutsutakse veel kolme argumendiga
+(`server/reocr_ops.py` batch-poll ja üksik-poll). Paranda mõlemad kutsed:
+
+```python
+                _write_ocr_file(slug, entry["page_filename"], text, job_id)
+```
+
+ja üksiku poolel (`~rida 745`):
+
+```python
+                    ocr_path = _write_ocr_file(j["slug"], j["page_filename"], text, jid)
+```
+
+Seejärel `.venv/bin/pytest tests/ -q` → kõik roheline.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/config.py server/reocr_ops.py server/reocr_state.py tests/test_reocr_ownership.py
+git commit -m "feat(reocr): varunda ülekirjutatud .ocr tulemus (#217)
+
+Ettevalmistus katkestamiseks: katkestatud töö ei tohi hävitada varasemat ootel
+tulemust, mida ta ise ei tootnud. _write_ocr_file varundab olemasoleva faili
+state/reocr_backups/{job_id}/ alla ja reocr_state hoiab sihtteede registrit.
+
+Varukoopia EI või minna teose kausta: data/.gitignore ignoreerib *.ocr, aga
+varukoopia nimi ei vastaks mustrile ja ilmuks git status'isse."
+```
+
+---
+
+### Task 2: `produced_pages` — mida see töö päriselt tootis
+
+**Files:**
+- Modify: `server/reocr_ops.py` (batch-poll ~rida 293, üksik-poll ~rida 745, töö loomine ~read 183 ja 613)
+- Test: `tests/test_reocr_ownership.py` (lisandub)
+
+**Interfaces:**
+- Produces: töö kirjes võti `produced_pages: List[str]` — **stem'id**, mille `.ocr` see töö kirjutas. Katkestamine (Task 4) kustutab AINULT need.
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+Lisa `tests/test_reocr_ownership.py` lõppu:
+
+```python
+def test_produced_pages_taidetakse_kirjutamise_hetkel(work_dir, monkeypatch):
+    """Loend peab kasvama siis, kui .ocr PÄRISELT kirjutatakse — mitte tööd
+    käivitades. Plaanitud ≠ toodetud."""
+    slug, d = work_dir
+    job = {"produced_pages": []}
+
+    reocr_ops._record_produced(job, "017.jpg")
+    reocr_ops._record_produced(job, "018.jpg")
+    reocr_ops._record_produced(job, "017.jpg")   # kordus ei tohi duplitseerida
+
+    assert job["produced_pages"] == ["017", "018"]
+
+
+def test_uus_too_algab_tuhja_produced_pages_iga():
+    job = {}
+    reocr_ops._record_produced(job, "001.jpg")
+    assert job["produced_pages"] == ["001"]
+```
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub**
+
+Run: `.venv/bin/pytest tests/test_reocr_ownership.py -k produced -v`
+Expected: FAIL — `AttributeError: module 'server.reocr_ops' has no attribute '_record_produced'`
+
+- [ ] **Step 3: Teosta**
+
+`server/reocr_ops.py`, `_write_ocr_file` kõrvale:
+
+```python
+def _record_produced(job: dict, page_filename: str) -> None:
+    """Märgib, et SEE töö kirjutas selle lehe .ocr faili.
+
+    Katkestamine kustutab ainult siit loendist tulevad lehed. Plaanitud lehtede
+    nimekiri (batch mapping) EI OLE omandi tõend — töö võib olla katkestatud
+    enne, kui ta plaani lõpuni jõudis (#217).
+    """
+    stem = os.path.splitext(os.path.basename(page_filename))[0]
+    produced = job.setdefault("produced_pages", [])
+    if stem not in produced:
+        produced.append(stem)
+```
+
+- [ ] **Step 4: Kutsu seda mõlemal kirjutamisteel**
+
+Batch-poll (`_poll_batch_job`, kohe pärast `_write_ocr_file` õnnestumist, sama
+`with _reocr_batch_jobs_lock:` ploki sees, kus `cur_entry["status"] = "ready"`):
+
+```python
+                        _record_produced(current, entry["page_filename"])
+```
+
+Üksik-poll (`_poll_iteration`, samas kohas kus `.ocr` kirjutatakse ja `j["status"]`
+muudetakse):
+
+```python
+                    _record_produced(j, j["page_filename"])
+```
+
+- [ ] **Step 5: Käivita testid ja commit**
+
+Run: `.venv/bin/pytest tests/ -q`
+Expected: kõik roheline.
+
+```bash
+git add server/reocr_ops.py tests/test_reocr_ownership.py
+git commit -m "feat(reocr): jälgi, millised lehed töö päriselt tootis (#217)
+
+produced_pages täidetakse .ocr kirjutamise hetkel, mitte tööd käivitades.
+Katkestamine kustutab ainult need — plaanitud lehtede nimekiri ei ole omandi
+tõend, sest töö võidi katkestada enne plaani lõppu."
+```
+
+---
+
+### Task 3: `cancelling` olek ja vastastikku välistavad terminalüleminekud
+
+**Files:**
+- Modify: `server/reocr_ops.py` (uus funktsioon + poll-valvurid)
+- Test: `tests/test_reocr_cancel_state.py` (uus)
+
+**Interfaces:**
+- Produces:
+  - `reocr_ops.CANCELLABLE_STATUSES: tuple` — `("uploading", "processing", "slow")`
+  - `reocr_ops._try_begin_cancel(job_id: str) -> Optional[str]` — CAS `aktiivne → cancelling`. Tagastab `"single"` / `"batch"` (kumb register) või `None`, kui ei õnnestunud (töö puudub, on juba terminalis või juba `cancelling`).
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+Loo `tests/test_reocr_cancel_state.py`:
+
+```python
+"""Katkestamise olekumasin: aktiivne → cancelling → cancelled (#217).
+
+Terminalüleminekud peavad olema vastastikku välistavad — vastasel juhul võib
+poller märkida töö `done`-ks samal ajal kui DELETE märgib `cancelled`.
+"""
+import threading
+
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture(autouse=True)
+def puhas_register(monkeypatch):
+    monkeypatch.setattr(reocr_ops, "_reocr_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_reocr_batch_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_persist_active_jobs", lambda: None)
+
+
+def test_aktiivne_too_laheb_cancelling_olekusse():
+    reocr_ops._reocr_jobs["j1"] = {"status": "processing"}
+    assert reocr_ops._try_begin_cancel("j1") == "single"
+    assert reocr_ops._reocr_jobs["j1"]["status"] == "cancelling"
+
+
+def test_batch_register_leitakse_sama_endpointiga():
+    reocr_ops._reocr_batch_jobs["b1"] = {"status": "uploading"}
+    assert reocr_ops._try_begin_cancel("b1") == "batch"
+    assert reocr_ops._reocr_batch_jobs["b1"]["status"] == "cancelling"
+
+
+def test_slow_too_on_katkestatav():
+    reocr_ops._reocr_jobs["j1"] = {"status": "slow"}
+    assert reocr_ops._try_begin_cancel("j1") == "single"
+
+
+@pytest.mark.parametrize("status", ["done", "error", "cancelling"])
+def test_terminal_ja_juba_katkestatav_too_ei_alga_uuesti(status):
+    reocr_ops._reocr_jobs["j1"] = {"status": status}
+    assert reocr_ops._try_begin_cancel("j1") is None
+    assert reocr_ops._reocr_jobs["j1"]["status"] == status
+
+
+def test_tundmatu_id_annab_none():
+    assert reocr_ops._try_begin_cancel("puudub") is None
+
+
+def test_sama_id_moelmas_registris_on_invariandi_rikkumine():
+    """job_id nimeruum on registrite vahel globaalne (sama generate_nanoid)."""
+    reocr_ops._reocr_jobs["x"] = {"status": "processing"}
+    reocr_ops._reocr_batch_jobs["x"] = {"status": "processing"}
+    with pytest.raises(RuntimeError):
+        reocr_ops._try_begin_cancel("x")
+
+
+def test_ainult_uks_lõim_voidab_CAS_i():
+    """20 lõime üritavad korraga katkestada — täpselt üks saab loa."""
+    reocr_ops._reocr_jobs["j1"] = {"status": "processing"}
+    voitjad = []
+    lukk = threading.Lock()
+
+    def proovi():
+        r = reocr_ops._try_begin_cancel("j1")
+        if r:
+            with lukk:
+                voitjad.append(r)
+
+    threads = [threading.Thread(target=proovi) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(voitjad) == 1
+```
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub**
+
+Run: `.venv/bin/pytest tests/test_reocr_cancel_state.py -v`
+Expected: FAIL — `AttributeError: _try_begin_cancel`
+
+- [ ] **Step 3: Teosta CAS**
+
+`server/reocr_ops.py`, `_persist_active_jobs` järele:
+
+```python
+CANCELLABLE_STATUSES = ("uploading", "processing", "slow")
+
+
+def _try_begin_cancel(job_id: str) -> Optional[str]:
+    """CAS: aktiivne → cancelling. Tagastab "single"/"batch" või None.
+
+    See on ainus koht, kus katkestamine algab. `cancelling` on vaheolek, mis
+    vastab küsimusele „kes võitis": poller ei tohi pärast seda enam ühtki
+    tulemust kirjutada ega tööd `done`-ks märkida (#217).
+    """
+    in_single = job_id in _reocr_jobs
+    in_batch = job_id in _reocr_batch_jobs
+    if in_single and in_batch:
+        # job_id nimeruum on registrite vahel globaalne — sama generate_nanoid().
+        # Kokkulangevus on invariandi rikkumine; ära arva, kumb oli mõeldud.
+        raise RuntimeError(f"job_id {job_id} esineb mõlemas registris")
+
+    if in_single:
+        with _reocr_jobs_lock:
+            job = _reocr_jobs.get(job_id)
+            if not job or job.get("status") not in CANCELLABLE_STATUSES:
+                return None
+            job["status"] = "cancelling"
+        _persist_active_jobs()
+        return "single"
+
+    if in_batch:
+        with _reocr_batch_jobs_lock:
+            job = _reocr_batch_jobs.get(job_id)
+            if not job or job.get("status") not in CANCELLABLE_STATUSES:
+                return None
+            job["status"] = "cancelling"
+        _persist_active_jobs()
+        return "batch"
+
+    return None
+```
+
+- [ ] **Step 4: Vaigista poll-lõimed sama CAS-iga**
+
+Poll on **jagatud singleton-lõim** — teda ei saa peatada. Selle asemel peab iga
+tulemuse kirjutamine kontrollima olekut luku all.
+
+`_poll_batch_job` alguses on juba kontroll `job["status"] != "processing"` → see katab
+`cancelling` juhtumi automaatselt. **Aga** allalaadimise ja kirjutamise vahel võib olek
+muutuda, seega lisa `_write_ocr_file` kutse ette (batch-poll, `for entry in pending:`
+tsüklis, kohe pärast `if text is None: continue`):
+
+```python
+            # Olek võis vahepeal muutuda (DELETE käib teises lõimes). Kirjutamine
+            # pärast `cancelling` algust jätaks ghost-tulemuse pärast koristust.
+            with _reocr_batch_jobs_lock:
+                cur = _reocr_batch_jobs.get(job_id)
+                if not cur or cur.get("status") != "processing":
+                    return
+```
+
+Sama kontroll üksik-polli kirjutamiskohta (`_poll_iteration`), `_write_ocr_file` ette:
+
+```python
+                with _reocr_jobs_lock:
+                    cur = _reocr_jobs.get(jid)
+                    if not cur or cur.get("status") != "processing":
+                        continue
+```
+
+- [ ] **Step 5: Kirjuta võistlustest**
+
+Lisa `tests/test_reocr_cancel_state.py` lõppu:
+
+```python
+def test_katkestamine_ja_done_ei_saa_moelmad_voita():
+    """Poller tahab `done`, DELETE tahab `cancelling` — täpselt üks võidab."""
+    reocr_ops._reocr_jobs["j1"] = {"status": "processing"}
+    tulemused = []
+    start = threading.Barrier(2)
+
+    def katkesta():
+        start.wait()
+        tulemused.append(("cancel", reocr_ops._try_begin_cancel("j1")))
+
+    def lopeta():
+        start.wait()
+        with reocr_ops._reocr_jobs_lock:
+            job = reocr_ops._reocr_jobs.get("j1")
+            ok = bool(job) and job.get("status") == "processing"
+            if ok:
+                job["status"] = "done"
+        tulemused.append(("done", ok))
+
+    t1, t2 = threading.Thread(target=katkesta), threading.Thread(target=lopeta)
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    lopp = reocr_ops._reocr_jobs["j1"]["status"]
+    assert lopp in ("cancelling", "done")
+    edukad = [nimi for nimi, ok in tulemused if ok]
+    assert len(edukad) == 1, "täpselt üks terminalüleminek peab õnnestuma"
+```
+
+- [ ] **Step 6: Käivita testid ja commit**
+
+Run: `.venv/bin/pytest tests/test_reocr_cancel_state.py tests/ -q`
+Expected: kõik roheline.
+
+```bash
+git add server/reocr_ops.py tests/test_reocr_cancel_state.py
+git commit -m "feat(reocr): cancelling-vaheolek ja välistavad terminalüleminekud (#217)
+
+_try_begin_cancel on CAS aktiivne → cancelling. Poll-lõimed on JAGATUD
+singletonid, mida ei saa peatada — nad vaigistatakse sama luku all tehtava
+olekukontrolliga enne iga .ocr kirjutamist."
+```
+
+---
+
+### Task 4: Üleslaadimislõime peatamine (`Event` + `join`)
+
+**Files:**
+- Modify: `server/reocr_ops.py` (`_upload()` mõlemas käivitajas, uus register)
+- Test: `tests/test_reocr_cancel_worker.py` (uus)
+
+**Interfaces:**
+- Produces:
+  - `reocr_ops._cancel_events: Dict[str, threading.Event]`
+  - `reocr_ops._upload_threads: Dict[str, threading.Thread]`
+  - `reocr_ops._quiesce_upload(job_id: str, timeout: float = 30.0) -> bool` — `True`, kui lõim on lõpetanud
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+Loo `tests/test_reocr_cancel_worker.py`:
+
+```python
+"""Üleslaadimislõime peatamine enne kaugkoristust (#217).
+
+Koostööline lipp üksi ei piisa: lipu seadmine ei tähenda, et lõim on lõpetanud.
+Kui koristus algab enne lõime väljumist, kirjutab pooleliolev sftp.put() pildid
+tagasi kataloogi, mille just eemaldasime.
+"""
+import threading
+import time
+
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture(autouse=True)
+def puhas(monkeypatch):
+    monkeypatch.setattr(reocr_ops, "_cancel_events", {})
+    monkeypatch.setattr(reocr_ops, "_upload_threads", {})
+
+
+def test_quiesce_ootab_loime_lopetamiseni():
+    laetud = []
+    ev = threading.Event()
+    reocr_ops._cancel_events["j1"] = ev
+
+    def upload():
+        for i in range(100):
+            if ev.is_set():
+                return
+            laetud.append(i)
+            time.sleep(0.01)
+
+    t = threading.Thread(target=upload)
+    reocr_ops._upload_threads["j1"] = t
+    t.start()
+    time.sleep(0.05)
+
+    assert reocr_ops._quiesce_upload("j1", timeout=5.0) is True
+    assert not t.is_alive(), "lõim peab olema lõpetanud ENNE tagastamist"
+    enne = len(laetud)
+    time.sleep(0.05)
+    assert len(laetud) == enne, "lõim ei tohi pärast quiesce'i midagi juurde teha"
+
+
+def test_quiesce_annab_false_kui_loim_ei_peatu():
+    """Ajalõpp: koristust EI TOHI alustada, kui kirjutaja on veel elus."""
+    ev = threading.Event()
+    reocr_ops._cancel_events["j1"] = ev
+    stop = threading.Event()
+
+    t = threading.Thread(target=lambda: stop.wait(10), daemon=True)
+    reocr_ops._upload_threads["j1"] = t
+    t.start()
+
+    assert reocr_ops._quiesce_upload("j1", timeout=0.2) is False
+    stop.set()
+
+
+def test_quiesce_tundmatu_too_on_ohutu():
+    """Lõim võis juba lõppeda — see ei ole viga."""
+    assert reocr_ops._quiesce_upload("puudub", timeout=0.1) is True
+```
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub**
+
+Run: `.venv/bin/pytest tests/test_reocr_cancel_worker.py -v`
+Expected: FAIL — `AttributeError: _cancel_events`
+
+- [ ] **Step 3: Teosta**
+
+`server/reocr_ops.py`, `_try_begin_cancel` kõrvale:
+
+```python
+# Töö-põhised katkestuslipud ja üleslaadimislõimed. Poll-lõimi siin EI OLE —
+# need on jagatud singletonid ja neid vaigistab CAS (vt _try_begin_cancel).
+_cancel_events: Dict[str, threading.Event] = {}
+_upload_threads: Dict[str, threading.Thread] = {}
+
+
+def _cancel_event(job_id: str) -> threading.Event:
+    """Töö katkestuslipp (loob vajadusel)."""
+    ev = _cancel_events.get(job_id)
+    if ev is None:
+        ev = threading.Event()
+        _cancel_events[job_id] = ev
+    return ev
+
+
+def _quiesce_upload(job_id: str, timeout: float = 30.0) -> bool:
+    """Seab katkestuslipu ja OOTAB üleslaadimislõime lõpetamist.
+
+    Tagastab False, kui lõim ei peatunud. Sel juhul EI TOHI kaugkoristust teha:
+    pooleliolev sftp.put() kirjutaks pildid tagasi kataloogi, mille kustutasime.
+    Jääk kaugserveris on parem kui võistlus.
+    """
+    _cancel_event(job_id).set()
+    t = _upload_threads.get(job_id)
+    if t is None or not t.is_alive():
+        return True
+    t.join(timeout)
+    return not t.is_alive()
+
+
+def _forget_cancel_state(job_id: str) -> None:
+    """Koristab katkestamise abistruktuurid."""
+    _cancel_events.pop(job_id, None)
+    _upload_threads.pop(job_id, None)
+```
+
+- [ ] **Step 4: Ühenda lipp üleslaadimistsüklitesse**
+
+Batch (`start_reocr_batch._upload`), `for entry in page_entries:` tsükli algusesse:
+
+```python
+            for entry in page_entries:
+                if _cancel_event(job_id).is_set():
+                    logger.info(f"Re-OCR batch {job_id}: üleslaadimine katkestatud")
+                    return
+```
+
+Üksik (`start_reocr._upload`), kohe pärast `sftp = _sftp_open(job_id)`:
+
+```python
+            if _cancel_event(job_id).is_set():
+                logger.info(f"Re-OCR {job_id}: üleslaadimine katkestatud")
+                return
+```
+
+Mõlemas käivitajas asenda lõime start nii, et lõim jääks registrisse. Batch (rida ~234):
+
+```python
+    _t = threading.Thread(target=_upload, daemon=True, name=f"reocr-batch-{job_id}")
+    _upload_threads[job_id] = _t
+    _t.start()
+```
+
+Üksik (rida ~675):
+
+```python
+    _t = threading.Thread(target=_upload, daemon=True, name=f"reocr-{job_id}")
+    _upload_threads[job_id] = _t
+    _t.start()
+```
+
+- [ ] **Step 5: Käivita testid ja commit**
+
+Run: `.venv/bin/pytest tests/ -q`
+Expected: kõik roheline.
+
+```bash
+git add server/reocr_ops.py tests/test_reocr_cancel_worker.py
+git commit -m "feat(reocr): peata üleslaadimislõim enne koristust (#217)
+
+_quiesce_upload seab lipu JA ootab lõime lõpetamist. Ajalõpu korral tagastab
+False — koristust ei tohi siis alustada, sest pooleliolev sftp.put() kirjutaks
+pildid tagasi kustutatud kataloogi."
+```
+
+---
+
+### Task 5: `cancel_reocr_job()` — koristuse orkestreerimine
+
+**Files:**
+- Modify: `server/reocr_ops.py` (uus avalik funktsioon), `server/reocr_ops.py:22-40` (`_append_to_log`)
+- Test: `tests/test_reocr_cancel.py` (uus)
+
+**Interfaces:**
+- Consumes: `_try_begin_cancel`, `_quiesce_upload`, `_restore_backups`, `_drop_backups`, `_record_produced` (Task 1–4)
+- Produces: `reocr_ops.cancel_reocr_job(job_id: str) -> dict` — `{"status": "cancelled", "remote_cleanup": "ok"|"failed", "deleted_ocr": int, "restored_ocr": int}`. Tõstab `KeyError` tundmatu töö korral ja `ValueError`, kui töö ei ole katkestatav.
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+Loo `tests/test_reocr_cancel.py`:
+
+```python
+"""cancel_reocr_job: „tööd ei olnud" semantika (#217)."""
+import os
+
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture
+def keskkond(tmp_path, monkeypatch):
+    slug = "1650-test-abc123"
+    work = tmp_path / slug
+    work.mkdir()
+    monkeypatch.setattr(reocr_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(reocr_ops, "REOCR_BACKUPS_DIR", str(tmp_path / "backups"))
+    monkeypatch.setattr(reocr_ops, "_reocr_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_reocr_batch_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_cancel_events", {})
+    monkeypatch.setattr(reocr_ops, "_upload_threads", {})
+    monkeypatch.setattr(reocr_ops, "_persist_active_jobs", lambda: None)
+    monkeypatch.setattr(reocr_ops, "_append_to_log", lambda job, jid: None)
+    monkeypatch.setattr(reocr_ops.reocr_state, "remove_batch_mapping", lambda jid: None)
+    koristatud = []
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job",
+                        lambda jid, job: koristatud.append(jid) or True)
+    return slug, work, koristatud
+
+
+def test_kustutab_ainult_toodetud_lehed(keskkond):
+    """REGRESSIOON: plaanitud lehtede järgi kustutamine hävitaks varasema
+    ootel tulemuse lehel, mida katkestatud töö ei puutunud."""
+    slug, work, _ = keskkond
+    (work / "001.ocr").write_text("selle töö tulemus", encoding="utf-8")
+    (work / "017.ocr").write_text("VARASEM ootel tulemus", encoding="utf-8")
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug,
+        "produced_pages": ["001"],           # 017 EI OLE siin
+        "pages": [{"page_filename": "001.jpg"}, {"page_filename": "017.jpg"}],
+    }
+
+    result = reocr_ops.cancel_reocr_job("b1")
+
+    assert result["deleted_ocr"] == 1
+    assert not (work / "001.ocr").exists()
+    assert (work / "017.ocr").read_text(encoding="utf-8") == "VARASEM ootel tulemus"
+
+
+def test_taastab_ylekirjutatud_tulemuse(keskkond):
+    slug, work, _ = keskkond
+    (work / "017.ocr").write_text("VANA", encoding="utf-8")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS", "b1")
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug, "produced_pages": ["017"], "pages": [],
+    }
+
+    result = reocr_ops.cancel_reocr_job("b1")
+
+    assert result["restored_ocr"] == 1
+    assert (work / "017.ocr").read_text(encoding="utf-8") == "VANA"
+
+
+def test_eemaldab_too_registrist(keskkond):
+    slug, _work, _ = keskkond
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug, "produced_pages": [], "pages": [],
+    }
+    reocr_ops.cancel_reocr_job("b1")
+    assert "b1" not in reocr_ops._reocr_batch_jobs
+
+
+def test_sftp_torge_ei_takista_lokaalset_katkestamist(keskkond, monkeypatch):
+    """Intsidendi kuju: VUTT rippus, LOSS oli edasi läinud."""
+    slug, _work, _ = keskkond
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job", lambda jid, job: False)
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug, "produced_pages": [], "pages": [],
+    }
+
+    result = reocr_ops.cancel_reocr_job("b1")
+
+    assert result["status"] == "cancelled"
+    assert result["remote_cleanup"] == "failed"
+    assert "b1" not in reocr_ops._reocr_batch_jobs
+
+
+def test_valmis_too_ei_ole_katkestatav(keskkond):
+    slug, _work, _ = keskkond
+    reocr_ops._reocr_jobs["j1"] = {"status": "done", "slug": slug}
+    with pytest.raises(ValueError):
+        reocr_ops.cancel_reocr_job("j1")
+
+
+def test_tundmatu_too_annab_keyerror(keskkond):
+    with pytest.raises(KeyError):
+        reocr_ops.cancel_reocr_job("puudub")
+```
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub**
+
+Run: `.venv/bin/pytest tests/test_reocr_cancel.py -v`
+Expected: FAIL — `AttributeError: cancel_reocr_job`
+
+- [ ] **Step 3: Teosta kaugkoristus**
+
+`server/reocr_ops.py`:
+
+```python
+def _cleanup_remote_job(job_id: str, job: dict) -> bool:
+    """Kustutab OCR-serverist selle töö pildid ja .txt-d. True = õnnestus.
+
+    Piltide kustutamine ON peatamismehhanism: process_batch väljub enne mudeli
+    kutsumist, kui ükski pilt ei avane. Kuni üks lennusolev batch (BATCH_SIZE=4)
+    jõuab siiski lõpuni — see on teadlik piir, vt spekki.
+    """
+    remote_work = job.get("remote_work")
+    if not remote_work:
+        return True
+    try:
+        sftp = _sftp_open(job_id)
+    except Exception as e:
+        logger.warning(f"Re-OCR {job_id} koristuse SFTP viga: {e}")
+        return False
+
+    work_abs = f"{OCR_SERVER_PATH}/{remote_work}"
+    ok = True
+    try:
+        try:
+            for name in sftp.listdir(work_abs):
+                try:
+                    sftp.remove(f"{work_abs}/{name}")
+                except Exception as e:
+                    logger.warning(f"Re-OCR {job_id} {name} kustutus: {e}")
+                    ok = False
+        except FileNotFoundError:
+            pass          # kaust on juba kadunud — intsidendi kuju, mitte viga
+        for d in (work_abs, f"{OCR_SERVER_PATH}/{job.get('remote_staging', '')}"):
+            try:
+                sftp.rmdir(d)
+            except Exception:
+                pass      # mitte-tühi või puuduv kaust ei ole katkestamise viga
+    finally:
+        try:
+            sftp.close()
+        except Exception:
+            pass
+        close_ssh(job_id)
+    return ok
+```
+
+- [ ] **Step 4: Teosta orkestreerimine**
+
+```python
+def cancel_reocr_job(job_id: str) -> dict:
+    """Katkestab re-OCR töö. „Tööd ei olnud" — vt spekki.
+
+    Järjekord ei ole vaba: koristus tohib alata alles siis, kui ühtki kirjutajat
+    enam ei ole. Vastasel juhul kirjutab pooleliolev üleslaadimine failid tagasi
+    kataloogi, mille just eemaldasime.
+    """
+    registry = _try_begin_cancel(job_id)
+    if registry is None:
+        if job_id in _reocr_jobs or job_id in _reocr_batch_jobs:
+            raise ValueError("Töö ei ole katkestatav")
+        raise KeyError(job_id)
+
+    jobs = _reocr_jobs if registry == "single" else _reocr_batch_jobs
+    lock = _reocr_jobs_lock if registry == "single" else _reocr_batch_jobs_lock
+    with lock:
+        job = dict(jobs.get(job_id) or {})
+
+    if not _quiesce_upload(job_id):
+        # Kirjutaja on veel elus — jäta töö `cancelling` olekusse, taaste korjab
+        # üles. Jääk kaugserveris on parem kui võistlus koristusega.
+        logger.error(f"Re-OCR {job_id}: üleslaadimislõim ei peatunud, koristus edasi lükatud")
+        raise RuntimeError("Üleslaadimislõim ei peatunud")
+
+    remote_ok = _cleanup_remote_job(job_id, job)
+
+    slug = job.get("slug") or ""
+    deleted = 0
+    for stem in job.get("produced_pages", []):
+        path = os.path.join(BASE_DIR, slug, stem + ".ocr")
+        try:
+            os.unlink(path)
+            deleted += 1
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.warning(f"Re-OCR {job_id} {stem}.ocr kustutus: {e}")
+    restored = _restore_backups(job_id)
+
+    with lock:
+        current = jobs.pop(job_id, None)
+    if current is not None:
+        current["status"] = "cancelled"
+        current["finished_at"] = datetime.now().timestamp()
+        current["remote_cleanup"] = "ok" if remote_ok else "failed"
+        _append_to_log(current, job_id)
+
+    reocr_state.remove_batch_mapping(job_id)
+    _forget_cancel_state(job_id)
+    _persist_active_jobs()
+
+    logger.info(
+        f"Re-OCR {job_id} katkestatud: {deleted} .ocr kustutatud, "
+        f"{restored} taastatud, kaugkoristus={'ok' if remote_ok else 'failed'}"
+    )
+    return {
+        "status": "cancelled",
+        "remote_cleanup": "ok" if remote_ok else "failed",
+        "deleted_ocr": deleted,
+        "restored_ocr": restored,
+    }
+```
+
+- [ ] **Step 5: Lisa `remote_cleanup` logikirjesse**
+
+`_append_to_log` (rida ~35), laienda kopeeritavate võtmete tsüklit:
+
+```python
+    for _k in ("recovered", "original_status", "recovered_at", "remote_cleanup"):
+```
+
+- [ ] **Step 6: Käivita testid ja commit**
+
+Run: `.venv/bin/pytest tests/ -q`
+Expected: kõik roheline.
+
+```bash
+git add server/reocr_ops.py tests/test_reocr_cancel.py
+git commit -m "feat(reocr): cancel_reocr_job — koristus õiges järjekorras (#217)
+
+Kustutab AINULT produced_pages lehed ja taastab ülekirjutatud varukoopiad.
+SFTP tõrge ei takista lokaalset katkestamist — logikirjesse jääb
+remote_cleanup: failed, sest 200 garanteerib ainult VUTT-i poole."
+```
+
+---
+
+### Task 6: `DELETE /admin/reocr/{job_id}`
+
+**Files:**
+- Modify: `server/routers/reocr.py` (lõppu)
+- Test: `tests/test_reocr_cancel_endpoint.py` (uus)
+
+**Interfaces:**
+- Consumes: `reocr_ops.cancel_reocr_job(job_id) -> dict`
+- Produces: `DELETE /admin/reocr/{job_id}` → 200 `{"status": "cancelled", ...}`, 409, 404
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+Loo `tests/test_reocr_cancel_endpoint.py`:
+
+```python
+"""DELETE /admin/reocr/{job_id} (#217)."""
+import pytest
+
+from server import reocr_ops
+
+
+def test_katkestamine_annab_200(client_admin_reocr, monkeypatch):
+    client, headers = client_admin_reocr
+    monkeypatch.setattr(reocr_ops, "cancel_reocr_job",
+                        lambda jid: {"status": "cancelled", "remote_cleanup": "ok",
+                                     "deleted_ocr": 2, "restored_ocr": 1})
+    r = client.delete("/admin/reocr/abc123", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["status"] == "cancelled"
+    assert r.json()["deleted_ocr"] == 2
+
+
+def test_valmis_too_annab_409(client_admin_reocr, monkeypatch):
+    client, headers = client_admin_reocr
+
+    def _raise(jid):
+        raise ValueError("Töö ei ole katkestatav")
+
+    monkeypatch.setattr(reocr_ops, "cancel_reocr_job", _raise)
+    assert client.delete("/admin/reocr/abc123", headers=headers).status_code == 409
+
+
+def test_tundmatu_too_annab_404(client_admin_reocr, monkeypatch):
+    client, headers = client_admin_reocr
+
+    def _raise(jid):
+        raise KeyError(jid)
+
+    monkeypatch.setattr(reocr_ops, "cancel_reocr_job", _raise)
+    assert client.delete("/admin/reocr/abc123", headers=headers).status_code == 404
+
+
+def test_korduv_katkestamine_annab_404(client_admin_reocr, monkeypatch):
+    """Töö on aktiivregistrist kadunud — katkestamine EI OLE idempotentne."""
+    client, headers = client_admin_reocr
+    kutsutud = []
+
+    def _once(jid):
+        if kutsutud:
+            raise KeyError(jid)
+        kutsutud.append(jid)
+        return {"status": "cancelled", "remote_cleanup": "ok",
+                "deleted_ocr": 0, "restored_ocr": 0}
+
+    monkeypatch.setattr(reocr_ops, "cancel_reocr_job", _once)
+    assert client.delete("/admin/reocr/abc123", headers=headers).status_code == 200
+    assert client.delete("/admin/reocr/abc123", headers=headers).status_code == 404
+
+
+def test_editor_ei_paase_ligi(client_admin_reocr, login_editor):
+    client, _headers = client_admin_reocr
+    r = client.delete("/admin/reocr/abc123",
+                      headers={"Authorization": f"Bearer {login_editor}"})
+    assert r.status_code in (401, 403)
+
+
+def test_tee_on_admin_all():
+    """nginx proksib /api/files/ kaudu KÕIK backend-teed avalikult."""
+    from server.routers import reocr as reocr_router
+    teed = [r.path for r in reocr_router.router.routes if "reocr" in r.path]
+    assert all(p.startswith("/admin/") for p in teed), teed
+```
+
+Fixture'id `client_admin_reocr` ja `login_editor` võta olemasolevast
+`tests/test_reocr_router.py`-st (sama muster) või `tests/conftest.py`-st, kui need on seal
+juba olemas — ära kirjuta uut auth-seadistust.
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub**
+
+Run: `.venv/bin/pytest tests/test_reocr_cancel_endpoint.py -v`
+Expected: FAIL — 405 Method Not Allowed (endpointi pole).
+
+- [ ] **Step 3: Teosta endpoint**
+
+`server/routers/reocr.py` lõppu:
+
+```python
+@router.delete("/admin/reocr/{job_id}")
+def admin_reocr_cancel(job_id: str, user=Depends(require_role("admin"))):
+    """Katkestab re-OCR töö (üksik või batch).
+
+    Sync def — kogu töö on blokeeriv I/O (SFTP + failisüsteem), ADR 0002.
+
+    200 garanteerib VUTT-i poole katkestamise: pollimist ei ole, teose lukk on
+    vaba, tulemust ei rakendata. Kui LOSSi koristus ebaõnnestus, võib
+    kaugserveris jääk edasi eksisteerida — vastuses `remote_cleanup: "failed"`.
+    """
+    try:
+        return reocr_ops.cancel_reocr_job(job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Tööd ei leitud")
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+```
+
+Kontrolli, et failis on `from fastapi import HTTPException` ja `from .. import reocr_ops`
+(või vastav import) juba olemas; kui `reocr_ops` imporditakse funktsioonide kaupa, lisa
+mooduli import.
+
+- [ ] **Step 4: Käivita testid ja commit**
+
+Run: `.venv/bin/pytest tests/ -q`
+Expected: kõik roheline.
+
+```bash
+git add server/routers/reocr.py tests/test_reocr_cancel_endpoint.py
+git commit -m "feat(reocr): DELETE /admin/reocr/{job_id} (#217)
+
+409 = ei ole katkestatav, 404 = tundmatu (ka korduv kutse), 503 = kirjutaja ei
+peatunud. Korduv DELETE ei ole idempotentne; ajalugu elab reocr_log.json-is."
+```
+
+---
+
+### Task 7: Krahhikindlus — `cancelling` töö lõpetatakse pärast restarti
+
+**Files:**
+- Modify: `server/reocr_ops.py:796` (`_startup_recovery_and_reaper`)
+- Test: `tests/test_reocr_cancel_recovery.py` (uus)
+
+**Interfaces:**
+- Consumes: `cancel_reocr_job`, `_cleanup_remote_job`
+- Produces: `reocr_ops._finish_interrupted_cancellations(jobs: dict) -> int` — mitu tööd lõpetati
+
+- [ ] **Step 1: Kirjuta kukkuv test**
+
+Loo `tests/test_reocr_cancel_recovery.py`:
+
+```python
+"""Pooleli jäänud katkestamine ei tohi restardi järel tööks tagasi muutuda (#217)."""
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture(autouse=True)
+def puhas(monkeypatch, tmp_path):
+    monkeypatch.setattr(reocr_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(reocr_ops, "REOCR_BACKUPS_DIR", str(tmp_path / "backups"))
+    monkeypatch.setattr(reocr_ops, "_persist_active_jobs", lambda: None)
+    monkeypatch.setattr(reocr_ops, "_append_to_log", lambda job, jid: None)
+    monkeypatch.setattr(reocr_ops.reocr_state, "remove_batch_mapping", lambda jid: None)
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job", lambda jid, job: True)
+
+
+def test_cancelling_too_lopetatakse():
+    jobs = {"b1": {"status": "cancelling", "slug": "s", "produced_pages": []}}
+    lopetatud = reocr_ops._finish_interrupted_cancellations(jobs)
+    assert lopetatud == 1
+    assert "b1" not in jobs
+
+
+def test_aktiivseid_toid_ei_puututa():
+    jobs = {"b1": {"status": "processing", "slug": "s"}}
+    assert reocr_ops._finish_interrupted_cancellations(jobs) == 0
+    assert "b1" in jobs
+
+
+def test_koristuse_torge_ei_jata_tood_aktiivseks(monkeypatch):
+    """Isegi kui kaugkoristus ebaõnnestub, ei tohi töö jääda teost lukustama."""
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job", lambda jid, job: False)
+    jobs = {"b1": {"status": "cancelling", "slug": "s", "produced_pages": []}}
+    assert reocr_ops._finish_interrupted_cancellations(jobs) == 1
+    assert "b1" not in jobs
+```
+
+- [ ] **Step 2: Käivita test ja veendu, et see kukub**
+
+Run: `.venv/bin/pytest tests/test_reocr_cancel_recovery.py -v`
+Expected: FAIL — `AttributeError: _finish_interrupted_cancellations`
+
+- [ ] **Step 3: Teosta**
+
+`server/reocr_ops.py`:
+
+```python
+def _finish_interrupted_cancellations(jobs: dict) -> int:
+    """Lõpetab `cancelling` olekusse jäänud tööd (protsess suri koristuse ajal).
+
+    `cancelling` töö EI OLE aktiivne töö — ilma selleta jääks pooleli katkestatud
+    töö restardi järel teost lukustama, mis on täpselt see probleem, mille vastu
+    kogu see feature tehakse (#217).
+    """
+    lopetatud = 0
+    for job_id in [k for k, v in jobs.items() if v.get("status") == "cancelling"]:
+        job = jobs[job_id]
+        remote_ok = _cleanup_remote_job(job_id, job)
+        slug = job.get("slug") or ""
+        for stem in job.get("produced_pages", []):
+            try:
+                os.unlink(os.path.join(BASE_DIR, slug, stem + ".ocr"))
+            except OSError:
+                pass
+        _restore_backups(job_id)
+        job["status"] = "cancelled"
+        job["remote_cleanup"] = "ok" if remote_ok else "failed"
+        _append_to_log(job, job_id)
+        jobs.pop(job_id, None)
+        reocr_state.remove_batch_mapping(job_id)
+        _forget_cancel_state(job_id)
+        lopetatud += 1
+        logger.info(f"Re-OCR {job_id}: pooleli jäänud katkestamine lõpetatud")
+    return lopetatud
+```
+
+- [ ] **Step 4: Ühenda stardi-taastesse**
+
+`_startup_recovery_and_reaper` sees, kohe pärast tööde mällu laadimist (enne
+poll-lõimede kasutuselevõttu), lisa mõlema registri jaoks:
+
+```python
+    _finish_interrupted_cancellations(_reocr_jobs)
+    _finish_interrupted_cancellations(_reocr_batch_jobs)
+    _persist_active_jobs()
+```
+
+- [ ] **Step 5: Käivita testid ja commit**
+
+Run: `.venv/bin/pytest tests/ -q`
+Expected: kõik roheline.
+
+```bash
+git add server/reocr_ops.py tests/test_reocr_cancel_recovery.py
+git commit -m "feat(reocr): lõpeta pooleli jäänud katkestamine restardi järel (#217)
+
+cancelling persisteeritakse enne koristust; stardi-taaste lõpetab selle
+best-effort. Ilma selleta muutuks pooleli katkestatud töö restardi järel taas
+aktiivseks ja lukustaks teose."
+```
+
+---
+
+### Task 8: Frontend — nupp, kinnitus ja `cancelled` kuvamine
+
+**Files:**
+- Modify: `src/pages/Review.tsx`, `src/pages/manage/PageActionBar.tsx`, `src/locales/et/*.json`, `src/locales/en/*.json`
+- Create: `src/services/reocrService.ts` funktsioon (kui teenusefail on olemas; muidu lisa olemasolevasse API-moodulisse, kus re-OCR kutsed juba elavad)
+
+**Interfaces:**
+- Consumes: `DELETE /admin/reocr/{job_id}`
+- Produces: `cancelReocrJob(jobId: string, token: string): Promise<{ status: string; remote_cleanup: string; deleted_ocr: number; restored_ocr: number }>`
+
+- [ ] **Step 1: Leia, kus re-OCR API-kutsed juba elavad**
+
+```bash
+grep -rn "admin/reocr\|reocr" src/services/*.ts src/pages/Review.tsx | head -20
+```
+
+Lisa `cancelReocrJob` SAMASSE moodulisse, kus `startReocr`/`getReocrStatus` on — ära loo
+uut teenusefaili ühe funktsiooni jaoks.
+
+- [ ] **Step 2: Lisa API-funktsioon**
+
+```ts
+export async function cancelReocrJob(
+  jobId: string, token: string,
+): Promise<{ status: string; remote_cleanup: string; deleted_ocr: number; restored_ocr: number }> {
+  const res = await fetch(`${FILE_API_URL}/admin/reocr/${jobId}`, {
+    method: 'DELETE',
+    headers: getAuthHeaders(token),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({}));
+    throw new Error(detail.detail || `Katkestamine ebaõnnestus (${res.status})`);
+  }
+  return res.json();
+}
+```
+
+- [ ] **Step 3: Lisa i18n võtmed MÕLEMASSE keelde**
+
+`src/locales/et/` vastavas nimeruumis (sama, kus re-OCR tekstid juba on):
+
+```json
+"cancelJob": "Katkesta töö",
+"cancelConfirmTitle": "Katkestada OCR-töö?",
+"cancelConfirmBody": "Töö peatatakse ja seni valmis saanud lehtede tulemused visatakse ära. Juba rakendatud tekste see ei puuduta.",
+"cancelSuccess": "Töö katkestatud",
+"cancelFailed": "Katkestamine ebaõnnestus",
+"statusCancelled": "Katkestatud"
+```
+
+`src/locales/en/` samasse nimeruumi:
+
+```json
+"cancelJob": "Cancel job",
+"cancelConfirmTitle": "Cancel the OCR job?",
+"cancelConfirmBody": "The job stops and results for pages finished so far are discarded. Already applied text is not affected.",
+"cancelSuccess": "Job cancelled",
+"cancelFailed": "Cancelling failed",
+"statusCancelled": "Cancelled"
+```
+
+- [ ] **Step 4: Lisa nupp Review.tsx OCR-tööde loendisse**
+
+Iga aktiivse töö (`uploading`/`processing`/`slow`) real nupp, mis avab kinnituse ja kutsub
+`cancelReocrJob`. Õnnestumisel värskenda loendit ja näita toast.
+
+- [ ] **Step 5: Lisa nupp Manage batch-ribale**
+
+`src/pages/manage/PageActionBar.tsx` — sama muster nagu `batchConfirm` juba kasutab.
+
+**NB:** `cancelled` EI OLE Manage'i püsiv staatus. Pärast katkestamist aktiivne töö kaob ja
+riba lihtsalt ei kuvata; kasutaja tagasiside on toast. Püsiv `cancelled` on ainult Review
+ajaloos (`reocr_log.json`).
+
+- [ ] **Step 6: Käivita väravad ja commit**
+
+```bash
+npm run typecheck && npm test && npm run lint:ci
+```
+
+Expected: typecheck puhas, testid rohelised (sh `localeParity.test.ts` — kui see kukub, on
+võti ainult ühes keeles).
+
+```bash
+git add src/ && git commit -m "feat(reocr): katkestamise nupp ja kinnitusdialoog (#217)"
+```
+
+---
+
+### Task 9: Dokumentatsioon ja issue
+
+**Files:**
+- Modify: `CLAUDE.md` (re-OCR rida, kui seal on staatuste loend), `docs/decisions/` (uus ADR)
+
+- [ ] **Step 1: Kirjuta ADR**
+
+Uus fail `docs/decisions/0018-reocr-katkestamine.md`. Sisu tuum (invariandid, mis peavad
+üle elama):
+
+- katkestamine = „tööd ei olnud"; osalisi tulemusi ei säilitata (põhjendus: taustatöö,
+  katkestamine ei võida aega, ainult suvalise prefiksi)
+- `.ocr` omand: `produced_pages`, mitte plaanitud lehed; ülekirjutamine varundatakse
+- `cancelling` on persisteeritud vaheolek; terminalüleminekud on CAS-iga välistavad
+- üleslaadimislõim `join`-itakse, poll-lõimi (jagatud singletonid) vaigistab CAS
+- `200` garanteerib VUTT-i poole; LOSSis võib jääk edasi eksisteerida
+- LOSSi peatamine käib piltide kustutamise kaudu; kuni `BATCH_SIZE = 4` lehte jõuab lõpuni
+
+- [ ] **Step 2: Käivita kõik väravad**
+
+```bash
+.venv/bin/pytest tests/ -q && npm run typecheck && npm test && npm run lint:ci
+```
+
+- [ ] **Step 3: Commit ja PR**
+
+```bash
+git add -A && git commit -m "docs(adr): 0018 — re-OCR töö katkestamine (#217)"
+git push -u origin feat/reocr-katkestamine
+gh pr create --title "Re-OCR töö katkestamine (#217)" --body "Sulgeb #217. Spekk: docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spekk | Task |
+|---|---|
+| `.ocr` omand: `produced_pages` | Task 2 |
+| Ülekirjutamise varundus + taastamine | Task 1 |
+| Varukoopiad `state/` all (gitignore-lõks) | Task 1 Step 3 + test |
+| `cancelling` vaheolek | Task 3 |
+| Välistavad terminalüleminekud (CAS) | Task 3 |
+| Poll-lõime vaigistamine (jagatud singleton) | Task 3 Step 4 |
+| Üleslaadimislõime `Event` + `join` | Task 4 |
+| `join` aegumine → ei koristata | Task 5 (`RuntimeError` → 503) |
+| Kaugkoristus, LOSSi peatamine | Task 5 Step 3 |
+| SFTP tõrge → lokaalne katkestamine ikka | Task 5 test |
+| `remote_cleanup` logikirjes | Task 5 Step 5 |
+| API staatustabel, korduv DELETE → 404 | Task 6 |
+| job_id nimeruumi invariant | Task 3 (`RuntimeError`) + test |
+| Krahhikindlus | Task 7 |
+| Frontend + i18n mõlemas keeles | Task 8 |
+| `cancelled` on logi-tasandi staatus | Task 8 Step 5 märkus |
+
+**Placeholder-kontroll:** kõik sammud sisaldavad päris koodi või päris käsku. Kaks
+teadlikku „leia üles" sammu (Task 6 Step 1 fixture'id, Task 8 Step 1 teenusemoodul) on
+seal, kus koodibaasis on juba olemasolev muster, mida tuleb järgida, mitte dubleerida —
+mõlemal on selge juhis, mida otsida ja mida MITTE teha.
+
+**Tüübi-järjepidevus:** `_write_ocr_file(slug, page_filename, text, job_id)` on neljandat
+argumenti kasutav kõigis kutsekohtades (Task 1 Step 6). `cancel_reocr_job` tagastusvorm on
+sama Task 5-s, Task 6 testides ja Task 8 TS-tüübis (`status`, `remote_cleanup`,
+`deleted_ocr`, `restored_ocr`). `_try_begin_cancel` tagastab `"single"`/`"batch"`/`None`
+nii teostuses kui testides.

--- a/docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md
+++ b/docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md
@@ -2,7 +2,7 @@
 
 **Kuupäev:** 2026-08-08
 **Issue:** #217
-**Staatus:** kinnitatud, ootab plaani
+**Staatus:** kinnitatud (ülevaatuse parandustega), ootab plaani
 
 ## Probleem
 
@@ -26,15 +26,13 @@ katkestust.
 
 `DELETE /admin/reocr/{job_id}` — üks endpoint nii üksik- kui batch-tööle.
 
-**Semantika: tööd ei olnud.** Katkestamine eemaldab lokaalse olekutega, koristab OCR-serveri,
-kustutab **selle töö** `.ocr` vahefailid ja kirjutab `reocr_log.json`-i kirje staatusega
-`cancelled`. Teose tegelikku teksti ei puudutata kunagi — re-OCR kirjutab ainult `.ocr`
-vahefaile, kuni admin need eraldi rakendab.
+**Semantika: tööd ei olnud.** Pärast katkestamist peab seis olema võimalikult lähedal
+seisule enne selle töö käivitamist. Teose tegelikku teksti ei puudutata kunagi — re-OCR
+kirjutab ainult `.ocr` vahefaile, kuni admin need eraldi rakendab.
 
-### Miks osalised tulemused kustutatakse
+### Miks selle töö osalised tulemused kustutatakse
 
-Kaalutud alternatiiv oli osalised `.ocr` failid alles jätta (olemasolev ülevaatuse voog
-oskaks neid juba käsitleda). Lükati tagasi:
+Kaalutud alternatiiv oli osalised `.ocr` failid alles jätta. Lükati tagasi:
 
 OCR jookseb **taustal** — katkestamine ei ole aktiivsest ootamisest pääsemine ega võida
 midagi peale suvalise algusprefiksi valmis lehtedest. Kui soovitakse väiksemat mahtu, tuleb
@@ -42,7 +40,56 @@ kohe vähem lehti OCR-i saata ja hiljem juurde lisada. Poolikute tulemuste alles
 soodustaks „katkestan ja vaatan, mis kätte jäi" mustrit, mis annab juhusliku lehekomplekti
 ilma selge tähenduseta.
 
-Seetõttu: katkestatud töö ei jäta jälge peale logikirje.
+## `.ocr` failide omand — kelle tulemus on kelle
+
+See on disaini kõige libedam koht ja esimene versioon sisaldas siin **andmekao viga**.
+
+Vale eeldus oli: „sama lehe uus töö kirjutas vana `.ocr` niikuinii üle, lisakadu ei teki".
+Vastunäide:
+
+1. lehel 17 on varasemast tööst `17.ocr`, mis on veel rakendamata;
+2. käivitatakse uus batch lehtedele 1–25;
+3. uus töö jõuab valmis teha ainult lehed 1–8;
+4. admin katkestab;
+5. `load_batch_mapping(job_id).pages` annab **plaanitud** lehed 1–25;
+6. kustutamine hävitaks `17.ocr`, mida katkestatud töö EI PUUTUNUD.
+
+Plaanitud lehtede nimekiri ei ole omandi tõend.
+
+### Otsus: tulemuse omand on jälgitav ja ülekirjutamine varundatakse
+
+**1. `produced_pages`** — töö kirje peab loendit lehtedest, mille `.ocr` see töö **päriselt
+kirjutas** (lisatakse siis, kui `_write_ocr_file` õnnestub, mitte tööd käivitades).
+Katkestamine kustutab ainult need.
+
+**2. Ülekirjutamise varundus** — kui `_write_ocr_file` leiab olemasoleva `.ocr` faili, siis
+see nihutatakse enne ülekirjutamist kohta
+
+```
+state/reocr_backups/{job_id}/{stem}.ocr
+```
+
+- katkestamine **taastab** varukoopiad tagasi teose kausta;
+- töö normaalne lõpp (`done`), `apply` või `discard` kustutab varukoopiad;
+- asukoht on `state/`, mitte teose kaust: `data/.gitignore` ignoreerib `*.ocr`, aga
+  `*.ocr.bak.{job_id}` EI vastaks sellele mustrile ja ilmuks `git status`-isse. Varukoopiad
+  on runtime-andmed ja kuuluvad `state/` alla (CLAUDE.md).
+
+Need kaks koos annavad „tööd ei olnud" semantika päriselt: puutumata lehed jäävad
+puutumata, ülekirjutatud lehed saavad oma eelmise sisu tagasi.
+
+### Tulevikusuund (mitte selles projektis)
+
+Arhitektuuriliselt puhtam oleks **töö-põhine tulemuste ala**:
+
+```
+state/reocr/{job_id}/{stem}.ocr     → apply promoveerib lehe tekstiks
+```
+
+Siis oleks katkestamine triviaalne (`rm -rf` töö kaust) ja omandiküsimust ei tekiks üldse.
+Sellest loobuti siin, sest see muudaks ka ülevaatuse voogu: praegu muutuvad lehed
+ülevaadatavaks **saabumise järjekorras** (`ocr_ready` stem'id), promoveerimismudel näitaks
+tulemusi alles töö lõpus. See on omaette projekt, mitte #217 kõrvalsaadus.
 
 ## LOSSi töö peatamine
 
@@ -69,7 +116,7 @@ järelejäänud batch neli ebaõnnestunud `open()` kutset — mikrosekundid, GPU
 Just seetõttu jõudis 2026-08-07 intsidendi töö kiiresti lõpuni, mitte ei jahvatanud 25 lehte
 inferentsi.
 
-**Kõva piir: `BATCH_SIZE = 4`.** `main_loop` teeb `rglob` **üks kord tsükli kohta** ja
+Kõva piir on `BATCH_SIZE = 4`. `main_loop` teeb `rglob` **üks kord tsükli kohta** ja
 itereerib seejärel selle külmutatud nimekirja üle. Kustutamine ei eemalda juba planeeritud
 kirjeid, vaid teeb nad avanematuks. Seega jõuab pärast katkestamist lõpuni **kuni üks
 lennusolev batch ehk 4 lehte** — need pildid olid mällu loetud enne kustutamist. Intsident
@@ -81,8 +128,6 @@ aga nõuaks teist deploy-teed marginaalse võidu eest.
 
 ### Sünkroniseerimismudel — mida VUTT LOSSist teab
 
-Aus kirjeldus, sest see määrab, mida katkestamine lubada saab:
-
 - **VUTT → LOSS** on ühesuunaline ja failipõhine. Katkestamine = piltide eemaldamine;
   valvuri järgmine `rglob` (iga 5 s) ei leia enam midagi.
 - **LOSS → VUTT staatust ei ole.** VUTT tuletab edenemist AINULT `.txt` failide pollimisest.
@@ -93,35 +138,104 @@ Aus kirjeldus, sest see määrab, mida katkestamine lubada saab:
 
 VUTT ei oota katkestamisel LOSSilt kinnitust. Kinnitust ei ole kellelt küsida.
 
+## Olekumasin: `cancelling` on vaheolek
+
+Katkestamine ei ole üks omistamine, vaid **kaheastmeline üleminek**:
+
+```
+uploading | processing | slow  →  cancelling  →  cancelled
+```
+
+`cancelling` ei pea UI-s nähtav olema; ta on olemas selleks, et vastata küsimusele „kes
+võitis".
+
+### Terminalüleminekud on vastastikku välistavad
+
+Ilma selleta on võistlus:
+
+```
+DELETE                              poller
+------                              ------
+kontrollib: processing
+                                    leiab viimase .txt
+                                    kirjutab .ocr
+                                    märgib done
+märgib cancelled
+kustutab .ocr
+```
+
+Nõue: `processing → done` ja `processing → cancelling` on **CAS-üleminekud sama luku all**
+(`_reocr_jobs_lock` / `_reocr_batch_jobs_lock`). Kumbki õnnestub ainult siis, kui olek on
+endiselt see, mida ta eeldas. Kui katkestamine võitis, EI TOHI ükski worker pärast seda
+minna `ready`/`done`/`error` olekusse ega kirjutada uut `.ocr` tulemust.
+
+## Workerite vaigistamine enne koristust
+
+Koostööline lipp üksi EI OLE piisav: lipu seadmine ei tähenda, et worker on lõpetanud.
+`sftp.put()` võib olla parajasti pooleli ja lõpetada kirjutamise pärast kaugkoristust —
+täpselt see olukord, mida see disain vältida tahab.
+
+Kaks workerit vajavad **erinevat** mehhanismi, sest nende elutsükkel on erinev:
+
+| Worker | Kuju | Vaigistamine |
+|---|---|---|
+| Üleslaadimine (`reocr-batch-{job_id}`, `reocr-{job_id}`) | **töö-põhine lõim** | `threading.Event` + endpoint teeb `join(timeout)` enne koristust |
+| Pollimine (`reocr-poll`, `reocr-batch-poll`) | **jagatud singleton-lõim**, üks iteratsioon iga 10 s kõigi tööde üle | EI SAA join'ida — see peataks kõik teised tööd. Selle asemel: `.ocr` kirjutamine ja olekuüleminek toimuvad **luku all koos oleku ülekontrolliga**; kui töö on `cancelling`, visatakse allalaaditud tekst ära |
+
+Poll-lõime osas teeb CAS seega topelttööd: ta ei lahenda ainult „kes võitis", vaid on ka
+ainus viis, kuidas jagatud loop saab olla katkestamise suhtes ohutu.
+
+Protokoll tervikuna:
+
+```
+CAS: aktiivne → cancelling  (persisteeritud)
+        ↓
+üleslaadimislõim näeb Event'i ja väljub  →  join(timeout)
+poll-lõim ei kirjuta enam midagi (CAS blokeerib)
+        ↓
+selle töö jaoks ei ole ühtki kirjutajat — ei lokaalselt ega kaugserveris
+        ↓
+koristus: kaugserver → .ocr (produced_pages) → varukoopiate taastamine
+        ↓
+CAS: cancelling → cancelled, registrist eemaldamine, logikirje
+```
+
+Kui `join` aegub, katkestamine EI JÄTKA kaugkoristusega: logitakse viga ja töö jääb
+`cancelling` olekusse, kust taasteloogika (allpool) selle üles korjab. Parem jätta jääk
+kaugserverisse kui kirjutada kataloogi, kuhu keegi veel kirjutab.
+
+## Krahhikindlus
+
+`cancelling` **persisteeritakse enne koristust** (`reocr_active.json`). Kui protsess sureb
+koristuse ajal, teab stardi-taaste (`_startup_recovery_and_reaper`):
+
+> `cancelling` olekus töö ei ole aktiivne töö. Lõpeta selle koristus best-effort ja kirjuta
+> `cancelled`.
+
+Ilma selleta jääks pooleli katkestatud töö pärast restarti taas aktiivseks — täpselt see
+probleem, mille vastu kogu see feature tehakse. See muudab katkestamise idempotentseks ja
+taastatavaks operatsiooniks.
+
 ## API
 
 `DELETE /admin/reocr/{job_id}`, `require_role("admin")`. Endpoint valib registri job_id järgi
 (`_reocr_jobs` vs `_reocr_batch_jobs`).
 
+**Invariant: job_id nimeruum on nende kahe registri vahel globaalne.** Mõlemad kasutavad
+sama `generate_nanoid()` generaatorit, seega kokkulangevus on teoreetiliselt võimalik. Kui
+sama id esineb mõlemas registris, on see invariandi rikkumine — logi viga ja tagasta 409,
+ära arva.
+
 | Töö staatus | Vastus |
 |---|---|
 | `uploading`, `processing`, `slow` | 200, töö katkestatakse |
+| `cancelling` | 409 — katkestamine juba käib |
 | `done`, `error` | 409 — ei ole aktiivne |
 | tundmatu id | 404 |
 
-### Tegevuste järjekord ja miks just see
-
-1. Märgi töö lokaalselt `cancelled` (koostööline lipp)
-2. Lase üleslaadimislõimel see märgata ja väljuda
-3. Koristada OCR-server (pildid + `.txt`, seejärel `rmdir` work ja staging)
-4. Kustuta selle töö `.ocr` failid. **Lehtede nimekiri tuleb töö enda kirjest**, mitte
-   kausta skaneerimisest: batch'il `reocr_state.load_batch_mapping(job_id)` `pages`, üksiktööl
-   job-kirje `remote_img`/`remote_txt`. Kaustapõhine kustutamine hävitaks teiste tööde
-   ootel tulemused.
-5. Eemalda `reocr_active.json` kirje ja `reocr_state.remove_batch_mapping(job_id)`
-6. Kirjuta `reocr_log.json`-i kirje `cancelled`
-
-Järjekord ei ole vaba: kui koristada enne lõime peatamist, kirjutab pooleliolev
-`for entry in page_entries` tsükkel pildid tagasi kataloogi, mille just eemaldasime.
-
-**Issue's kirjeldatud lahendus ei kata seda punkti** — „märgi töö lõpetatuks → poll lõpetab"
-peatab poll-lõime, aga mitte üleslaadimislõime. Vaja on koostöölist lippu, mida
-üleslaadimistsükkel lehtede vahel kontrollib.
+**Korduv DELETE annab 404**, sest töö on aktiivregistrist eemaldatud. Katkestamine EI OLE
+idempotentne HTTP mõttes; see on teadlik valik, sest idempotentsus nõuaks logi-lookup'i
+väärtuse eest, mida siin ei ole. Ajalugu elab `reocr_log.json`-is.
 
 ### Lokaalne katkestamine ei sõltu kaugserverist
 
@@ -129,24 +243,50 @@ SFTP tõrge logitakse hoiatusena, aga lokaalne katkestamine viiakse **ikka lõpu
 Intsident oli täpselt selline: VUTT rippus, LOSS oli juba edasi läinud. Katkestamine, mis
 nõuab tervet kaugserverit, ebaõnnestub just siis, kui teda vaja on.
 
+**Mida 200 seega tähendab.** `200 cancelled` garanteerib VUTT-i poole katkestamise:
+pollimist ei ole, teose lukk on vaba, tulemust ei rakendata, lokaalne töö on kadunud. Kui
+LOSSi koristus ebaõnnestus, võib kaugserveris töö või failijääk **edasi eksisteerida**.
+Logikirje ütleb selle välja:
+
+```json
+{ "status": "cancelled", "remote_cleanup": "failed" }
+```
+
+Nii on hilisem diagnostika võimalik ilma logi ridu kokku otsimata.
+
 ## Frontend
 
 - Nupp OCR-tööde paneelis (`src/pages/Review.tsx`, `/admin/ocr/jobs` loend) ja teose
   Manage-vaate batch-ribal
 - Kinnitusdialoog, mis ütleb otse, et osalised tulemused visatakse ära
-- `cancelled` staatus vajab kuvamist (Review + Manage) ja i18n võtmeid **mõlemas keeles**
-  korraga (`fallbackLng` on väljas, ADR 0011)
+- i18n võtmed **mõlemas keeles** korraga (`fallbackLng` on väljas, ADR 0011)
+
+**Kust `cancelled` pärast värskendust tuleb.** Andmemudel määrab siin vastuse:
+`cancelled` on **logi tasandi staatus, mitte elava töö oma** — töö on aktiivregistrist
+kadunud.
+
+- **Review** loeb `reocr_log.json`-i ja näitab `cancelled` kirjet ajaloos — püsiv.
+- **Manage batch-riba** põhineb aktiivsel tööl. Pärast katkestamist ei ole aktiivset tööd,
+  seega riba lihtsalt kaob. Kasutaja tagasiside on **transient toast**, mitte püsiv
+  „cancelled" silt.
+
+Nii ei luba UI rohkem, kui andmemudel kannab.
 
 ## Testid
 
 | Test | Mida kaitseb |
 |---|---|
 | Katkestamine eemaldab töö `reocr_active.json`-ist | Teos ei jää 12 h lukku |
-| Selle töö `.ocr` failid kustutatakse | „Tööd ei olnud" semantika |
-| **Teiste teoste `.ocr` failid jäävad puutumata** | Kustutamise ulatus tuleb batch-mapping'ust, mitte kaustast |
-| Üleslaadimislõim peatub partii keskel | Koostööline lipp toimib |
+| Ainult `produced_pages` `.ocr` failid kustutatakse | **Omand** — plaanitud ≠ toodetud |
+| **Varasem `.ocr` sihtlehel säilib, kui katkestatud töö seda ei tootnud** | Ülalkirjeldatud andmekao viga |
+| Ülekirjutatud `.ocr` taastatakse varukoopiast | „Tööd ei olnud" semantika täies ulatuses |
+| Teiste teoste `.ocr` failid jäävad puutumata | Kustutamise ulatus tuleb töö kirjest, mitte kaustast |
+| **Katkestamine samal ajal, kui poller saab viimase tulemuse** | `done`/`cancelled` võistlus — täpselt üks terminalolek võidab |
+| **Poller ei kirjuta `.ocr` pärast `cancelling` algust** | Ghost-tulemus pärast koristust |
+| **Üleslaadimislõim ei kirjuta kaugfaili pärast kaugkoristust** | Koristuse/üleslaadimise võistlus |
+| `cancelling` töö lõpetatakse pärast restarti | Krahhikindlus; teos ei jää lukku |
 | SFTP tõrge → lokaalne katkestamine ikka õnnestub | Intsidendi kuju |
-| `done` → 409 | Ei kustuta valmis töö tulemusi |
+| `done` → 409, tundmatu → 404 | Ei kustuta valmis töö tulemusi |
 | Töö, mille kaugfailid on juba kadunud, on katkestatav | Intsidendi kuju |
 
 ## Riskid
@@ -155,8 +295,9 @@ nõuab tervet kaugserverit, ebaõnnestub just siis, kui teda vaja on.
 |---|---|
 | Kuni 4 lehte jõuab pärast katkestamist lõpuni | Teadlik ja dokumenteeritud; nende `.txt` kaob koos kataloogiga |
 | Katkestamine kustutab kehtiva töö tulemused | Kinnitusdialoog ütleb selle otse välja; `done` tööd ei ole katkestatavad |
-| Kustutamine haarab kaasa varasema re-OCR ootel tulemuse | Sama lehe uus töö kirjutas vana `.ocr` niikuinii üle — lisakadu ei teki |
-| Lennusolev batch kirjutab `.txt` kustutatud kataloogi | Kirjutamine ebaõnnestub LOSSis, VUTT ei polli enam |
+| Kaugkoristus ebaõnnestub → jääk LOSSis | `200` semantika on dokumenteeritud; logis `remote_cleanup: failed` |
+| `join` aegub → koristust ei tehta | Töö jääb `cancelling`, taaste korjab üles; jääk on parem kui võistlus |
+| Varukoopiad kogunevad | Kustutatakse `done`/`apply`/`discard` juures; taaste koristab orvud |
 
 ## Järgnev projekt (eraldi spekk)
 

--- a/docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md
+++ b/docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md
@@ -1,0 +1,176 @@
+# Re-OCR töö katkestamine — disainidokument
+
+**Kuupäev:** 2026-08-08
+**Issue:** #217
+**Staatus:** kinnitatud, ootab plaani
+
+## Probleem
+
+Käimasolevat re-OCR tööd ei saa katkestada — ei UI-st ega API-st. `server/routers/reocr.py`
+pakub käivitamist, staatust, logi, tulemuste rakendamist ja äraviskamist, aga **mitte
+katkestamist**. Ainus katkestatav OCR-töö on upload-viisardi oma
+(`DELETE /admin/upload/{upload_id}` → `cancel_upload()`).
+
+Valesti käivitatud töö puhul ei ole muud võimalust kui oodata `REOCR_ABSOLUTE_TIMEOUT` = 12 h
+täitumist. Vahepeal pärib poll-loop iga 10 s SFTP-ga `.txt`-faile, mida ei tule, ja
+`get_active_batch_for_work()` annab uuele batch'ile samal teosel **409** — teos on 12 tunniks
+lukus.
+
+**Intsident 2026-08-07:** batch `h72qr9` (teos `aekis7`, 25 lk) käivitati käsikirja-mudelil
+topeltlehtedega. Katkestamiseks kustutati pildid käsitsi OCR-serverist. LOSSi pool peatus
+korrektselt, VUTT-i pool jäi rippuma (9 lehte `ready`, 16 `processing`). Puhastus nõudis
+backendi seiskamist, käsitsi `state/reocr_active.json` muutmist ja restarti — ehk tootmise
+katkestust.
+
+## Otsus
+
+`DELETE /admin/reocr/{job_id}` — üks endpoint nii üksik- kui batch-tööle.
+
+**Semantika: tööd ei olnud.** Katkestamine eemaldab lokaalse olekutega, koristab OCR-serveri,
+kustutab **selle töö** `.ocr` vahefailid ja kirjutab `reocr_log.json`-i kirje staatusega
+`cancelled`. Teose tegelikku teksti ei puudutata kunagi — re-OCR kirjutab ainult `.ocr`
+vahefaile, kuni admin need eraldi rakendab.
+
+### Miks osalised tulemused kustutatakse
+
+Kaalutud alternatiiv oli osalised `.ocr` failid alles jätta (olemasolev ülevaatuse voog
+oskaks neid juba käsitleda). Lükati tagasi:
+
+OCR jookseb **taustal** — katkestamine ei ole aktiivsest ootamisest pääsemine ega võida
+midagi peale suvalise algusprefiksi valmis lehtedest. Kui soovitakse väiksemat mahtu, tuleb
+kohe vähem lehti OCR-i saata ja hiljem juurde lisada. Poolikute tulemuste alleshoidmine
+soodustaks „katkestan ja vaatan, mis kätte jäi" mustrit, mis annab juhusliku lehekomplekti
+ilma selge tähenduseta.
+
+Seetõttu: katkestatud töö ei jäta jälge peale logikirje.
+
+## LOSSi töö peatamine
+
+**Per-töö peatamise mehhanismi OCR-serveris EI OLE.** Ainus tõeline peatussignaal on
+SIGTERM/SIGINT → `shutdown_requested`, mida `main_loop` kontrollib batchide vahel — see
+peatab **terve teenuse**, sh teiste tööd. Katkestamiseks kõlbmatu.
+
+**Piltide kustutamine ON tegelik peatamismehhanism** ja see peatab ka GPU-töö.
+`process_batch` avab pildid enne mudeli kutsumist:
+
+```python
+for img_path, txt_path in batch_items:
+    try:
+        img = PILImage.open(img_path).convert("RGB")
+        ...
+    except Exception as e:
+        logger.error(f"Viga pildi avamisel {img_path}: {e}")
+if not images_pil:
+    return          # mudelit EI kutsuta
+```
+
+Kui ükski batchi pilt ei avane, väljutakse enne mudelit. Kustutamise järel maksab iga
+järelejäänud batch neli ebaõnnestunud `open()` kutset — mikrosekundid, GPU-d ei puudutata.
+Just seetõttu jõudis 2026-08-07 intsidendi töö kiiresti lõpuni, mitte ei jahvatanud 25 lehte
+inferentsi.
+
+**Kõva piir: `BATCH_SIZE = 4`.** `main_loop` teeb `rglob` **üks kord tsükli kohta** ja
+itereerib seejärel selle külmutatud nimekirja üle. Kustutamine ei eemalda juba planeeritud
+kirjeid, vaid teeb nad avanematuks. Seega jõuab pärast katkestamist lõpuni **kuni üks
+lennusolev batch ehk 4 lehte** — need pildid olid mällu loetud enne kustutamist. Intsident
+kinnitab: lk 9 oli batchis 9–12 ja jooksis lõpuni.
+
+**OCR-serverit ei muudeta** (ADR 0017 põhimõte). Kaalutud ja tagasi lükatud: töö-põhine
+katkestusmärgend (`.cancelled` fail, mida valvur kontrolliks) annaks 0-lehelise peatumise,
+aga nõuaks teist deploy-teed marginaalse võidu eest.
+
+### Sünkroniseerimismudel — mida VUTT LOSSist teab
+
+Aus kirjeldus, sest see määrab, mida katkestamine lubada saab:
+
+- **VUTT → LOSS** on ühesuunaline ja failipõhine. Katkestamine = piltide eemaldamine;
+  valvuri järgmine `rglob` (iga 5 s) ei leia enam midagi.
+- **LOSS → VUTT staatust ei ole.** VUTT tuletab edenemist AINULT `.txt` failide pollimisest.
+  Ta ei suuda eristada „pole veel alustanud" olukorrast „on parajasti batchi keskel".
+- **Jääk koristab ennast ise:** lennusoleva batchi `.txt` üritatakse kirjutada kataloogi,
+  mille me eemaldasime — kirjutamine ebaõnnestub ja logitakse LOSSis. VUTT-i see ei jõua,
+  sest pollimine on lõpetatud.
+
+VUTT ei oota katkestamisel LOSSilt kinnitust. Kinnitust ei ole kellelt küsida.
+
+## API
+
+`DELETE /admin/reocr/{job_id}`, `require_role("admin")`. Endpoint valib registri job_id järgi
+(`_reocr_jobs` vs `_reocr_batch_jobs`).
+
+| Töö staatus | Vastus |
+|---|---|
+| `uploading`, `processing`, `slow` | 200, töö katkestatakse |
+| `done`, `error` | 409 — ei ole aktiivne |
+| tundmatu id | 404 |
+
+### Tegevuste järjekord ja miks just see
+
+1. Märgi töö lokaalselt `cancelled` (koostööline lipp)
+2. Lase üleslaadimislõimel see märgata ja väljuda
+3. Koristada OCR-server (pildid + `.txt`, seejärel `rmdir` work ja staging)
+4. Kustuta selle töö `.ocr` failid. **Lehtede nimekiri tuleb töö enda kirjest**, mitte
+   kausta skaneerimisest: batch'il `reocr_state.load_batch_mapping(job_id)` `pages`, üksiktööl
+   job-kirje `remote_img`/`remote_txt`. Kaustapõhine kustutamine hävitaks teiste tööde
+   ootel tulemused.
+5. Eemalda `reocr_active.json` kirje ja `reocr_state.remove_batch_mapping(job_id)`
+6. Kirjuta `reocr_log.json`-i kirje `cancelled`
+
+Järjekord ei ole vaba: kui koristada enne lõime peatamist, kirjutab pooleliolev
+`for entry in page_entries` tsükkel pildid tagasi kataloogi, mille just eemaldasime.
+
+**Issue's kirjeldatud lahendus ei kata seda punkti** — „märgi töö lõpetatuks → poll lõpetab"
+peatab poll-lõime, aga mitte üleslaadimislõime. Vaja on koostöölist lippu, mida
+üleslaadimistsükkel lehtede vahel kontrollib.
+
+### Lokaalne katkestamine ei sõltu kaugserverist
+
+SFTP tõrge logitakse hoiatusena, aga lokaalne katkestamine viiakse **ikka lõpuni**.
+Intsident oli täpselt selline: VUTT rippus, LOSS oli juba edasi läinud. Katkestamine, mis
+nõuab tervet kaugserverit, ebaõnnestub just siis, kui teda vaja on.
+
+## Frontend
+
+- Nupp OCR-tööde paneelis (`src/pages/Review.tsx`, `/admin/ocr/jobs` loend) ja teose
+  Manage-vaate batch-ribal
+- Kinnitusdialoog, mis ütleb otse, et osalised tulemused visatakse ära
+- `cancelled` staatus vajab kuvamist (Review + Manage) ja i18n võtmeid **mõlemas keeles**
+  korraga (`fallbackLng` on väljas, ADR 0011)
+
+## Testid
+
+| Test | Mida kaitseb |
+|---|---|
+| Katkestamine eemaldab töö `reocr_active.json`-ist | Teos ei jää 12 h lukku |
+| Selle töö `.ocr` failid kustutatakse | „Tööd ei olnud" semantika |
+| **Teiste teoste `.ocr` failid jäävad puutumata** | Kustutamise ulatus tuleb batch-mapping'ust, mitte kaustast |
+| Üleslaadimislõim peatub partii keskel | Koostööline lipp toimib |
+| SFTP tõrge → lokaalne katkestamine ikka õnnestub | Intsidendi kuju |
+| `done` → 409 | Ei kustuta valmis töö tulemusi |
+| Töö, mille kaugfailid on juba kadunud, on katkestatav | Intsidendi kuju |
+
+## Riskid
+
+| Risk | Leevendus |
+|---|---|
+| Kuni 4 lehte jõuab pärast katkestamist lõpuni | Teadlik ja dokumenteeritud; nende `.txt` kaob koos kataloogiga |
+| Katkestamine kustutab kehtiva töö tulemused | Kinnitusdialoog ütleb selle otse välja; `done` tööd ei ole katkestatavad |
+| Kustutamine haarab kaasa varasema re-OCR ootel tulemuse | Sama lehe uus töö kirjutas vana `.ocr` niikuinii üle — lisakadu ei teki |
+| Lennusolev batch kirjutab `.txt` kustutatud kataloogi | Kirjutamine ebaõnnestub LOSSis, VUTT ei polli enam |
+
+## Järgnev projekt (eraldi spekk)
+
+**Upload'i „vale mudel" taastetee.** Kasutaja saadab käsikirjalise teksti trükimudelile ja
+tahab uuesti alustada ilma poolitamist kordamata. Tänane `cancel_upload()` on hävitav
+(`rmtree` + kaug-`rm -rf`), seega poolitusplaan kaob koos kõige muuga.
+
+Nõuded, mis on juba kokku lepitud:
+
+- **Poolitusplaan säilib.** Plaan on JSON `uploads/{id}/state.json`-is ja lähtefail püsib
+  VUTT-i poolel kuni impordini (`cleanup_prepress_artifacts` kutsutakse ainult
+  `import_work.py`-st). Uuesti maksab ainult masinaaeg (300 DPI + SFTP), mitte inimtöö.
+- **Metaandmeid peab saama muuta enne uut jooksu.** See on sisuline nõue, mitte mugavus:
+  mudel valitakse sammus 1 ja küpsetatakse `remote_staging_path = AUTO-OCR/{ocr_model}/{id}`
+  sisse (`upload_ops.py:214`). Ainult plaani säilitamine ei lahendaks vale mudeli juhtumit.
+- Osalised tulemused kustutatakse (vale mudeli oma ei ole kehtiv töötulemus).
+- `apply` ühekordne CAS (`awaiting_split → applying`, ADR 0017) tuleb teadlikult uuesti avada.

--- a/server/config.py
+++ b/server/config.py
@@ -102,6 +102,11 @@ ARCHIVES_FILE = os.path.join(_DATA_CONFIG_DIR, "archives.json")
 USER_SETTINGS_DIR = os.path.join(_STATE_DIR, "user_settings")
 NOTIFICATIONS_DIR = os.path.join(_STATE_DIR, "notifications")
 
+# Re-OCR ülekirjutatud .ocr tulemuste varukoopiad (katkestamisel taastatakse).
+# EI TOHI olla teose kaustas: data/.gitignore ignoreerib *.ocr, aga varukoopia
+# nimi ei vastaks mustrile ja ilmuks git status'isse (#217).
+REOCR_BACKUPS_DIR = os.path.join(_STATE_DIR, "reocr_backups")
+
 # Prosopograafia: ÜKS juur, selle all varatüübid (#221).
 # Kaardid on gitis, pildid mitte (data/.gitignore → *.jpg), aga MÕLEMAD elavad
 # siin — pildid olid varem state/-is ja see lahknemine tekitas kolm koopiat.

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -381,6 +381,36 @@ def cancel_reocr_job(job_id: str) -> dict:
     }
 
 
+def _finish_interrupted_cancellations(jobs: dict) -> int:
+    """Lõpetab `cancelling` olekusse jäänud tööd (protsess suri koristuse ajal).
+
+    `cancelling` töö EI OLE aktiivne töö — ilma selleta jääks pooleli katkestatud
+    töö restardi järel teost lukustama, mis on täpselt see probleem, mille vastu
+    kogu see feature tehakse (#217).
+    """
+    lopetatud = 0
+    for job_id in [k for k, v in jobs.items() if v.get("status") == "cancelling"]:
+        job = jobs[job_id]
+        remote_ok = _cleanup_remote_job(job_id, job)
+        slug = job.get("slug") or ""
+        for stem in job.get("produced_pages", []):
+            try:
+                os.unlink(os.path.join(BASE_DIR, slug, stem + ".ocr"))
+            except OSError:
+                pass
+        _restore_backups(job_id)
+        job["status"] = "cancelled"
+        job["finished_at"] = datetime.now().timestamp()
+        job["remote_cleanup"] = "ok" if remote_ok else "failed"
+        _append_to_log(job, job_id)
+        jobs.pop(job_id, None)
+        reocr_state.remove_batch_mapping(job_id)
+        _forget_cancel_state(job_id)
+        lopetatud += 1
+        logger.info(f"Re-OCR {job_id}: pooleli jäänud katkestamine lõpetatud")
+    return lopetatud
+
+
 def _mark_slow_if_stale(jid: str, job: dict, now: float) -> bool:
     """Sea slow=True esimest korda kui üle slow-läve. Debounce: teisel korral False."""
     if now - job.get("started_at", now) <= REOCR_PROCESSING_TIMEOUT:
@@ -1119,7 +1149,15 @@ def start_reocr_background() -> Optional[threading.Thread]:
         _reocr_batch_jobs.update(batch)
     logger.info(f"Re-OCR taastatud mällu: {len(single)} üksik + {len(batch)} batch "
                 f"({revived} surnud upload-i → processing)")
-    if revived:
+
+    # Pooleli jäänud katkestamised ENNE reconciliation'i: `cancelling` töö ei ole
+    # aktiivne töö ja teda ei tohi orvuna "taastada" (#217).
+    lopetatud = (_finish_interrupted_cancellations(_reocr_jobs)
+                 + _finish_interrupted_cancellations(_reocr_batch_jobs))
+    if lopetatud:
+        logger.info(f"Re-OCR: lõpetatud {lopetatud} pooleli jäänud katkestamist")
+
+    if revived or lopetatud:
         _persist_active_jobs()  # kirjuta teisendatud staatus kohe tagasi
     thread = threading.Thread(target=_startup_recovery_and_reaper, daemon=True,
                               name="reocr-startup-recovery")

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -126,6 +126,19 @@ def _restore_backups(job_id: str) -> int:
     return restored
 
 
+def _record_produced(job: dict, page_filename: str) -> None:
+    """Märgib, et SEE töö kirjutas selle lehe .ocr faili.
+
+    Katkestamine kustutab ainult siit loendist tulevad lehed. Plaanitud lehtede
+    nimekiri (batch mapping) EI OLE omandi tõend — töö võib olla katkestatud
+    enne, kui ta plaani lõpuni jõudis (#217).
+    """
+    stem = os.path.splitext(os.path.basename(page_filename))[0]
+    produced = job.setdefault("produced_pages", [])
+    if stem not in produced:
+        produced.append(stem)
+
+
 def _drop_backups(job_id: str) -> None:
     """Kustutab varukoopiad (töö lõppes normaalselt / rakendati / visati ära)."""
     shutil.rmtree(_backup_dir(job_id), ignore_errors=True)
@@ -352,6 +365,8 @@ def _poll_batch_job(job_id: str) -> None:
                             if cur_entry.get("remote_txt_name") == entry["remote_txt_name"] and cur_entry.get("status") == "processing":
                                 cur_entry["status"] = "ready"
                                 current["last_progress_at"] = datetime.now().timestamp()
+                                # Omand: see töö kirjutas selle lehe .ocr faili (#217)
+                                _record_produced(current, entry["page_filename"])
                                 ready = True
                                 break
             except Exception as e:
@@ -800,6 +815,11 @@ def poll_reocr_job(job_id: str) -> dict:
             if page_fn:
                 try:
                     ocr_path = _write_ocr_file(log_job["slug"], page_fn, text, job_id)
+                    # Omand: see töö kirjutas selle lehe .ocr faili (#217)
+                    with _reocr_jobs_lock:
+                        live = _reocr_jobs.get(job_id)
+                        if live is not None:
+                            _record_produced(live, page_fn)
                     logger.info(f"Re-OCR {job_id}: .ocr fail kirjutatud → {ocr_path}")
                 except Exception as write_err:
                     logger.warning(f"Re-OCR {job_id}: .ocr faili kirjutamine ebaõnnestus: {write_err}")

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -37,7 +37,7 @@ def _append_to_log(job: dict, job_id: str):
         "started_at": job.get("started_at"),
         "finished_at": job.get("finished_at"),
     }
-    for _k in ("recovered", "original_status", "recovered_at"):
+    for _k in ("recovered", "original_status", "recovered_at", "remote_cleanup"):
         if _k in job:
             entry[_k] = job[_k]
     with _log_lock:
@@ -271,6 +271,116 @@ def _forget_cancel_state(job_id: str) -> None:
     _upload_threads.pop(job_id, None)
 
 
+def _cleanup_remote_job(job_id: str, job: dict) -> bool:
+    """Kustutab OCR-serverist selle töö pildid ja .txt-d. True = õnnestus.
+
+    Piltide kustutamine ON peatamismehhanism: valvuri process_batch väljub enne
+    mudeli kutsumist, kui ükski pilt ei avane. Kuni üks lennusolev batch
+    (BATCH_SIZE = 4) jõuab siiski lõpuni — teadlik piir, vt spekki (#217).
+    """
+    remote_work = job.get("remote_work")
+    if not remote_work:
+        return True
+    try:
+        sftp = _sftp_open(job_id)
+    except Exception as e:
+        logger.warning(f"Re-OCR {job_id} koristuse SFTP viga: {e}")
+        return False
+
+    work_abs = f"{OCR_SERVER_PATH}/{remote_work}"
+    ok = True
+    try:
+        try:
+            for name in sftp.listdir(work_abs):
+                try:
+                    sftp.remove(f"{work_abs}/{name}")
+                except Exception as e:
+                    logger.warning(f"Re-OCR {job_id} {name} kustutus: {e}")
+                    ok = False
+        except FileNotFoundError:
+            pass          # kaust on juba kadunud — intsidendi kuju, mitte viga
+        remote_staging = job.get("remote_staging") or ""
+        for d in (work_abs, f"{OCR_SERVER_PATH}/{remote_staging}" if remote_staging else ""):
+            if not d:
+                continue
+            try:
+                sftp.rmdir(d)
+            except Exception:
+                pass      # mitte-tühi või puuduv kaust ei ole katkestamise viga
+    finally:
+        try:
+            sftp.close()
+        except Exception:
+            pass
+        close_ssh(job_id)
+    return ok
+
+
+def cancel_reocr_job(job_id: str) -> dict:
+    """Katkestab re-OCR töö. „Tööd ei olnud" — vt spekki (#217).
+
+    Järjekord ei ole vaba: koristus tohib alata alles siis, kui ühtki kirjutajat
+    enam ei ole. Vastasel juhul kirjutab pooleliolev üleslaadimine failid tagasi
+    kataloogi, mille just eemaldasime.
+    """
+    registry = _try_begin_cancel(job_id)
+    if registry is None:
+        if job_id in _reocr_jobs or job_id in _reocr_batch_jobs:
+            raise ValueError("Töö ei ole katkestatav")
+        raise KeyError(job_id)
+
+    jobs = _reocr_jobs if registry == "single" else _reocr_batch_jobs
+    lock = _reocr_jobs_lock if registry == "single" else _reocr_batch_jobs_lock
+    with lock:
+        job = dict(jobs.get(job_id) or {})
+
+    if not _quiesce_upload(job_id):
+        # Kirjutaja on veel elus — jäta töö `cancelling` olekusse, stardi-taaste
+        # korjab üles. Jääk kaugserveris on parem kui võistlus koristusega.
+        logger.error(
+            f"Re-OCR {job_id}: üleslaadimislõim ei peatunud, koristus edasi lükatud"
+        )
+        raise RuntimeError("Üleslaadimislõim ei peatunud")
+
+    remote_ok = _cleanup_remote_job(job_id, job)
+
+    slug = job.get("slug") or ""
+    deleted = 0
+    for stem in job.get("produced_pages", []):
+        path = os.path.join(BASE_DIR, slug, stem + ".ocr")
+        try:
+            os.unlink(path)
+            deleted += 1
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.warning(f"Re-OCR {job_id} {stem}.ocr kustutus: {e}")
+    restored = _restore_backups(job_id)
+
+    with lock:
+        current = jobs.pop(job_id, None)
+    if current is not None:
+        current["status"] = "cancelled"
+        current["finished_at"] = datetime.now().timestamp()
+        current["remote_cleanup"] = "ok" if remote_ok else "failed"
+        _append_to_log(current, job_id)
+
+    reocr_state.remove_batch_mapping(job_id)
+    _forget_cancel_state(job_id)
+    _persist_active_jobs()
+
+    logger.info(
+        f"Re-OCR {job_id} katkestatud: {deleted} .ocr kustutatud, "
+        f"{restored} taastatud, kaugkoristus={'ok' if remote_ok else 'failed'}"
+    )
+    return {
+        "status": "cancelled",
+        "remote_cleanup": "ok" if remote_ok else "failed",
+        "deleted_ocr": deleted,
+        "restored_ocr": restored,
+    }
+
+
 def _mark_slow_if_stale(jid: str, job: dict, now: float) -> bool:
     """Sea slow=True esimest korda kui üle slow-läve. Debounce: teisel korral False."""
     if now - job.get("started_at", now) <= REOCR_PROCESSING_TIMEOUT:
@@ -402,12 +512,18 @@ def _batch_inactive(job: Dict, now: float, timeout: int) -> bool:
     return (now - job.get("last_progress_at", job["started_at"])) > timeout
 
 
-def _finalize_batch_if_complete(job: Dict) -> None:
-    """Kui kõik lehed ready/error → märgi job done."""
+def _finalize_batch_if_complete(job: Dict, job_id: Optional[str] = None) -> None:
+    """Kui kõik lehed ready/error → märgi job done.
+
+    Normaalne lõpp kustutab varukoopiad: valminud töö tulemus ON nüüd kehtiv
+    ootel tulemus ja ülekirjutatud vanem versioon on lõplikult asendatud (#217).
+    """
     if all(e["status"] in ("ready", "error") for e in job["pages"]):
         if job["status"] != "done":
             job["status"] = "done"
             job["finished_at"] = datetime.now().timestamp()
+            if job_id:
+                _drop_backups(job_id)
 
 
 def _poll_batch_job(job_id: str) -> None:
@@ -421,7 +537,7 @@ def _poll_batch_job(job_id: str) -> None:
         remote_work = job["remote_work"]
         remote_staging = job.get("remote_staging", os.path.dirname(remote_work))
         if not pending:
-            _finalize_batch_if_complete(job)
+            _finalize_batch_if_complete(job, job_id)
             return
     try:
         sftp = _sftp_open(job_id)
@@ -501,7 +617,7 @@ def _poll_batch_job(job_id: str) -> None:
     with _reocr_batch_jobs_lock:
         current = _reocr_batch_jobs.get(job_id)
         if current:
-            _finalize_batch_if_complete(current)
+            _finalize_batch_if_complete(current, job_id)
 
 
 def _batch_poll_iteration(now: float) -> None:
@@ -903,6 +1019,9 @@ def poll_reocr_job(job_id: str) -> dict:
                 current_job["text"] = text
                 current_job["finished_at"] = datetime.now().timestamp()
                 log_job = dict(current_job)
+                # Normaalne lõpp: ülekirjutatud vanem tulemus on lõplikult
+                # asendatud, varukoopiat pole enam vaja hoida (#217).
+                _drop_backups(job_id)
         if log_job:
             logger.info(f"Re-OCR {job_id} valmis ({len(text)} tähemärki)")
             _append_to_log(log_job, job_id)

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -743,8 +743,9 @@ def build_reocr_status(work_id: str, work_path: str) -> Dict:
     active: Dict[str, str] = {}
     errors: Dict[str, str] = {}
     progress: Optional[Dict] = None
+    active_job_id: Optional[str] = None   # katkestamiseks Manage-vaates (#217)
     with _reocr_batch_jobs_lock:
-        for j in _reocr_batch_jobs.values():
+        for jid, j in _reocr_batch_jobs.items():
             if j["work_id"] != work_id:
                 continue
             is_active = j["status"] in ("uploading", "processing")
@@ -762,6 +763,8 @@ def build_reocr_status(work_id: str, work_path: str) -> Dict:
             # Eelista aktiivset batchi; muidu viimast nähtut
             if is_active or progress is None:
                 progress = summary
+            if is_active:
+                active_job_id = jid
     ocr_ready: List[str] = []
     try:
         for fn in os.listdir(work_path):
@@ -799,6 +802,8 @@ def build_reocr_status(work_id: str, work_path: str) -> Dict:
         "progress": progress,
         "batch_ready": batch_ready,
         "batch_known": batch_known,
+        # Aktiivse batchi id — Manage-vaate katkestamisnupu jaoks (#217)
+        "active_job_id": active_job_id,
     }
 
 

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -4,11 +4,15 @@ Re-OCR operatsioonid — olemasoleva lehekülje uuesti transkribeerimine OCR ser
 import io
 import json
 import os
+import shutil
 import threading
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 
-from .config import BASE_DIR, OCR_SERVER_PATH, REOCR_LOG_FILE, UPLOAD_ENABLED, get_logger
+from .config import (
+    BASE_DIR, OCR_SERVER_PATH, REOCR_BACKUPS_DIR, REOCR_LOG_FILE,
+    UPLOAD_ENABLED, get_logger,
+)
 from .utils import atomic_write_json, generate_nanoid
 from .upload_ops import _sftp_open, close_ssh
 from .upload.ocr_client import publish_atomic
@@ -70,13 +74,62 @@ def get_reocr_log(offset: int = 0, limit: int = 50) -> dict:
 logger = get_logger(__name__)
 
 
-def _write_ocr_file(slug: str, page_filename: str, text: str) -> str:
-    """Kirjutab OCR-tulemuse {BASE_DIR}/{slug}/{stem}.ocr failina (püsiv staging). Tagastab tee."""
+def _backup_dir(job_id: str) -> str:
+    """Selle töö ülekirjutatud .ocr failide varukoopiad."""
+    return os.path.join(REOCR_BACKUPS_DIR, job_id)
+
+
+def _write_ocr_file(slug: str, page_filename: str, text: str, job_id: str) -> str:
+    """Kirjutab OCR-tulemuse {BASE_DIR}/{slug}/{stem}.ocr failina (püsiv staging).
+
+    Kui sihtkohas on juba ootel tulemus, varundatakse see ENNE ülekirjutamist.
+    Katkestamine taastab varukoopia — muidu hävitaks katkestatud töö varasema
+    kehtiva tulemuse, mida ta ise ei tootnud (#217).
+    """
     stem = os.path.splitext(os.path.basename(page_filename))[0]
     ocr_path = os.path.join(BASE_DIR, slug, stem + ".ocr")
+
+    if os.path.exists(ocr_path):
+        bdir = _backup_dir(job_id)
+        os.makedirs(bdir, exist_ok=True)
+        backup_path = os.path.join(bdir, stem + ".ocr")
+        # Ainult ESIMENE ülekirjutus varundatakse — muidu kirjutaks sama töö
+        # kordusjooks varukoopia enda tulemusega üle.
+        if not os.path.exists(backup_path):
+            shutil.copy2(ocr_path, backup_path)
+            reocr_state.add_backup_target(job_id, stem + ".ocr", ocr_path)
+
     with open(ocr_path, "w", encoding="utf-8") as f:
         f.write(text)
     return ocr_path
+
+
+def _restore_backups(job_id: str) -> int:
+    """Taastab selle töö ülekirjutatud .ocr failid. Tagastab taastatud arvu."""
+    bdir = _backup_dir(job_id)
+    if not os.path.isdir(bdir):
+        return 0
+    mapping = reocr_state.load_backup_targets(job_id)
+    restored = 0
+    for name in os.listdir(bdir):
+        target = mapping.get(name)
+        if not target:
+            logger.warning(f"Re-OCR {job_id}: varukoopial {name} puudub sihtkoht")
+            continue
+        try:
+            shutil.move(os.path.join(bdir, name), target)
+            restored += 1
+        except OSError as e:
+            logger.warning(f"Re-OCR {job_id}: varukoopia taaste {name}: {e}")
+    shutil.rmtree(bdir, ignore_errors=True)
+    reocr_state.remove_backup_targets(job_id)
+    return restored
+
+
+def _drop_backups(job_id: str) -> None:
+    """Kustutab varukoopiad (töö lõppes normaalselt / rakendati / visati ära)."""
+    shutil.rmtree(_backup_dir(job_id), ignore_errors=True)
+    reocr_state.remove_backup_targets(job_id)
 
 
 def _build_batch_pages(slug: str, pages: List[Tuple[str, Optional[int]]]) -> List[Dict]:
@@ -291,7 +344,7 @@ def _poll_batch_job(job_id: str) -> None:
             ready = False
             try:
                 # AUTORITEETNE: kirje page_filename määrab sihtkoha
-                _write_ocr_file(slug, entry["page_filename"], text)
+                _write_ocr_file(slug, entry["page_filename"], text, job_id)
                 with _reocr_batch_jobs_lock:
                     current = _reocr_batch_jobs.get(job_id)
                     if current and current.get("status") == "processing":
@@ -746,7 +799,7 @@ def poll_reocr_job(job_id: str) -> dict:
             page_fn = log_job.get("page_filename", "")
             if page_fn:
                 try:
-                    ocr_path = _write_ocr_file(log_job["slug"], page_fn, text)
+                    ocr_path = _write_ocr_file(log_job["slug"], page_fn, text, job_id)
                     logger.info(f"Re-OCR {job_id}: .ocr fail kirjutatud → {ocr_path}")
                 except Exception as write_err:
                     logger.warning(f"Re-OCR {job_id}: .ocr faili kirjutamine ebaõnnestus: {write_err}")

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -195,6 +195,46 @@ def _persist_active_jobs() -> None:
     reocr_state.persist_active_jobs({**single, **batch})
 
 
+# `slow` on LIPP, mitte staatus — aeglase töö staatus jääb `processing`
+# (vt _mark_slow_if_stale), seega ta on siin juba kaetud.
+CANCELLABLE_STATUSES = ("uploading", "processing")
+
+
+def _try_begin_cancel(job_id: str) -> Optional[str]:
+    """CAS: aktiivne → cancelling. Tagastab "single"/"batch" või None.
+
+    See on ainus koht, kus katkestamine algab. `cancelling` on vaheolek, mis
+    vastab küsimusele „kes võitis": poller ei tohi pärast seda enam ühtki
+    tulemust kirjutada ega tööd `done`-ks märkida (#217).
+    """
+    in_single = job_id in _reocr_jobs
+    in_batch = job_id in _reocr_batch_jobs
+    if in_single and in_batch:
+        # job_id nimeruum on registrite vahel globaalne — sama generate_nanoid().
+        # Kokkulangevus on invariandi rikkumine; ära arva, kumb oli mõeldud.
+        raise RuntimeError("job_id {} esineb mõlemas registris".format(job_id))
+
+    if in_single:
+        with _reocr_jobs_lock:
+            job = _reocr_jobs.get(job_id)
+            if not job or job.get("status") not in CANCELLABLE_STATUSES:
+                return None
+            job["status"] = "cancelling"
+        _persist_active_jobs()
+        return "single"
+
+    if in_batch:
+        with _reocr_batch_jobs_lock:
+            job = _reocr_batch_jobs.get(job_id)
+            if not job or job.get("status") not in CANCELLABLE_STATUSES:
+                return None
+            job["status"] = "cancelling"
+        _persist_active_jobs()
+        return "batch"
+
+    return None
+
+
 def _mark_slow_if_stale(jid: str, job: dict, now: float) -> bool:
     """Sea slow=True esimest korda kui üle slow-läve. Debounce: teisel korral False."""
     if now - job.get("started_at", now) <= REOCR_PROCESSING_TIMEOUT:
@@ -354,6 +394,13 @@ def _poll_batch_job(job_id: str) -> None:
                 continue
             if text is None:
                 continue
+            # Olek võis allalaadimise ajal muutuda (DELETE käib teises lõimes).
+            # Poll on JAGATUD singleton-lõim — teda ei saa peatada, seega on see
+            # kontroll ainus, mis hoiab ära ghost-tulemuse pärast koristust (#217).
+            with _reocr_batch_jobs_lock:
+                cur = _reocr_batch_jobs.get(job_id)
+                if not cur or cur.get("status") != "processing":
+                    return
             ready = False
             try:
                 # AUTORITEETNE: kirje page_filename määrab sihtkoha

--- a/server/reocr_ops.py
+++ b/server/reocr_ops.py
@@ -235,6 +235,42 @@ def _try_begin_cancel(job_id: str) -> Optional[str]:
     return None
 
 
+# Töö-põhised katkestuslipud ja üleslaadimislõimed. Poll-lõimi siin EI OLE —
+# need on jagatud singletonid ja neid vaigistab CAS (vt _try_begin_cancel).
+_cancel_events: Dict[str, threading.Event] = {}
+_upload_threads: Dict[str, threading.Thread] = {}
+
+
+def _cancel_event(job_id: str) -> threading.Event:
+    """Töö katkestuslipp (loob vajadusel)."""
+    ev = _cancel_events.get(job_id)
+    if ev is None:
+        ev = threading.Event()
+        _cancel_events[job_id] = ev
+    return ev
+
+
+def _quiesce_upload(job_id: str, timeout: float = 30.0) -> bool:
+    """Seab katkestuslipu ja OOTAB üleslaadimislõime lõpetamist.
+
+    Tagastab False, kui lõim ei peatunud. Sel juhul EI TOHI kaugkoristust teha:
+    pooleliolev sftp.put() kirjutaks pildid tagasi kataloogi, mille kustutasime.
+    Jääk kaugserveris on parem kui võistlus (#217).
+    """
+    _cancel_event(job_id).set()
+    t = _upload_threads.get(job_id)
+    if t is None or not t.is_alive():
+        return True
+    t.join(timeout)
+    return not t.is_alive()
+
+
+def _forget_cancel_state(job_id: str) -> None:
+    """Koristab katkestamise abistruktuurid."""
+    _cancel_events.pop(job_id, None)
+    _upload_threads.pop(job_id, None)
+
+
 def _mark_slow_if_stale(jid: str, job: dict, now: float) -> bool:
     """Sea slow=True esimest korda kui üle slow-läve. Debounce: teisel korral False."""
     if now - job.get("started_at", now) <= REOCR_PROCESSING_TIMEOUT:
@@ -301,6 +337,10 @@ def start_reocr_batch(work_id: str, slug: str, work_path: str,
 
     def _upload():
         try:
+            # Katkestamine võis jõuda enne, kui lõim käivitus (#217).
+            if _cancel_event(job_id).is_set():
+                logger.info(f"Re-OCR {job_id}: üleslaadimine katkestatud")
+                return
             sftp = _sftp_open(job_id)
             staging_abs = f"{OCR_SERVER_PATH}/{remote_staging}"
             work_abs = f"{OCR_SERVER_PATH}/{remote_work}"
@@ -310,6 +350,9 @@ def start_reocr_batch(work_id: str, slug: str, work_path: str,
                 except FileNotFoundError:
                     sftp.mkdir(d)
             for entry in page_entries:
+                if _cancel_event(job_id).is_set():
+                    logger.info(f"Re-OCR batch {job_id}: üleslaadimine katkestatud")
+                    return
                 src = os.path.join(work_path, entry["page_filename"])
                 # .tmp+rename: valvur ei kontrolli piltide stabiilsust (#220)
                 publish_atomic(sftp, src, f"{work_abs}/{entry['remote_img_name']}")
@@ -337,7 +380,9 @@ def start_reocr_batch(work_id: str, slug: str, work_path: str,
                     current["finished_at"] = datetime.now().timestamp()
             _persist_active_jobs()
 
-    threading.Thread(target=_upload, daemon=True, name=f"reocr-batch-{job_id}").start()
+    _t = threading.Thread(target=_upload, daemon=True, name=f"reocr-batch-{job_id}")
+    _upload_threads[job_id] = _t
+    _t.start()
     return job_id
 
 
@@ -750,6 +795,10 @@ def start_reocr_job(work_id: str, slug: str, img_path: str, page_filename: str =
 
     def _upload():
         try:
+            # Katkestamine võis jõuda enne, kui lõim käivitus (#217).
+            if _cancel_event(job_id).is_set():
+                logger.info(f"Re-OCR {job_id}: üleslaadimine katkestatud")
+                return
             sftp = _sftp_open(job_id)
             staging_abs = f"{OCR_SERVER_PATH}/{remote_staging}"
             work_abs = f"{OCR_SERVER_PATH}/{remote_work}"
@@ -787,7 +836,9 @@ def start_reocr_job(work_id: str, slug: str, img_path: str, page_filename: str =
             except Exception:
                 pass
 
-    threading.Thread(target=_upload, daemon=True, name=f"reocr-{job_id}").start()
+    _t = threading.Thread(target=_upload, daemon=True, name=f"reocr-{job_id}")
+    _upload_threads[job_id] = _t
+    _t.start()
     return job_id
 
 

--- a/server/reocr_recovery.py
+++ b/server/reocr_recovery.py
@@ -147,7 +147,7 @@ def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[
             buf = io.BytesIO()
             sftp.getfo(f"{work_dir}/{fname}", buf)
             text = buf.getvalue().decode("utf-8", errors="replace")
-            reocr_ops._write_ocr_file(slug, info["page_filename"], text)
+            reocr_ops._write_ocr_file(slug, info["page_filename"], text, job_id)
             now = datetime.now().timestamp()
             reocr_ops._append_to_log(
                 {"work_id": work_id, "slug": slug, "page_filename": info["page_filename"],
@@ -218,7 +218,7 @@ def _recover_single(sftp, base: str, job_id: str, recovered: List[str], skipped:
             buf = io.BytesIO()
             sftp.getfo(txt_abs, buf)
             text = buf.getvalue().decode("utf-8", errors="replace")
-            reocr_ops._write_ocr_file(slug, meta["page_filename"], text)
+            reocr_ops._write_ocr_file(slug, meta["page_filename"], text, job_id)
             now = datetime.now().timestamp()
             reocr_ops._append_to_log(
                 {"work_id": meta.get("work_id"), "slug": slug, "page_filename": meta["page_filename"],

--- a/server/reocr_recovery.py
+++ b/server/reocr_recovery.py
@@ -148,6 +148,8 @@ def _recover_batch(sftp, base: str, job_id: str, mapping: dict, recovered: List[
             sftp.getfo(f"{work_dir}/{fname}", buf)
             text = buf.getvalue().decode("utf-8", errors="replace")
             reocr_ops._write_ocr_file(slug, info["page_filename"], text, job_id)
+            # Orb on terminalis — varukoopia ei kuulu enam ühelegi elavale tööle (#217)
+            reocr_ops._drop_backups(job_id)
             now = datetime.now().timestamp()
             reocr_ops._append_to_log(
                 {"work_id": work_id, "slug": slug, "page_filename": info["page_filename"],
@@ -219,6 +221,8 @@ def _recover_single(sftp, base: str, job_id: str, recovered: List[str], skipped:
             sftp.getfo(txt_abs, buf)
             text = buf.getvalue().decode("utf-8", errors="replace")
             reocr_ops._write_ocr_file(slug, meta["page_filename"], text, job_id)
+            # Orb on terminalis — varukoopia ei kuulu enam ühelegi elavale tööle (#217)
+            reocr_ops._drop_backups(job_id)
             now = datetime.now().timestamp()
             reocr_ops._append_to_log(
                 {"work_id": meta.get("work_id"), "slug": slug, "page_filename": meta["page_filename"],

--- a/server/reocr_state.py
+++ b/server/reocr_state.py
@@ -100,3 +100,61 @@ def list_batch_mapping_ids() -> list:
         return [os.path.splitext(f)[0] for f in os.listdir(BATCH_MAPS_DIR) if f.endswith(".json")]
     except FileNotFoundError:
         return []
+
+
+# --- Ülekirjutatud .ocr tulemuste varukoopiate sihtkohad (#217) ---
+#
+# Varukoopia failinimi (017.ocr) ei ütle, MILLISE teose kausta ta kuulub —
+# taastamine vajab täisteed. Register hoiab seost varukoopia nime ja sihttee vahel.
+
+BACKUP_TARGETS_DIR = os.path.join(STATE_DIR, "reocr_backup_targets")
+
+
+def _backup_targets_path(job_id: str) -> str:
+    return os.path.join(BACKUP_TARGETS_DIR, f"{job_id}.json")
+
+
+def add_backup_target(job_id: str, backup_name: str, target_path: str) -> None:
+    """Seob varukoopia failinime tema teose-kausta sihtteega. Atomaarne."""
+    with _file_lock:
+        try:
+            os.makedirs(BACKUP_TARGETS_DIR, exist_ok=True)
+            path = _backup_targets_path(job_id)
+            data = {}
+            if os.path.exists(path):
+                try:
+                    with open(path, "r", encoding="utf-8") as f:
+                        loaded = json.load(f)
+                    if isinstance(loaded, dict):
+                        data = loaded
+                except (OSError, ValueError):
+                    data = {}
+            data[backup_name] = target_path
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp, path)
+        except Exception as e:
+            logger.warning(f"varukoopia sihtkoha kirjutamine ebaõnnestus ({job_id}): {e}")
+
+
+def load_backup_targets(job_id: str) -> Dict[str, str]:
+    """Varukoopia nimi → sihttee. Puuduv või vigane fail = tühi dict."""
+    with _file_lock:
+        try:
+            with open(_backup_targets_path(job_id), "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return data if isinstance(data, dict) else {}
+        except (OSError, ValueError):
+            return {}
+
+
+def remove_backup_targets(job_id: str) -> None:
+    """Kustuta selle töö varukoopia-register (best-effort)."""
+    with _file_lock:
+        try:
+            os.remove(_backup_targets_path(job_id))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.warning(f"varukoopia registri kustutamine ebaõnnestus ({job_id}): {e}")

--- a/server/reocr_state.py
+++ b/server/reocr_state.py
@@ -14,7 +14,9 @@ from .config import STATE_DIR, get_logger
 logger = get_logger(__name__)
 
 REOCR_ACTIVE_FILE = os.path.join(STATE_DIR, "reocr_active.json")
-_ACTIVE_STATUSES = ("uploading", "processing")
+# `cancelling` PEAB siin olema: pooleli jäänud katkestamine tuleb restardi järel
+# üles leida ja lõpetada, muidu muutub töö taas aktiivseks ja lukustab teose (#217).
+_ACTIVE_STATUSES = ("uploading", "processing", "cancelling")
 _file_lock = threading.Lock()
 
 

--- a/server/routers/reocr.py
+++ b/server/routers/reocr.py
@@ -11,6 +11,7 @@ from ..reocr_apply import apply_ocr_results, discard_ocr_results
 from ..reocr_ops import (
     REOCR_MAX_CONCURRENT,
     build_reocr_status,
+    cancel_reocr_job,
     get_active_batch_for_work,
     get_active_reocr_count,
     get_reocr_log,
@@ -249,3 +250,25 @@ async def admin_reocr_discard(
     page_filenames = _validate_apply_pages(data.get("page_filenames"))
     result = await run_in_threadpool(discard_ocr_results, path, page_filenames)
     return {"status": "success", **result}
+
+
+@router.delete("/admin/reocr/{job_id}")
+def admin_reocr_cancel(job_id: str, user=Depends(require_role("admin"))):
+    """Katkestab re-OCR töö (üksik või batch).
+
+    Sync def — kogu töö on blokeeriv I/O (SFTP + failisüsteem), ADR 0002.
+
+    200 garanteerib VUTT-i poole katkestamise: pollimist ei ole, teose lukk on
+    vaba, tulemust ei rakendata. Kui LOSSi koristus ebaõnnestus, võib
+    kaugserveris jääk edasi eksisteerida — vastuses `remote_cleanup: "failed"`.
+    """
+    try:
+        return cancel_reocr_job(job_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Tööd ei leitud")
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except RuntimeError as e:
+        # Kirjutaja ei peatunud — töö jääb `cancelling` olekusse, stardi-taaste
+        # korjab üles. Klient võib hiljem uuesti proovida.
+        raise HTTPException(status_code=503, detail=str(e))

--- a/src/locales/en/review.json
+++ b/src/locales/en/review.json
@@ -19,10 +19,20 @@
     "slow": "slow, still running",
     "elapsedMin": "running {{mins}} min",
     "elapsedLtMin": "running <1 min",
-    "queueAhead": "~{{count}} earlier jobs"
+    "queueAhead": "~{{count}} earlier jobs",
+    "cancelJob": "Cancel job",
+    "cancelConfirm": "Cancel? Results for pages finished so far will be discarded.",
+    "cancelConfirmYes": "Yes, cancel",
+    "cancelling": "Cancelling...",
+    "cancelFailed": "Cancelling failed",
+    "statusCancelled": "Cancelled"
   },
   "ocr": {
-    "type": { "upload": "Upload", "reocr": "Re-OCR", "batch": "Batch" },
+    "type": {
+      "upload": "Upload",
+      "reocr": "Re-OCR",
+      "batch": "Batch"
+    },
     "statusKey": {
       "uploading": "uploading",
       "processing": "OCR running",

--- a/src/locales/en/workspace.json
+++ b/src/locales/en/workspace.json
@@ -194,7 +194,12 @@
         "processing": "OCR running",
         "ready": "OCR ready for review",
         "error": "OCR failed"
-      }
+      },
+      "cancelJob": "Cancel OCR job",
+      "cancelConfirm": "Results for pages finished so far will be discarded.",
+      "cancelConfirmYes": "Yes, cancel",
+      "cancelling": "Cancelling...",
+      "cancelFailed": "Cancelling failed"
     },
     "tabs": {
       "replace": "Replace pages"

--- a/src/locales/et/review.json
+++ b/src/locales/et/review.json
@@ -19,10 +19,20 @@
     "slow": "aeglane, töötab edasi",
     "elapsedMin": "töötab {{mins}} min",
     "elapsedLtMin": "töötab <1 min",
-    "queueAhead": "~{{count}} varasemat tööd"
+    "queueAhead": "~{{count}} varasemat tööd",
+    "cancelJob": "Katkesta töö",
+    "cancelConfirm": "Katkestada? Seni valmis saanud lehtede tulemused visatakse ära.",
+    "cancelConfirmYes": "Jah, katkesta",
+    "cancelling": "Katkestan...",
+    "cancelFailed": "Katkestamine ebaõnnestus",
+    "statusCancelled": "Katkestatud"
   },
   "ocr": {
-    "type": { "upload": "Üleslaadimine", "reocr": "Re-OCR", "batch": "Batch" },
+    "type": {
+      "upload": "Üleslaadimine",
+      "reocr": "Re-OCR",
+      "batch": "Batch"
+    },
     "statusKey": {
       "uploading": "üleslaadimine",
       "processing": "OCR töötleb",

--- a/src/locales/et/workspace.json
+++ b/src/locales/et/workspace.json
@@ -194,7 +194,12 @@
         "processing": "OCR töötab",
         "ready": "OCR valmis ülevaatamiseks",
         "error": "OCR ebaõnnestus"
-      }
+      },
+      "cancelJob": "Katkesta OCR-töö",
+      "cancelConfirm": "Seni valmis saanud lehtede tulemused visatakse ära.",
+      "cancelConfirmYes": "Jah, katkesta",
+      "cancelling": "Katkestan...",
+      "cancelFailed": "Katkestamine ebaõnnestus"
     },
     "tabs": {
       "replace": "Asenda leheküljed"

--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -30,7 +30,8 @@ import {
   Wand2,
   CheckCircle,
   XCircle,
-  UserCircle
+  UserCircle,
+  Ban
 } from 'lucide-react';
 import Header from '../components/Header';
 import { FILE_API_URL } from '../config';
@@ -62,8 +63,10 @@ interface ReocrJob {
   page_filename: string;
   page_number: number | null;
   username: string;
-  status: 'uploading' | 'processing' | 'done' | 'error';
+  status: 'uploading' | 'processing' | 'done' | 'error' | 'cancelled';
   error: string | null;
+  /** Kas LOSSi koristus õnnestus. Ainult katkestatud töödel (#217). */
+  remote_cleanup?: 'ok' | 'failed';
   started_at: number | null;
   finished_at: number | null;
   slow?: boolean;
@@ -172,6 +175,32 @@ const Review: React.FC = () => {
       // eiramine
     } finally {
       if (showLoader) setReocrLoading(false);
+    }
+  };
+
+  // Töö katkestamine (#217). Kinnitus käib rea sees — sama muster nagu
+  // Manage-vaate batch-ribal; eraldi modaali see ei vääri.
+  const [cancelConfirmId, setCancelConfirmId] = useState<string | null>(null);
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
+  const handleCancelJob = async (jobId: string) => {
+    if (!token) return;
+    setCancellingId(jobId);
+    setCancelError(null);
+    try {
+      const res = await fetchWithTimeout(`${FILE_API_URL}/admin/reocr/${jobId}`, {
+        method: 'DELETE',
+        headers: getAuthHeaders(token),
+        timeout: 30000,   // koristus teeb SFTP-d, 10 s võib jääda napiks
+      });
+      if (!res.ok) throw new Error(String(res.status));
+      setCancelConfirmId(null);
+      await loadReocrJobs();
+    } catch {
+      setCancelError(jobId);
+    } finally {
+      setCancellingId(null);
     }
   };
 
@@ -647,6 +676,49 @@ const Review: React.FC = () => {
                             {isSlow ? t('reocr.slow') : t(`ocr.statusKey.${job.status_key}`)}
                           </span>
                         )}
+
+                        {/* Katkestamine ainult re-OCR töödel (#217): upload'i
+                            viisardil on oma katkestamine ja oma endpoint. */}
+                        {isActive && job.type !== 'upload' && (
+                          cancelConfirmId === job.id ? (
+                            <div className="flex shrink-0 items-center gap-1.5">
+                              <button
+                                type="button"
+                                onClick={() => handleCancelJob(job.id)}
+                                disabled={cancellingId === job.id}
+                                title={t('reocr.cancelConfirm')}
+                                className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                              >
+                                {cancellingId === job.id
+                                  ? t('reocr.cancelling')
+                                  : t('reocr.cancelConfirmYes')}
+                              </button>
+                              <button
+                                type="button"
+                                onClick={() => setCancelConfirmId(null)}
+                                className="rounded border border-gray-300 px-2 py-1 text-xs hover:bg-gray-100"
+                              >
+                                {t('common:buttons.cancel')}
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              type="button"
+                              data-testid={`cancel-job-${job.id}`}
+                              onClick={() => setCancelConfirmId(job.id)}
+                              title={t('reocr.cancelJob')}
+                              className="shrink-0 rounded border border-gray-300 p-1.5 text-gray-500 hover:bg-red-50 hover:text-red-600"
+                            >
+                              <Ban size={14} />
+                            </button>
+                          )
+                        )}
+
+                        {cancelError === job.id && (
+                          <span className="shrink-0 text-xs text-red-600">
+                            {t('reocr.cancelFailed')}
+                          </span>
+                        )}
                       </div>
                     );
                   })}
@@ -669,12 +741,17 @@ const Review: React.FC = () => {
                         <div
                           key={entry.job_id}
                           className={`flex items-center gap-4 px-4 py-2.5 rounded-lg border text-sm ${
-                            entry.status === 'done' ? 'border-green-100 bg-green-50/50' : 'border-red-100 bg-red-50/50'
+                            entry.status === 'done' ? 'border-green-100 bg-green-50/50' :
+                            entry.status === 'cancelled' ? 'border-gray-200 bg-gray-50' :
+                            'border-red-100 bg-red-50/50'
                           }`}
                         >
+                          {/* Katkestatud töö EI OLE viga — hall, mitte punane (#217) */}
                           <div className="shrink-0">
                             {entry.status === 'done'
                               ? <CheckCircle size={15} className="text-green-500" />
+                              : entry.status === 'cancelled'
+                              ? <Ban size={15} className="text-gray-400" />
                               : <XCircle size={15} className="text-red-400" />}
                           </div>
                           <div className="flex-1 min-w-0">

--- a/src/pages/WorkManage.tsx
+++ b/src/pages/WorkManage.tsx
@@ -36,6 +36,7 @@ import {
   reorderWorkPages,
   replaceWorkPageImage,
   restoreDeletedWorkPage,
+  cancelReocrJob,
   startReocrBatch,
   WorkPageInfo,
 } from '../services/workApi';
@@ -116,6 +117,9 @@ const WorkManage: React.FC = () => {
   const [ocrModel, setOcrModel] = useState<'print' | 'hand'>('print');
   const [batchConfirm, setBatchConfirm] = useState(false);
   const [batchError, setBatchError] = useState<string | null>(null);
+  // Batchi katkestamine (#217)
+  const [batchCancelConfirm, setBatchCancelConfirm] = useState(false);
+  const [batchCancelling, setBatchCancelling] = useState(false);
   const [reocrPollNonce, setReocrPollNonce] = useState(0); // batch-käivitusel taaskäivitab poll-effecti
 
   // Ootel re-OCR tulemuste hulgi-tegevused (kinnitus avaneb inline, nagu bulkDelete)
@@ -364,6 +368,23 @@ const WorkManage: React.FC = () => {
       setReocrPollNonce((n) => n + 1);
     } catch (e: any) {
       setBatchError(e.message || t('manage.reocr.error'));
+    }
+  };
+
+  const handleCancelBatch = async () => {
+    const jobId = reocrStatus?.active_job_id;
+    if (!authToken || !jobId) return;
+    setBatchCancelling(true);
+    setBatchError(null);
+    try {
+      await cancelReocrJob(jobId, authToken);
+      setBatchCancelConfirm(false);
+      // Nonce bump: status-fetch näitab, et aktiivset tööd enam pole
+      setReocrPollNonce((n) => n + 1);
+    } catch (e: any) {
+      setBatchError(e.message || t('manage.reocr.cancelFailed'));
+    } finally {
+      setBatchCancelling(false);
     }
   };
 
@@ -736,12 +757,52 @@ const WorkManage: React.FC = () => {
 
                 {/* Progress-kokkuvõte */}
                 {reocrStatus?.progress && reocrStatus.progress.total > 0 && (
-                  <div className="mx-4 mb-2 text-sm text-green-700">
-                    {t('manage.reocr.progress', {
-                      ready: reocrStatus.progress.ready,
-                      total: reocrStatus.progress.total,
-                      errors: reocrStatus.progress.errors,
-                    })}
+                  <div className="mx-4 mb-2 flex flex-wrap items-center gap-3 text-sm text-green-700">
+                    <span>
+                      {t('manage.reocr.progress', {
+                        ready: reocrStatus.progress.ready,
+                        total: reocrStatus.progress.total,
+                        errors: reocrStatus.progress.errors,
+                      })}
+                    </span>
+                    {/* Katkestamine (#217). `cancelled` EI OLE siin püsiv staatus:
+                        pärast katkestamist aktiivne töö kaob ja riba lihtsalt ei
+                        kuvata. Püsiv ajalugu elab Review-vaates. */}
+                    {reocrStatus.progress.active && reocrStatus.active_job_id && (
+                      batchCancelConfirm ? (
+                        <span className="flex items-center gap-1.5">
+                          <button
+                            type="button"
+                            onClick={handleCancelBatch}
+                            disabled={batchCancelling}
+                            className="rounded bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50"
+                          >
+                            {batchCancelling
+                              ? t('manage.reocr.cancelling')
+                              : t('manage.reocr.cancelConfirmYes')}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setBatchCancelConfirm(false)}
+                            className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
+                          >
+                            {t('common:buttons.cancel')}
+                          </button>
+                          <span className="text-xs text-gray-500">
+                            {t('manage.reocr.cancelConfirm')}
+                          </span>
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          data-testid="cancel-batch"
+                          onClick={() => setBatchCancelConfirm(true)}
+                          className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-red-50 hover:text-red-700"
+                        >
+                          {t('manage.reocr.cancelJob')}
+                        </button>
+                      )
+                    )}
                   </div>
                 )}
 

--- a/src/services/workApi.ts
+++ b/src/services/workApi.ts
@@ -137,6 +137,19 @@ export function startReocrBatch(
   return apiPost<ApiStatusResponse>(`/admin/work/${workId}/reocr-batch`, body, authJson(token, { timeout: 30000 }));
 }
 
+export interface ReocrCancelResponse {
+  status: string;
+  /** "failed" = LOSSi koristus ei õnnestunud; VUTT-i pool on siiski katkestatud (#217). */
+  remote_cleanup: 'ok' | 'failed';
+  deleted_ocr: number;
+  restored_ocr: number;
+}
+
+/** Katkestab re-OCR töö (üksik või batch). Koristus teeb SFTP-d → pikem timeout. */
+export function cancelReocrJob(jobId: string, token: string): Promise<ReocrCancelResponse> {
+  return apiDelete<ReocrCancelResponse>(`/admin/reocr/${jobId}`, auth(token, { timeout: 30000 }));
+}
+
 export interface ReocrFailure {
   filename: string;
   error: string;

--- a/src/utils/reocrStatus.ts
+++ b/src/utils/reocrStatus.ts
@@ -9,6 +9,8 @@ export interface ReocrStatusResponse {
   ocr_ready: string[]; // stem'id (ilma laiendita)
   errors: Record<string, string>;
   progress: { total: number; ready: number; errors: number; active: boolean } | null;
+  /** Aktiivse batchi id — katkestamiseks. null, kui aktiivset tööd pole (#217). */
+  active_job_id?: string | null;
   /** Viimase batch-töö lehed, mille .ocr on kettal (stem'id). Puudub vanas backendis. */
   batch_ready?: string[];
   /** Kas batch-kirje leiti. False = server taaskäivitati → varuvariant. */

--- a/tests/test_reocr_atomic_publish.py
+++ b/tests/test_reocr_atomic_publish.py
@@ -83,16 +83,31 @@ def test_batch_reocr_avaldab_aatomiliselt(monkeypatch, tmp_path):
 
 
 def test_reocr_ops_ei_kasuta_enam_otse_put_i():
-    """Valvur: reocr_ops lähtekoodis ei tohi olla sftp.put() sihtnimega.
+    """Valvur: reocr_ops ei tohi kutsuda otse sftp.put().
 
-    See on tekstipõhine kontroll, sest mõlemad üleslaadimisteed elavad
-    taustalõimede sees, mida on kallis tervikuna käivitada.
+    Kontroll käib AST-i pealt, mitte tekstiotsinguga: docstring'id ja
+    kommentaarid räägivad `sftp.put()`-ist kui probleemist, ja tekstiotsing
+    langes nende peale valepositiiviga.
+
+    Mõlemad üleslaadimisteed elavad taustalõimede sees, mida on kallis
+    tervikuna käivitada — seepärast staatiline kontroll.
     """
+    import ast
     import inspect
 
     from server import reocr_ops
 
-    source = inspect.getsource(reocr_ops)
-    assert "sftp.put(" not in source, (
-        "reocr_ops kutsub veel otse sftp.put() — kasuta publish_atomic()"
+    puu = ast.parse(inspect.getsource(reocr_ops))
+    kutsed = [
+        node for node in ast.walk(puu)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "put"
+        and isinstance(node.func.value, ast.Name)
+        and "sftp" in node.func.value.id.lower()
+    ]
+    assert not kutsed, (
+        "reocr_ops kutsub otse sftp.put() ridadel {} — kasuta publish_atomic()".format(
+            [n.lineno for n in kutsed]
+        )
     )

--- a/tests/test_reocr_batch.py
+++ b/tests/test_reocr_batch.py
@@ -11,7 +11,7 @@ def test_write_ocr_file_kirjutab_stem_ocr(tmp_path, monkeypatch):
     work_dir = tmp_path / "1700-teos"
     work_dir.mkdir()
 
-    path = reocr_ops._write_ocr_file("1700-teos", "1700-teos-pg005.jpg", "Tekst siin.")
+    path = reocr_ops._write_ocr_file("1700-teos", "1700-teos-pg005.jpg", "Tekst siin.", "job1")
 
     assert path == str(work_dir / "1700-teos-pg005.ocr")
     assert (work_dir / "1700-teos-pg005.ocr").read_text(encoding="utf-8") == "Tekst siin."

--- a/tests/test_reocr_cancel.py
+++ b/tests/test_reocr_cancel.py
@@ -1,0 +1,142 @@
+"""cancel_reocr_job: „tööd ei olnud" semantika (#217)."""
+import os
+
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture
+def keskkond(tmp_path, monkeypatch):
+    slug = "1650-test-abc123"
+    work = tmp_path / slug
+    work.mkdir()
+    monkeypatch.setattr(reocr_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(reocr_ops, "REOCR_BACKUPS_DIR", str(tmp_path / "backups"))
+    monkeypatch.setattr(
+        reocr_ops.reocr_state, "BACKUP_TARGETS_DIR", str(tmp_path / "targets")
+    )
+    monkeypatch.setattr(reocr_ops, "_reocr_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_reocr_batch_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_cancel_events", {})
+    monkeypatch.setattr(reocr_ops, "_upload_threads", {})
+    monkeypatch.setattr(reocr_ops, "_persist_active_jobs", lambda: None)
+    logitud = []
+    monkeypatch.setattr(reocr_ops, "_append_to_log",
+                        lambda job, jid: logitud.append(dict(job)))
+    monkeypatch.setattr(reocr_ops.reocr_state, "remove_batch_mapping", lambda jid: None)
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job", lambda jid, job: True)
+    return slug, work, logitud
+
+
+def test_kustutab_ainult_toodetud_lehed(keskkond):
+    """REGRESSIOON: plaanitud lehtede järgi kustutamine hävitaks varasema
+    ootel tulemuse lehel, mida katkestatud töö ei puutunud."""
+    slug, work, _ = keskkond
+    (work / "001.ocr").write_text("selle töö tulemus", encoding="utf-8")
+    (work / "017.ocr").write_text("VARASEM ootel tulemus", encoding="utf-8")
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug,
+        "produced_pages": ["001"],           # 017 EI OLE siin
+        "pages": [{"page_filename": "001.jpg"}, {"page_filename": "017.jpg"}],
+    }
+
+    result = reocr_ops.cancel_reocr_job("b1")
+
+    assert result["deleted_ocr"] == 1
+    assert not (work / "001.ocr").exists()
+    assert (work / "017.ocr").read_text(encoding="utf-8") == "VARASEM ootel tulemus"
+
+
+def test_taastab_ylekirjutatud_tulemuse(keskkond):
+    slug, work, _ = keskkond
+    (work / "017.ocr").write_text("VANA", encoding="utf-8")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS", "b1")
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug, "produced_pages": ["017"], "pages": [],
+    }
+
+    result = reocr_ops.cancel_reocr_job("b1")
+
+    assert result["restored_ocr"] == 1
+    assert (work / "017.ocr").read_text(encoding="utf-8") == "VANA"
+
+
+def test_eemaldab_too_registrist(keskkond):
+    slug, _work, _ = keskkond
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug, "produced_pages": [], "pages": [],
+    }
+    reocr_ops.cancel_reocr_job("b1")
+    assert "b1" not in reocr_ops._reocr_batch_jobs
+
+
+def test_logikirje_saab_cancelled_ja_remote_cleanup(keskkond):
+    slug, _work, logitud = keskkond
+    reocr_ops._reocr_jobs["j1"] = {
+        "status": "processing", "slug": slug, "produced_pages": [],
+    }
+    reocr_ops.cancel_reocr_job("j1")
+    assert logitud[-1]["status"] == "cancelled"
+    assert logitud[-1]["remote_cleanup"] == "ok"
+
+
+def test_sftp_torge_ei_takista_lokaalset_katkestamist(keskkond, monkeypatch):
+    """Intsidendi kuju: VUTT rippus, LOSS oli edasi läinud."""
+    slug, _work, logitud = keskkond
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job", lambda jid, job: False)
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug, "produced_pages": [], "pages": [],
+    }
+
+    result = reocr_ops.cancel_reocr_job("b1")
+
+    assert result["status"] == "cancelled"
+    assert result["remote_cleanup"] == "failed"
+    assert "b1" not in reocr_ops._reocr_batch_jobs
+    assert logitud[-1]["remote_cleanup"] == "failed"
+
+
+def test_kirjutaja_ei_peatu_jatab_too_cancelling_olekusse(keskkond, monkeypatch):
+    """Koristust EI TOHI alustada, kui üleslaadimislõim on veel elus."""
+    slug, _work, _ = keskkond
+    monkeypatch.setattr(reocr_ops, "_quiesce_upload", lambda jid, timeout=30.0: False)
+    koristatud = []
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job",
+                        lambda jid, job: koristatud.append(jid) or True)
+    reocr_ops._reocr_batch_jobs["b1"] = {
+        "status": "processing", "slug": slug, "produced_pages": [], "pages": [],
+    }
+
+    with pytest.raises(RuntimeError):
+        reocr_ops.cancel_reocr_job("b1")
+
+    assert koristatud == [], "koristus ei tohi käivituda"
+    assert reocr_ops._reocr_batch_jobs["b1"]["status"] == "cancelling"
+
+
+def test_valmis_too_ei_ole_katkestatav(keskkond):
+    slug, _work, _ = keskkond
+    reocr_ops._reocr_jobs["j1"] = {"status": "done", "slug": slug}
+    with pytest.raises(ValueError):
+        reocr_ops.cancel_reocr_job("j1")
+
+
+def test_tundmatu_too_annab_keyerror(keskkond):
+    with pytest.raises(KeyError):
+        reocr_ops.cancel_reocr_job("puudub")
+
+
+# --- varukoopiate elutsükkel ---
+
+def test_normaalne_lopp_kustutab_varukoopiad(keskkond):
+    """Varukoopia ei tohi jääda igavesti state/-i vedelema."""
+    slug, work, _ = keskkond
+    (work / "017.ocr").write_text("VANA", encoding="utf-8")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS", "b9")
+    assert os.path.isdir(reocr_ops._backup_dir("b9"))
+
+    reocr_ops._drop_backups("b9")
+
+    assert not os.path.isdir(reocr_ops._backup_dir("b9"))
+    assert (work / "017.ocr").read_text(encoding="utf-8") == "UUS"

--- a/tests/test_reocr_cancel_endpoint.py
+++ b/tests/test_reocr_cancel_endpoint.py
@@ -1,0 +1,77 @@
+"""DELETE /admin/reocr/{job_id} (#217)."""
+import pytest
+
+import server.routers.reocr as reocr_router
+
+
+def _admin(login):
+    return {"Authorization": "Bearer {}".format(login("admin", "adminpass"))}
+
+
+def test_katkestamine_annab_200(client, login, monkeypatch):
+    monkeypatch.setattr(
+        reocr_router, "cancel_reocr_job",
+        lambda jid: {"status": "cancelled", "remote_cleanup": "ok",
+                     "deleted_ocr": 2, "restored_ocr": 1},
+    )
+    r = client.delete("/admin/reocr/abc123", headers=_admin(login))
+    assert r.status_code == 200
+    assert r.json()["status"] == "cancelled"
+    assert r.json()["deleted_ocr"] == 2
+
+
+def test_valmis_too_annab_409(client, login, monkeypatch):
+    def _raise(jid):
+        raise ValueError("Töö ei ole katkestatav")
+
+    monkeypatch.setattr(reocr_router, "cancel_reocr_job", _raise)
+    assert client.delete("/admin/reocr/abc123", headers=_admin(login)).status_code == 409
+
+
+def test_tundmatu_too_annab_404(client, login, monkeypatch):
+    def _raise(jid):
+        raise KeyError(jid)
+
+    monkeypatch.setattr(reocr_router, "cancel_reocr_job", _raise)
+    assert client.delete("/admin/reocr/abc123", headers=_admin(login)).status_code == 404
+
+
+def test_kirjutaja_ei_peatunud_annab_503(client, login, monkeypatch):
+    def _raise(jid):
+        raise RuntimeError("Üleslaadimislõim ei peatunud")
+
+    monkeypatch.setattr(reocr_router, "cancel_reocr_job", _raise)
+    assert client.delete("/admin/reocr/abc123", headers=_admin(login)).status_code == 503
+
+
+def test_korduv_katkestamine_annab_404(client, login, monkeypatch):
+    """Töö on aktiivregistrist kadunud — katkestamine EI OLE idempotentne."""
+    kutsutud = []
+
+    def _once(jid):
+        if kutsutud:
+            raise KeyError(jid)
+        kutsutud.append(jid)
+        return {"status": "cancelled", "remote_cleanup": "ok",
+                "deleted_ocr": 0, "restored_ocr": 0}
+
+    monkeypatch.setattr(reocr_router, "cancel_reocr_job", _once)
+    headers = _admin(login)
+    assert client.delete("/admin/reocr/abc123", headers=headers).status_code == 200
+    assert client.delete("/admin/reocr/abc123", headers=headers).status_code == 404
+
+
+def test_editor_ei_paase_ligi(client, login, monkeypatch):
+    monkeypatch.setattr(reocr_router, "cancel_reocr_job",
+                        lambda jid: pytest.fail("editor ei tohi siia jõuda"))
+    token = login("editor", "editorpass")
+    r = client.delete("/admin/reocr/abc123",
+                      headers={"Authorization": "Bearer {}".format(token)})
+    assert r.status_code in (401, 403)
+
+
+def test_tee_on_admin_all():
+    """nginx proksib /api/files/ kaudu KÕIK backend-teed avalikult."""
+    teed = [r.path for r in reocr_router.router.routes if "reocr" in r.path.lower()]
+    assert teed, "reocr-teid ei leitud"
+    assert all(p.startswith("/admin/") for p in teed), teed

--- a/tests/test_reocr_cancel_recovery.py
+++ b/tests/test_reocr_cancel_recovery.py
@@ -1,0 +1,52 @@
+"""Pooleli jäänud katkestamine ei tohi restardi järel tööks tagasi muutuda (#217)."""
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture(autouse=True)
+def puhas(monkeypatch, tmp_path):
+    monkeypatch.setattr(reocr_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(reocr_ops, "REOCR_BACKUPS_DIR", str(tmp_path / "backups"))
+    monkeypatch.setattr(
+        reocr_ops.reocr_state, "BACKUP_TARGETS_DIR", str(tmp_path / "targets")
+    )
+    monkeypatch.setattr(reocr_ops, "_persist_active_jobs", lambda: None)
+    monkeypatch.setattr(reocr_ops, "_append_to_log", lambda job, jid: None)
+    monkeypatch.setattr(reocr_ops.reocr_state, "remove_batch_mapping", lambda jid: None)
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job", lambda jid, job: True)
+
+
+def test_cancelling_too_lopetatakse():
+    jobs = {"b1": {"status": "cancelling", "slug": "s", "produced_pages": []}}
+    lopetatud = reocr_ops._finish_interrupted_cancellations(jobs)
+    assert lopetatud == 1
+    assert "b1" not in jobs
+
+
+def test_aktiivseid_toid_ei_puututa():
+    jobs = {"b1": {"status": "processing", "slug": "s"}}
+    assert reocr_ops._finish_interrupted_cancellations(jobs) == 0
+    assert "b1" in jobs
+
+
+def test_koristuse_torge_ei_jata_tood_aktiivseks(monkeypatch):
+    """Isegi kui kaugkoristus ebaõnnestub, ei tohi töö jääda teost lukustama."""
+    monkeypatch.setattr(reocr_ops, "_cleanup_remote_job", lambda jid, job: False)
+    jobs = {"b1": {"status": "cancelling", "slug": "s", "produced_pages": []}}
+    assert reocr_ops._finish_interrupted_cancellations(jobs) == 1
+    assert "b1" not in jobs
+
+
+def test_toodetud_lehed_kustutatakse_ka_taastel(tmp_path):
+    slug = "1650-test-abc123"
+    work = tmp_path / slug
+    work.mkdir()
+    (work / "001.ocr").write_text("selle töö tulemus", encoding="utf-8")
+    (work / "017.ocr").write_text("VARASEM", encoding="utf-8")
+    jobs = {"b1": {"status": "cancelling", "slug": slug, "produced_pages": ["001"]}}
+
+    reocr_ops._finish_interrupted_cancellations(jobs)
+
+    assert not (work / "001.ocr").exists()
+    assert (work / "017.ocr").read_text(encoding="utf-8") == "VARASEM"

--- a/tests/test_reocr_cancel_state.py
+++ b/tests/test_reocr_cancel_state.py
@@ -1,0 +1,123 @@
+"""Katkestamise olekumasin: aktiivne → cancelling → cancelled (#217).
+
+Terminalüleminekud peavad olema vastastikku välistavad — vastasel juhul võib
+poller märkida töö `done`-ks samal ajal kui DELETE märgib `cancelled`.
+"""
+import threading
+
+import pytest
+
+from server import reocr_ops, reocr_state
+
+
+@pytest.fixture(autouse=True)
+def puhas_register(monkeypatch):
+    monkeypatch.setattr(reocr_ops, "_reocr_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_reocr_batch_jobs", {})
+    monkeypatch.setattr(reocr_ops, "_persist_active_jobs", lambda: None)
+
+
+def test_aktiivne_too_laheb_cancelling_olekusse():
+    reocr_ops._reocr_jobs["j1"] = {"status": "processing"}
+    assert reocr_ops._try_begin_cancel("j1") == "single"
+    assert reocr_ops._reocr_jobs["j1"]["status"] == "cancelling"
+
+
+def test_batch_register_leitakse_sama_endpointiga():
+    reocr_ops._reocr_batch_jobs["b1"] = {"status": "uploading"}
+    assert reocr_ops._try_begin_cancel("b1") == "batch"
+    assert reocr_ops._reocr_batch_jobs["b1"]["status"] == "cancelling"
+
+
+def test_aeglane_too_on_katkestatav():
+    """`slow` on LIPP, mitte staatus — aeglase töö staatus on endiselt
+    `processing` (vt _mark_slow_if_stale). Ta peab olema katkestatav."""
+    reocr_ops._reocr_jobs["j1"] = {"status": "processing", "slow": True}
+    assert reocr_ops._try_begin_cancel("j1") == "single"
+
+
+@pytest.mark.parametrize("status", ["done", "error", "cancelling", "cancelled"])
+def test_terminal_ja_juba_katkestatav_too_ei_alga_uuesti(status):
+    reocr_ops._reocr_jobs["j1"] = {"status": status}
+    assert reocr_ops._try_begin_cancel("j1") is None
+    assert reocr_ops._reocr_jobs["j1"]["status"] == status
+
+
+def test_tundmatu_id_annab_none():
+    assert reocr_ops._try_begin_cancel("puudub") is None
+
+
+def test_sama_id_moelmas_registris_on_invariandi_rikkumine():
+    """job_id nimeruum on registrite vahel globaalne (sama generate_nanoid)."""
+    reocr_ops._reocr_jobs["x"] = {"status": "processing"}
+    reocr_ops._reocr_batch_jobs["x"] = {"status": "processing"}
+    with pytest.raises(RuntimeError):
+        reocr_ops._try_begin_cancel("x")
+
+
+def test_ainult_uks_loim_voidab_CAS_i():
+    """20 lõime üritavad korraga katkestada — täpselt üks saab loa."""
+    reocr_ops._reocr_jobs["j1"] = {"status": "processing"}
+    voitjad = []
+    lukk = threading.Lock()
+
+    def proovi():
+        r = reocr_ops._try_begin_cancel("j1")
+        if r:
+            with lukk:
+                voitjad.append(r)
+
+    threads = [threading.Thread(target=proovi) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(voitjad) == 1
+
+
+def test_katkestamine_ja_done_ei_saa_moelmad_voita():
+    """Poller tahab `done`, DELETE tahab `cancelling` — täpselt üks võidab."""
+    reocr_ops._reocr_jobs["j1"] = {"status": "processing"}
+    tulemused = []
+    start = threading.Barrier(2)
+
+    def katkesta():
+        start.wait()
+        tulemused.append(("cancel", bool(reocr_ops._try_begin_cancel("j1"))))
+
+    def lopeta():
+        start.wait()
+        with reocr_ops._reocr_jobs_lock:
+            job = reocr_ops._reocr_jobs.get("j1")
+            ok = bool(job) and job.get("status") == "processing"
+            if ok:
+                job["status"] = "done"
+        tulemused.append(("done", ok))
+
+    t1, t2 = threading.Thread(target=katkesta), threading.Thread(target=lopeta)
+    t1.start(); t2.start(); t1.join(); t2.join()
+
+    lopp = reocr_ops._reocr_jobs["j1"]["status"]
+    assert lopp in ("cancelling", "done")
+    edukad = [nimi for nimi, ok in tulemused if ok]
+    assert len(edukad) == 1, "täpselt üks terminalüleminek peab õnnestuma"
+
+
+# --- püsivus ---
+
+def test_cancelling_too_persisteeritakse(tmp_path, monkeypatch):
+    """KRIITILINE: kui `cancelling` ei jõua reocr_active.json-i, ei leia
+    stardi-taaste pooleli jäänud katkestamist üles ja teos jääb lukku."""
+    fail = tmp_path / "reocr_active.json"
+    monkeypatch.setattr(reocr_state, "REOCR_ACTIVE_FILE", str(fail))
+
+    reocr_state.persist_active_jobs({
+        "b1": {"status": "cancelling", "slug": "s"},
+        "b2": {"status": "processing", "slug": "s"},
+        "b3": {"status": "done", "slug": "s"},
+    })
+
+    import json
+    salvestatud = json.loads(fail.read_text(encoding="utf-8"))
+    assert set(salvestatud) == {"b1", "b2"}, "cancelling ja processing jäävad, done mitte"

--- a/tests/test_reocr_cancel_worker.py
+++ b/tests/test_reocr_cancel_worker.py
@@ -1,0 +1,75 @@
+"""Üleslaadimislõime peatamine enne kaugkoristust (#217).
+
+Koostööline lipp üksi ei piisa: lipu seadmine ei tähenda, et lõim on lõpetanud.
+Kui koristus algab enne lõime väljumist, kirjutab pooleliolev sftp.put() pildid
+tagasi kataloogi, mille just eemaldasime.
+"""
+import threading
+import time
+
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture(autouse=True)
+def puhas(monkeypatch):
+    monkeypatch.setattr(reocr_ops, "_cancel_events", {})
+    monkeypatch.setattr(reocr_ops, "_upload_threads", {})
+
+
+def test_quiesce_ootab_loime_lopetamiseni():
+    laetud = []
+    ev = threading.Event()
+    reocr_ops._cancel_events["j1"] = ev
+
+    def upload():
+        for i in range(100):
+            if ev.is_set():
+                return
+            laetud.append(i)
+            time.sleep(0.01)
+
+    t = threading.Thread(target=upload)
+    reocr_ops._upload_threads["j1"] = t
+    t.start()
+    time.sleep(0.05)
+
+    assert reocr_ops._quiesce_upload("j1", timeout=5.0) is True
+    assert not t.is_alive(), "lõim peab olema lõpetanud ENNE tagastamist"
+    enne = len(laetud)
+    time.sleep(0.05)
+    assert len(laetud) == enne, "lõim ei tohi pärast quiesce'i midagi juurde teha"
+
+
+def test_quiesce_annab_false_kui_loim_ei_peatu():
+    """Ajalõpp: koristust EI TOHI alustada, kui kirjutaja on veel elus."""
+    ev = threading.Event()
+    reocr_ops._cancel_events["j1"] = ev
+    stop = threading.Event()
+
+    t = threading.Thread(target=lambda: stop.wait(10), daemon=True)
+    reocr_ops._upload_threads["j1"] = t
+    t.start()
+
+    assert reocr_ops._quiesce_upload("j1", timeout=0.2) is False
+    stop.set()
+
+
+def test_quiesce_tundmatu_too_on_ohutu():
+    """Lõim võis juba lõppeda — see ei ole viga."""
+    assert reocr_ops._quiesce_upload("puudub", timeout=0.1) is True
+
+
+def test_quiesce_seab_lipu_ka_siis_kui_loimi_pole():
+    """Lipp peab olema seatud enne kui lõim jõuab käivituda."""
+    assert reocr_ops._quiesce_upload("j2", timeout=0.1) is True
+    assert reocr_ops._cancel_event("j2").is_set()
+
+
+def test_forget_koristab_abistruktuurid():
+    reocr_ops._cancel_event("j3").set()
+    reocr_ops._upload_threads["j3"] = threading.Thread(target=lambda: None)
+    reocr_ops._forget_cancel_state("j3")
+    assert "j3" not in reocr_ops._cancel_events
+    assert "j3" not in reocr_ops._upload_threads

--- a/tests/test_reocr_ownership.py
+++ b/tests/test_reocr_ownership.py
@@ -94,3 +94,23 @@ def test_varukoopia_tee_on_state_all_mitte_teose_kaustas(work_dir):
 
 def test_taastamine_ilma_varukoopiateta_on_ohutu(work_dir):
     assert reocr_ops._restore_backups("puudub") == 0
+
+
+# --- produced_pages: mida see töö PÄRISELT tootis ---
+
+def test_produced_pages_taidetakse_kirjutamise_hetkel():
+    """Loend peab kasvama siis, kui .ocr PÄRISELT kirjutatakse — mitte tööd
+    käivitades. Plaanitud ≠ toodetud."""
+    job = {"produced_pages": []}
+
+    reocr_ops._record_produced(job, "017.jpg")
+    reocr_ops._record_produced(job, "018.jpg")
+    reocr_ops._record_produced(job, "017.jpg")   # kordus ei tohi duplitseerida
+
+    assert job["produced_pages"] == ["017", "018"]
+
+
+def test_uus_too_algab_tuhja_produced_pages_iga():
+    job = {}
+    reocr_ops._record_produced(job, "001.jpg")
+    assert job["produced_pages"] == ["001"]

--- a/tests/test_reocr_ownership.py
+++ b/tests/test_reocr_ownership.py
@@ -1,0 +1,96 @@
+"""Re-OCR tulemuse omand: kes kirjutas, see kustutab (#217).
+
+Plaanitud lehtede nimekiri EI OLE omandi tõend — katkestatud töö ei pruukinud
+jõuda kõiki plaanitud lehti puutuda.
+"""
+import os
+
+import pytest
+
+from server import reocr_ops
+
+
+@pytest.fixture
+def work_dir(tmp_path, monkeypatch):
+    """Teose kaust + eraldatud varukoopiate juur."""
+    slug = "1650-test-abc123"
+    d = tmp_path / slug
+    d.mkdir()
+    monkeypatch.setattr(reocr_ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(reocr_ops, "REOCR_BACKUPS_DIR", str(tmp_path / "backups"))
+    monkeypatch.setattr(
+        reocr_ops.reocr_state, "BACKUP_TARGETS_DIR", str(tmp_path / "targets")
+    )
+    return slug, d
+
+
+def test_kirjutamine_loob_ocr_faili(work_dir):
+    slug, d = work_dir
+    path = reocr_ops._write_ocr_file(slug, "001.jpg", "tekst", "job1")
+    assert os.path.basename(path) == "001.ocr"
+    assert open(path, encoding="utf-8").read() == "tekst"
+
+
+def test_olemasolev_ocr_varundatakse_enne_ylekirjutamist(work_dir):
+    """Vana ootel tulemus ei tohi jäljetult kaduda."""
+    slug, d = work_dir
+    (d / "017.ocr").write_text("VANA ootel tulemus", encoding="utf-8")
+
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS tulemus", "job1")
+
+    assert (d / "017.ocr").read_text(encoding="utf-8") == "UUS tulemus"
+    backup = os.path.join(reocr_ops._backup_dir("job1"), "017.ocr")
+    assert open(backup, encoding="utf-8").read() == "VANA ootel tulemus"
+
+
+def test_varundust_ei_tehta_kui_faili_polnud(work_dir):
+    slug, d = work_dir
+    reocr_ops._write_ocr_file(slug, "002.jpg", "tekst", "job1")
+    assert not os.path.exists(os.path.join(reocr_ops._backup_dir("job1"), "002.ocr"))
+
+
+def test_ainult_esimene_ylekirjutus_varundatakse(work_dir):
+    """Sama töö kordusjooks EI TOHI varukoopiat oma tulemusega üle kirjutada."""
+    slug, d = work_dir
+    (d / "017.ocr").write_text("ALGNE", encoding="utf-8")
+
+    reocr_ops._write_ocr_file(slug, "017.jpg", "esimene", "job1")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "teine", "job1")
+
+    backup = os.path.join(reocr_ops._backup_dir("job1"), "017.ocr")
+    assert open(backup, encoding="utf-8").read() == "ALGNE"
+
+
+def test_taastamine_toob_vana_sisu_tagasi(work_dir):
+    slug, d = work_dir
+    (d / "017.ocr").write_text("VANA", encoding="utf-8")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS", "job1")
+
+    restored = reocr_ops._restore_backups("job1")
+
+    assert restored == 1
+    assert (d / "017.ocr").read_text(encoding="utf-8") == "VANA"
+    assert not os.path.isdir(reocr_ops._backup_dir("job1"))
+
+
+def test_varukoopiate_kustutamine_ei_puutu_teose_faile(work_dir):
+    slug, d = work_dir
+    (d / "017.ocr").write_text("VANA", encoding="utf-8")
+    reocr_ops._write_ocr_file(slug, "017.jpg", "UUS", "job1")
+
+    reocr_ops._drop_backups("job1")
+
+    assert (d / "017.ocr").read_text(encoding="utf-8") == "UUS"
+    assert not os.path.isdir(reocr_ops._backup_dir("job1"))
+
+
+def test_varukoopia_tee_on_state_all_mitte_teose_kaustas(work_dir):
+    """data/.gitignore ignoreerib *.ocr, aga mitte *.ocr.bak.* — varukoopia
+    teose kaustas ilmuks git status'isse."""
+    slug, d = work_dir
+    assert "backups" in reocr_ops._backup_dir("job1")
+    assert slug not in reocr_ops._backup_dir("job1")
+
+
+def test_taastamine_ilma_varukoopiateta_on_ohutu(work_dir):
+    assert reocr_ops._restore_backups("puudub") == 0

--- a/tests/test_reocr_poll.py
+++ b/tests/test_reocr_poll.py
@@ -118,7 +118,7 @@ def test_poll_processing_txt_ready_done(monkeypatch):
 
     written = {}
     monkeypatch.setattr(reocr_ops, "_write_ocr_file",
-                        lambda slug, page_fn, text: written.setdefault("call", (slug, page_fn, text)))
+                        lambda slug, page_fn, text, job_id: written.setdefault("call", (slug, page_fn, text)))
     monkeypatch.setattr(reocr_ops, "_append_to_log", lambda job, jid: None)
 
     reocr_ops._reocr_jobs["j1"] = _make_job(status="processing")


### PR DESCRIPTION
Sulgeb #217. Admin saab käimasoleva re-OCR töö (üksik või batch) katkestada.

Spekk: `docs/superpowers/specs/2026-08-08-reocr-katkestamine-design.md` ·
Plaan: `docs/superpowers/plans/2026-08-08-reocr-katkestamine.md` · **ADR 0018**

## Miks

Valesti käivitatud tööd ei saanud peatada — jäi oodata `REOCR_ABSOLUTE_TIMEOUT` = 12 h. Vahepeal andis `get_active_batch_for_work()` uuele batch'ile 409, ehk **teos oli 12 tundi lukus**. Intsident 2026-08-07 nõudis backendi seiskamist ja `reocr_active.json` käsitsi muutmist.

## Semantika: „tööd ei olnud"

Katkestamine kustutab selle töö `.ocr` tulemused, koristab OCR-serveri ja kirjutab logikirje. Teose tegelikku teksti ei puudutata — re-OCR kirjutab ainult `.ocr` vahefaile kuni eraldi rakendamiseni.

Osalisi tulemusi **ei säilitata**: OCR jookseb taustal, seega katkestamine ei võida aega, vaid annab suvalise algusprefiksi valmis lehtedest. Väiksem maht valitakse käivitamisel ja lehti lisatakse hiljem juurde.

## Kolm kohta, kus disain oleks vaikselt katki läinud

**1. `.ocr` omand — päris andmekao viga, mille ülevaatus püüdis.** Esimene disain kustutas batch-mapping'u **plaanitud** lehtede järgi. Vastunäide: lehel 17 on varasem ootel tulemus, uus batch plaanib lehed 1–25, jõuab teha 1–8, admin katkestab → kustutaks `17.ocr`, mida katkestatud töö ei puutunud. Nüüd tuleb omand `produced_pages`-ist, mis täidetakse `.ocr` kirjutamise hetkel. Ülekirjutatud failid varundatakse `state/reocr_backups/{job_id}/` alla ja katkestamine taastab need.

**2. Kaks workerit vajavad erinevat vaigistamist.** Üleslaadimine on töö-põhine lõim → `Event` + `join`. Poll on **jagatud singleton** (üks iteratsioon iga 10 s kõigi tööde üle) → teda ei saa join'ida ilma kõiki teisi töid seiskamata, seega vaigistab teda sama CAS. Kui `join` aegub, koristust EI TEHTA — töö jääb `cancelling` olekusse taaste jaoks, sest jääk kaugserveris on parem kui pooleliolev `sftp.put()` kustutatud kataloogi.

**3. `cancelling` peab üle restardi elama.** `_ACTIVE_STATUSES` sai `"cancelling"` — muidu oleks `persist_active_jobs` selle `reocr_active.json`-ist välja filtreerinud ja pooleli jäänud katkestamine muutuks restardi järel taas aktiivseks tööks. Kaetud testiga.

## LOSSi peatamine

Per-töö peatamise mehhanismi OCR-serveris ei ole; ainus tõeline signaal (SIGTERM) peataks terve teenuse. **Piltide kustutamine ON peatamismehhanism**: `process_batch` avab pildid enne mudeli kutsumist ja väljub, kui ükski ei avane — järelejäänud batchid maksavad neli ebaõnnestunud `open()` kutset, GPU-d ei puudutata.

**Dokumenteeritud piir: `BATCH_SIZE = 4`** — `main_loop` teeb `rglob` üks kord tsükli kohta, seega kuni üks lennusolev batch jõuab lõpuni. OCR-serverit ei muudetud (ADR 0017 põhimõte).

`200` garanteerib seega **ainult VUTT-i poole**: pollimist pole, lukk on vaba, tulemust ei rakendata. Kui LOSSi koristus ebaõnnestus, on logikirjes `remote_cleanup: "failed"`.

## Muu

- `DELETE /admin/reocr/{job_id}`: 409 = ei ole katkestatav, 404 = tundmatu (ka korduv kutse — katkestamine ei ole idempotentne), 503 = kirjutaja ei peatunud
- **Review**: nupp iga aktiivse re-OCR töö real; upload'i tüüpi töid ei puuduta (neil on viisardi oma katkestamine). Logivaates on `cancelled` hall, mitte punane — katkestamine ei ole viga
- **Manage**: batch-riba nupp. Selleks lisandus `build_reocr_status`-esse `active_job_id` — `active` map oli lehefail → lehe staatus, mitte töö id
- `_write_ocr_file` võtab nüüd `job_id`; kutsekohti oli **neli**, sh `reocr_recovery.py` orbude taaste
- Varukoopiad kustutatakse normaalsel lõpul (batch + üksik) ja orbude taastel, et `state/reocr_backups/` ei kasvaks

## Testid

Uued: `test_reocr_ownership.py`, `test_reocr_cancel_state.py`, `test_reocr_cancel_worker.py`, `test_reocr_cancel.py`, `test_reocr_cancel_endpoint.py`, `test_reocr_cancel_recovery.py`.

Kaetud võistlused: `done` vs `cancelled` (täpselt üks terminalolek võidab), 20 lõime CAS-il, poller ei kirjuta pärast `cancelling` algust, koristus ei alga enne kirjutaja peatumist, SFTP tõrge ei takista lokaalset katkestamist, `cancelling` töö lõpetatakse restardi järel.

Ühtlasi täpsustatud #220 valvurtest: see otsis `sftp.put(` **tekstina** ja langes valepositiiviga uue docstringi peale, mis seda probleemi kirjeldab. Kontroll käib nüüd AST-i pealt.

1217 backend + 723 frontend testi rohelised; typecheck puhas, lint baasjoonel (55).

## Käsitsi testimiseks

Käivita batch, katkesta jooksu ajal: teos peab kohe vabanema (uus batch ei anna 409), kuni 4 lehte võivad LOSSis lõpuni joosta, aga nende tulemus ei jõua kuhugi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
