### PR TITLE
SEO: Google'i uued UA-d bot-mustrisse + teose kirjeldus aastast/kohast/trükkalist

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -9,10 +9,11 @@ http {
     # Peida nginx versioon turvakaalutlustel (OWASP soovitus)
     server_tokens off;
 
-    # Tuvasta sotsiaalmeedia robotid
+    # Tuvasta sotsiaalmeedia robotid ja otsingumootorite indekseerijad.
+    # Hoia muster sünkroonis nginx.host.conf-iga (elav konfiguratsioon on hostis).
     map $http_user_agent $is_bot {
         default 0;
-        ~*(facebookexternalhit|twitterbot|bluesky|whatsapp|telegrambot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|pinterest\/0\.|bingbot|googlebot) 1;
+        ~*(facebookexternalhit|twitterbot|bluesky|whatsapp|telegrambot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|slackbot|discordbot|mastodon|pinterest\/0\.|bingbot|googlebot|google-inspectiontool|googleother) 1;
     }
 
     server {

--- a/nginx.host.conf
+++ b/nginx.host.conf
@@ -10,11 +10,13 @@
 # Eeldab ka brotli mooduleid (Ubuntu: libnginx-mod-http-brotli-filter,
 # libnginx-mod-http-brotli-static) — vt /etc/nginx/modules-enabled/.
 
-# Tuvasta sotsiaalmeedia robotid                                                                                                                        
-map $http_user_agent $is_bot {                                                                                                                          
+# Tuvasta sotsiaalmeedia robotid ja otsingumootorite indekseerijad.
+# NB! google-inspectiontool (GSC „Test live URL") ja googleother EI sisalda
+# sõna „googlebot" — ilma nendeta näeb GSC tühja SPA-shelli, mitte prerenderit,
+# ja Google'i ristkontroll näeb teist saiti kui Googlebot ise.
+map $http_user_agent $is_bot {
     default 0;
-    ~*(facebookexternalhit|twitterbot|Bluesky|whatsapp|telegrambot|linkedinbot|embedly|quora\ link\
-preview|showyoubot|outbrain|slackbot|discordbot|mastodon|pinterest\/0\.|bingbot|googlebot) 1;
+    ~*(facebookexternalhit|twitterbot|Bluesky|whatsapp|telegrambot|linkedinbot|embedly|quora\ link\ preview|showyoubot|outbrain|slackbot|discordbot|mastodon|pinterest\/0\.|bingbot|googlebot|google-inspectiontool|googleother) 1;
 }
 
 server {

--- a/server/metadata_handler.py
+++ b/server/metadata_handler.py
@@ -172,6 +172,34 @@ def cached_person_meta_html(person_id, cache_key, build_fn):
     return rendered
 
 
+def _build_work_description(meta: dict) -> str:
+    """Teose kirjeldus meta/og/twitter siltidele: loojad. aasta. koht: trükkal.
+
+    Iga osa jäetakse vahele, kui seda ei ole. Anonüümne allikas (nt kirikuraamat)
+    saab „1692. Tartu", mitte üldist saidikirjeldust. Tühi string = pole midagi öelda,
+    kutsuja langeb tagasi vaikekirjeldusele.
+    """
+    parts = []
+
+    creators = meta.get("creators") or []
+    creator_names = ", ".join(c.get("name", "") for c in creators if c.get("name"))
+    if creator_names:
+        parts.append(creator_names)
+
+    year = meta.get("year")
+    if year:
+        parts.append(str(year))
+
+    place = _label(meta.get("location"))
+    publisher = _label(meta.get("publisher"))
+    if place and publisher:
+        parts.append(f"{place}: {publisher}")
+    elif place or publisher:
+        parts.append(place or publisher)
+
+    return ". ".join(parts)
+
+
 def build_meta_html(work_id: str, creator_persons=None, include_text: bool = True) -> str:
     """Genereerib Google'ile ja sotsiaalmeedia robotitele HTML-i koos metaandmetega.
 
@@ -192,11 +220,7 @@ def build_meta_html(work_id: str, creator_persons=None, include_text: bool = Tru
                 with open(metadata_path, "r", encoding="utf-8") as f:
                     meta = json.load(f)
                 title = meta.get("title", title)
-                creators = meta.get("creators") or []
-                creator_names = ", ".join(c.get("name", "") for c in creators if c.get("name"))
-                year = meta.get("year", "")
-                if creator_names:
-                    description = f"{creator_names}. {year}" if year else creator_names
+                description = _build_work_description(meta) or description
             except Exception:
                 pass
         image_url = f"{SITE_URL}/api/images/{_escape(work_id)}/_og?v=2"

--- a/tests/test_metadata_handler.py
+++ b/tests/test_metadata_handler.py
@@ -253,6 +253,59 @@ def test_unknown_work_returns_fallback(patch_find):
     assert "<html>" in html
 
 
+def _description_of(html: str) -> str:
+    import re
+    m = re.search(r'<meta name="description" content="([^"]*)"', html)
+    assert m, "description-meta puudub"
+    return m.group(1)
+
+
+def test_description_has_creators_year_place_and_publisher(patch_find):
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    registry["work001"] = _write_meta(tmp_path, FULL_META)
+    assert _description_of(build_meta_html("work001")) == (
+        "Johannes Gezelius, Petrus Schomerus. 1654. Tartu: Johannes Vogel"
+    )
+
+
+def test_description_without_creators_uses_year_and_place(patch_find):
+    """Anonüümne allikas (nt kirikuraamat) ei tohi saada üldist saidikirjeldust."""
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    meta = {
+        **FULL_META,
+        "id": "work010",
+        "creators": [],
+        "publisher": None,
+        "year": 1692,
+    }
+    registry["work010"] = _write_meta(tmp_path, meta)
+    assert _description_of(build_meta_html("work010")) == "1692. Tartu"
+
+
+def test_description_omits_missing_place_and_publisher(patch_find):
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    registry["work002"] = _write_meta(tmp_path, MANUSCRIPT_META)
+    assert _description_of(build_meta_html("work002")) == "Adam Lode. 1680"
+
+
+def test_description_falls_back_when_no_metadata(patch_find):
+    from server.metadata_handler import build_meta_html
+    registry, tmp_path = patch_find
+    meta = {
+        "id": "work011",
+        "title": "Tundmatu teos",
+        "creators": [],
+        "year": None,
+        "location": None,
+        "publisher": None,
+    }
+    registry["work011"] = _write_meta(tmp_path, meta)
+    assert "Tartu Ülikooli varauusaegseid" in _description_of(build_meta_html("work011"))
+
+
 def test_work_id_escaped_in_urls(patch_find):
     from server.metadata_handler import build_meta_html
     # work_id tundmatu — fallback haru


### PR DESCRIPTION
Kaks eraldiseisvat SEO-parandust, mõlemad juba tootmises verifitseeritud.

## 1. `$is_bot` muster ei katnud Google'i kahte uuemat agenti

`nginx.host.conf` muster kattis ainult `googlebot`-i. Need kaks ei sisalda seda sõna:

| UA | enne | pärast |
|---|---|---|
| Googlebot (desktop + smartphone) | prerender | prerender |
| **Google-InspectionTool/1.0** (desktop + mobile) | **SPA-shell 3315 B** | **prerender** |
| **GoogleOther** / GoogleOther-Image | **SPA-shell** | **prerender** |
| bingbot, slackbot | prerender | prerender |
| Chrome | SPA-shell | SPA-shell |

`Google-InspectionTool` on see, mida GSC „Test live URL" kasutab. Tagajärg: URL-i inspekteerides nägi omanik tühja lehte ja iga GSC-põhine diagnoos oli kasutu. SPA ei saa end ka JS-iga täita, sest andmed tulevad `/meili`-st (`src/config.ts:12`), mille robots.txt keelab. Ühtlasi nägi Google'i ristkontroll teist saiti kui Googlebot ise.

Kaasa parandatud:
- rikutud rea-escape mustris — `quora\ link\` + LF + `preview` sisaldas literaalset reavahetust, nii et see haru ei matchinud kunagi
- `nginx.conf` koopia sünkroonitud (puudusid `slackbot|discordbot|mastodon`)

**NB:** elav konfiguratsioon on hostis (`/etc/nginx/sites-available/vutt`) ja on juba uuendatud (backup `vutt.bak-google-ua-20260809`, `nginx -t` OK, reload tehtud). Repo koopia oli enne muudatust hostiga identne.

## 2. Teose kirjeldus langes anonüümsetel allikatel üldisele saiditekstile

Kirjeldust ehitati ainult siis, kui teosel oli vähemalt üks looja. Muidu sai teos kirjelduseks „Vaata ja toimeta Tartu Ülikooli varauusaegseid akadeemilisi tekste." — eksitav ja korduv igal kirikuraamatul ja arhiivikäsikirjal, sh sotsiaalmeedia jagamiskaardil.

Uus `_build_work_description()` liidab olemasolevad osad punktiga: **loojad → aasta → koht: trükkal**. Tootmises verifitseeritud valim:

```
Andreas Virginius, Petrus Angelstadius. 1646. Tartu: Johann Vogel
1702. Pärnu: Johann Brendeken     <- anonüümne, trükkal teada
1692. Tartu                       <- anonüümne kirikuraamat
1695                              <- ainult aasta
Karl Kühlstaedt. 1827             <- muutumatu
```

Vaikekirjeldus jääb alles ainult siis, kui ükski neist väljadest puudub (nt tundmatu work_id).

## Testid

4 uut testi `tests/test_metadata_handler.py`-s (loojad+aasta+koht+trükkal; ilma loojateta; puuduv koht/trükkal; fallback). Kogu backend-komplekt: **1221 testi läbib**.

## Deploy

- nginx: juba tootmises
- backend: server jookseb praegu sellelt harult (`bd842a3`). **Pärast merge'i tuleb server main'ile tagasi viia** — `git checkout main && ./scripts/server_update.sh --no-cache` — muidu jääb ta feature-harule seisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)