### PR TITLE
Otsing: normaliseeri ß → ss mõlemas otsas (#228)

### DIFF
--- a/server/meili_doc.py
+++ b/server/meili_doc.py
@@ -57,6 +57,38 @@ def split_marginalia(text):
     return main, "\n".join(notes)
 
 
+def normalize_eszett(text):
+    """Asendab ß → ss otsinguväljadel (#228).
+
+    Meilisearch voldib täpitähed ise (`Königsberg` == `Konigsberg`), aga ß-i mitte,
+    sest Unicode NFKD ei lagunda seda. Kirjaveataluvus ei kata auku: `daß` on 4 märki,
+    mille puhul Meili lubab null kirjaviga — korpuses on `daß` 12 386 korda, aga
+    „dass" otsimine leiaks neist murdosa.
+
+    Kehtib ka ladina materjalis, kus ß on pikk-s + s ligatuur (`auspicatißimos`).
+    Sama teisendus PEAB käima ka päringule (`normalizeSearchQuery`
+    `src/services/searchService.ts`-s) — ainult ühe poole normaliseerimine
+    tähendaks, et `Schluß` otsimine ei leiaks enam midagi.
+
+    NB: rakendub AINULT otsinguväljadele. `text_content` (toores redaktoritekst,
+    mida töölaud loeb) jääb puutumata.
+    """
+    if not text:
+        return ""
+    return text.replace("ß", "ss").replace("ẞ", "SS")
+
+
+def _normalize_comment_texts(comments):
+    """ß → ss kommentaaride tekstis (#228), ülejäänud väljad ja algne objekt puutumata."""
+    out = []
+    for c in comments or []:
+        if isinstance(c, dict) and c.get("text"):
+            out.append({**c, "text": normalize_eszett(c["text"])})
+        else:
+            out.append(c)
+    return out
+
+
 def clean_text_for_search(text):
     """Puhastab teksti otsinguindeksi jaoks, eemaldades vormindusmärgid ja liites poolitused.
 
@@ -87,7 +119,9 @@ def clean_text_for_search(text):
     # 4. Eemalda üleliigsed tühikud
     text = re.sub(r'\s+', ' ', text).strip()
 
-    return text
+    # 5. ß → ss (#228). Käib PÄRAST poolituste liitmist, et „gro⸗\nße" liidetaks
+    # enne normaliseerimist üheks sõnaks.
+    return normalize_eszett(text)
 
 
 def _clean_search_text(page_text):
@@ -348,7 +382,7 @@ def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_
     doc = {
         "id": page_id,
         "work_id": work_ctx['work_id'],  # Nanoid (püsiv lühikood)
-        "title": work_ctx['title'],
+        "title": normalize_eszett(work_ctx['title']),   # OTSING+KUVA: ß→ss (#228)
         "autor": work_ctx['autor'],      # Filtreerimiseks (jääb)
         "respondens": work_ctx['respondens'],  # Filtreerimiseks (jääb)
         "aasta": work_ctx['year'],       # Filtreerimiseks ja sortimiseks (jääb)
@@ -378,7 +412,7 @@ def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_
         ],
         "page_tags_object": page_tags_data,
         "has_annotations": bool(page_tags_data or page_meta['comments'] or page_meta['text_annotations']),
-        "comments": page_meta['comments'],
+        "comments": _normalize_comment_texts(page_meta['comments']),
         "text_annotations": page_meta['text_annotations'],
         "history": page_meta['history'],
         "last_modified": int(os.path.getmtime(txt_path if os.path.exists(txt_path) else os.path.join(dir_path, img_name)) * 1000),
@@ -388,7 +422,7 @@ def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_
         "tags_object": tags,
         "tags_search": get_all_labels(tags) + work_ctx['tag_aliases'],
         "tags_ids": get_all_ids(tags),
-        "notes": work_ctx.get('notes'),
+        "notes": normalize_eszett(work_ctx.get('notes')),
         "collections": work_ctx['work_collections'],
         "collections_hierarchy": work_ctx['collections_hierarchy'],
         "is_public": any(
@@ -417,7 +451,7 @@ def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_
         "type_ids": get_all_ids(work_ctx['work_type']),
         "languages": work_ctx['languages'],
         "creators": creators,
-        "authors_text": work_ctx['authors_text'],
+        "authors_text": [normalize_eszett(a) for a in work_ctx['authors_text']],
         "author_names": list(dict.fromkeys(
             name for c in creators
             if c.get('name') and c.get('role') != 'respondens'
@@ -441,7 +475,7 @@ def _build_page_document(work_ctx, page_id, page_num, page_text, page_meta, img_
     # .get() — vanad work_ctx-id (nt osatestid) ei pruugi neid sisaldada.
     if work_ctx.get('series'):
         doc['series'] = work_ctx['series']
-        doc['series_title'] = work_ctx.get('series_title', '')
+        doc['series_title'] = normalize_eszett(work_ctx.get('series_title', ''))
     if work_ctx.get('relations'):
         doc['relations'] = work_ctx['relations']
 

--- a/src/services/__tests__/searchEszett.test.ts
+++ b/src/services/__tests__/searchEszett.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+vi.mock('../meiliService', () => ({
+  checkMixedContent: vi.fn(),
+  normalizeWork: vi.fn((hit) => hit),
+  normalizeContentSearchHit: vi.fn((hit) => hit),
+}));
+
+vi.mock('../../config', () => ({
+  MEILI_HOST: 'http://localhost:7700',
+  MEILI_INDEX: 'teosed',
+  IMAGE_BASE_URL: '/api/images',
+  FILE_API_URL: '/api/files',
+}));
+
+import { normalizeSearchQuery, searchWorks, searchContent, searchWorkHits } from '../searchService';
+
+const mockIndex = { search: mockSearch } as any;
+
+beforeEach(() => {
+  mockSearch.mockReset();
+  mockSearch.mockResolvedValue({ hits: [], facetDistribution: {}, totalHits: 0, estimatedTotalHits: 0 });
+});
+
+// Meili voldib täpitähed ise (Königsberg == Konigsberg), aga ß-i mitte.
+// Indeksipool normaliseerib server/meili_doc.py:normalize_eszett-is — päring PEAB
+// käima sama teed, muidu ei leiaks „Schluß" otsimine enam midagi (#228).
+describe('normalizeSearchQuery', () => {
+  it('asendab ß ss-iga', () => {
+    expect(normalizeSearchQuery('daß')).toBe('dass');
+    expect(normalizeSearchQuery('nachließen')).toBe('nachliessen');
+  });
+
+  it('asendab suurtähe ẞ', () => {
+    expect(normalizeSearchQuery('STRAẞE')).toBe('STRASSE');
+  });
+
+  it('töötab fraasiotsingu jutumärkide sees', () => {
+    expect(normalizeSearchQuery('"Schluß der Sache"')).toBe('"Schluss der Sache"');
+  });
+
+  it('jätab muu puutumata', () => {
+    expect(normalizeSearchQuery('Königsberg')).toBe('Königsberg');
+    expect(normalizeSearchQuery('')).toBe('');
+  });
+});
+
+describe('otsingu sisenemispunktid normaliseerivad päringu', () => {
+  it('searchWorks', async () => {
+    await searchWorks(mockIndex, 'daß');
+    expect(mockSearch.mock.calls[0][0]).toBe('dass');
+  });
+
+  it('searchContent', async () => {
+    await searchContent(mockIndex, 'daß');
+    expect(mockSearch.mock.calls[0][0]).toBe('dass');
+  });
+
+  it('searchWorkHits', async () => {
+    await searchWorkHits(mockIndex, 'daß', 'work1');
+    expect(mockSearch.mock.calls[0][0]).toBe('dass');
+  });
+});

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -12,6 +12,21 @@ import { pickLabelByLang } from '../utils/labelUtils';
 import type { MatchingStrategies, Index } from 'meilisearch';
 import { HIGHLIGHT_PRE_TAG, HIGHLIGHT_POST_TAG } from '../utils/sanitizeHtml';
 
+/**
+ * ß → ss otsingupäringus (#228).
+ *
+ * Meilisearch voldib täpitähed ise (`Königsberg` == `Konigsberg`), aga ß-i mitte,
+ * sest Unicode NFKD ei lagunda seda. Kirjaveataluvus ei kata auku: `daß` on 4 märki,
+ * mille puhul Meili lubab null kirjaviga.
+ *
+ * Indeksipool teeb sama teisenduse (`normalize_eszett`, `server/meili_doc.py`).
+ * MÕLEMAD pooled on kohustuslikud — ainult indeksi normaliseerimine tähendaks,
+ * et `Schluß` otsimine ei leiaks enam midagi. Lihtne märgiasendus töötab ka
+ * fraasiotsingu jutumärkide sees. Filtreid see EI puuduta.
+ */
+export const normalizeSearchQuery = (query: string): string =>
+  (query || '').replace(/ß/g, 'ss').replace(/ẞ/g, 'SS');
+
 // Aastafilter vahemike kattuvusena: teose [year_start, year_end] kattub kasutaja vahemikuga.
 // Kattuvus: A.end >= B.start AND A.start <= B.end.
 // Aastata teosed (year_start=year_end=0) käituvad nagu varasem year=0.
@@ -316,8 +331,9 @@ export const getAuthorFacets = async (
 };
 
 // Dashboardi otsing: otsib teoseid
-export const searchWorks = async (index: Index, query: string, options?: DashboardSearchOptions): Promise<SearchWorksResult> => {
+export const searchWorks = async (index: Index, rawQuery: string, options?: DashboardSearchOptions): Promise<SearchWorksResult> => {
   checkMixedContent();
+  const query = normalizeSearchQuery(rawQuery);
 
   try {
     const filter: string[] = [];
@@ -553,8 +569,9 @@ async function fetchWorkLevelFacets(
 // Täisteksti otsing
 // Kui workId on määratud - otsib ainult sellest teosest (kõik vasted, ilma distinct'ita)
 // Muidu - tagastab 10 teost (distinct), iga teose kohta 1 esinduslik vaste
-export const searchContent = async (index: Index, query: string, page: number = 1, options: ContentSearchOptions = {}): Promise<ContentSearchResponse> => {
+export const searchContent = async (index: Index, rawQuery: string, page: number = 1, options: ContentSearchOptions = {}): Promise<ContentSearchResponse> => {
   checkMixedContent();
+  const query = normalizeSearchQuery(rawQuery);
 
   const limit = options.workId ? 20 : 10; // Teose piires rohkem vasteid lehel
   const offset = (page - 1) * limit;
@@ -787,8 +804,9 @@ export const searchContent = async (index: Index, query: string, page: number = 
 };
 
 // Laadi ühe teose kõik otsingutulemused (akordioni avamiseks)
-export const searchWorkHits = async (index: Index, query: string, workId: string, options: ContentSearchOptions = {}): Promise<ContentSearchHit[]> => {
+export const searchWorkHits = async (index: Index, rawQuery: string, workId: string, options: ContentSearchOptions = {}): Promise<ContentSearchHit[]> => {
   checkMixedContent();
+  const query = normalizeSearchQuery(rawQuery);
 
   const filter: string[] = [`work_id = "${workId}"`];
 

--- a/tests/test_meilisearch_ops.py
+++ b/tests/test_meilisearch_ops.py
@@ -336,3 +336,43 @@ class TestSplitMarginalia:
         assert marg == ""
         # Sisu peab jääma otsingus kättesaadavaks (clean_text_for_search eemaldab rämpsu)
         assert "pooleli" in clean_text_for_search(main)
+
+
+# --- ß-normaliseerimine otsinguväljadel (#228) ---
+# Meili voldib täpitähed ise (Königsberg == Konigsberg), aga ß-i mitte, sest
+# Unicode NFKD ei lagunda seda. Kirjaveataluvus ei päästa: 'daß' on 4 märki,
+# mille puhul Meili lubab null kirjaviga. Normaliseerime MÕLEMAS otsas —
+# päringupool elab src/services/searchService.ts-s (vt normalizeSearchQuery).
+class TestNormalizeEszett:
+    def test_asendab_ss_iga(self):
+        from server.meili_doc import normalize_eszett
+        assert normalize_eszett("daß") == "dass"
+        assert normalize_eszett("nachließen") == "nachliessen"
+
+    def test_asendab_suurtähe(self):
+        from server.meili_doc import normalize_eszett
+        assert normalize_eszett("STRAẞE") == "STRASSE"
+
+    def test_ladina_ligatuur_samuti(self):
+        """Ladina materjalis on ß pikk-s + s ligatuur, mitte saksa eszett."""
+        from server.meili_doc import normalize_eszett
+        assert normalize_eszett("auspicatißimos") == "auspicatissimos"
+
+    def test_jätab_muu_puutumata(self):
+        from server.meili_doc import normalize_eszett
+        assert normalize_eszett("Königsberg") == "Königsberg"
+        assert normalize_eszett("") == ""
+        assert normalize_eszett(None) == ""
+
+    def test_clean_text_for_search_normaliseerib(self):
+        """Katab korraga lehekylje_tekst ja marginaalia_tekst — mõlemad käivad siit."""
+        assert "dass" in clean_text_for_search("vnd ist gewiß, daß der Herr")
+        assert "ß" not in clean_text_for_search("vnd ist gewiß, daß der Herr")
+
+    def test_normaliseerimine_ei_riku_poolitust(self):
+        """ß-asendus ei tohi segada reavahetuse sidekriipsude liitmist."""
+        assert "grosse" in clean_text_for_search("gro⸗\nße")
+
+    def test_marginaalia_normaliseeritakse_samuti(self):
+        main, marg = _clean_search_text("tekst\n<m>groß</m>")
+        assert marg == "gross"

--- a/tests/test_meilisearch_sync_snapshot.py
+++ b/tests/test_meilisearch_sync_snapshot.py
@@ -347,3 +347,68 @@ def test_last_modified_on_mtime_põhine(synced):
     """last_modified peab kajastama txt faili mtime (fikseeritud 1_000_000s → 1_000_000_000 ms)."""
     for d in synced["docs"]:
         assert d["last_modified"] == 1_000_000_000
+
+
+# =========================================================
+# ß-normaliseerimine metaandmete otsinguväljadel (#228)
+# =========================================================
+
+@pytest.fixture
+def synced_eszett(tmp_path, monkeypatch):
+    """Sama kui `synced`, aga ß-iga kõigil tekstipõhistel otsinguväljadel."""
+    work_dir = tmp_path / SLUG
+    work_dir.mkdir()
+    (work_dir / "_metadata.json").write_text(json.dumps({
+        "id": WORK_ID,
+        "slug": SLUG,
+        "title": "In auspicatißimos natales",
+        "year": 1690,
+        "notes": "Vrd. Schluß lk 12",
+        "creators": [{"name": "Andreas Koßkull sen.", "id": "Q123", "role": "auctor"}],
+        "languages": ["la"],
+        "collections": ["col-public"],
+    }, ensure_ascii=False), encoding="utf-8")
+
+    _write_page(
+        work_dir, f"{SLUG}-{WORK_ID}-001",
+        txt="vnd ist gewiß, daß der Herr\n<m>groß</m>",
+        sequence=100, status="Toores",
+        comments=[{"text": "kommentaaris on daß"}],
+    )
+    os.utime(work_dir / f"{SLUG}-{WORK_ID}-001.txt", (1_000_000, 1_000_000))
+
+    monkeypatch.setattr(ops, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(ops, "ARCHIVES_FILE", str(tmp_path / "_archives.json"))
+    (tmp_path / "_archives.json").write_text(json.dumps(ARCHIVES), encoding="utf-8")
+    monkeypatch.setattr(ops, "load_collections", lambda: COLLECTIONS)
+    monkeypatch.setattr(ops, "load_people_aliases", lambda: PEOPLE)
+    monkeypatch.setattr(ops, "load_labels_store", lambda: LABELS)
+
+    captured = {"docs": None}
+    monkeypatch.setattr(ops, "send_to_meilisearch",
+                        lambda documents, wait=True: captured.__setitem__("docs", documents) or True)
+    monkeypatch.setattr(ops, "_delete_extra_pages", lambda work_id, new_count: None)
+
+    assert ops.sync_work_to_meilisearch(SLUG) is True
+    return captured
+
+
+def test_eszett_normaliseeritud_lehe_tekstis(synced_eszett):
+    doc = synced_eszett["docs"][0]
+    assert "gewiss, dass" in doc["lehekylje_tekst"]
+    assert doc["marginaalia_tekst"] == "gross"
+
+
+def test_eszett_normaliseeritud_metaandmete_valjadel(synced_eszett):
+    doc = synced_eszett["docs"][0]
+    assert doc["title"] == "In auspicatissimos natales"
+    assert doc["notes"] == "Vrd. Schluss lk 12"
+    assert "Andreas Kosskull sen." in doc["authors_text"]
+    assert doc["comments"][0]["text"] == "kommentaaris on dass"
+
+
+def test_text_content_jaab_puutumata(synced_eszett):
+    """Toores redaktoritekst on ainus, mida töölaud loeb — ß peab alles jääma."""
+    doc = synced_eszett["docs"][0]
+    assert "gewiß, daß" in doc["text_content"]
+    assert "<m>groß</m>" in doc["text_content"]


### PR DESCRIPTION
Sulgeb #228.

Meilisearch voldib täpitähed ise (`Königsberg` == `Konigsberg`), aga `ß`-i mitte — Unicode NFKD ei lagunda seda. Kirjaveataluvus auku ei kata: `daß` on 4 märki, mille puhul Meili lubab **null** kirjaviga.

Tootmisindeksis mõõdetud (fraasiotsing):

| päring | vasteid | | päring | vasteid |
|---|---|---|---|---|
| `"nachließen"` | 1 | | `"daß"` | 3292 |
| `"nachliessen"` | **0** | | `"dass"` | **309** |

Korpuses on 9977 erinevat ß-tokenit, 52 732 esinemist 22 889 failis (`daß` üksi 12 386×). Sünonüümide-nimekiri oleks selle mahu juures liiga suur ja vajaks regenereerimist iga uue teose järel.

## Muudatus

**Indeksipool** (`server/meili_doc.py`) — `normalize_eszett()`, rakendatud:
- `clean_text_for_search()` lõpus → katab `lehekylje_tekst` + `marginaalia_tekst` ehk kogu massi. Käib **pärast** poolituste liitmist, et „gro⸗\nße" liidetaks enne normaliseerimist.
- `title`, `notes`, `authors_text`, `series_title`, `comments[].text`

`text_content` (toores redaktoritekst, mida töölaud loeb) jääb **puutumata** — ß säilib nii failides kui redaktoris.

**Päringupool** (`src/services/searchService.ts`) — `normalizeSearchQuery()` kõigis kolmes sisenemispunktis (`searchWorks`, `searchContent`, `searchWorkHits`). Parameeter ümber nimetatud `rawQuery`-ks, nii et normaliseerimata kuju ei saa kogemata edasi lekkida. Filtreid ei puuduta; fraasiotsing töötab kaasa, sest tegu on märgiasendusega.

Mõlemad pooled on kohustuslikud — ainult indeksi normaliseerimine tähendaks, et `Schluß` otsimine ei leiaks enam midagi.

## Kuvamine

Otsingutulemuse katkend näitab nüüd „dass", kus käsikirjas on „daß" (`lehekylje_tekst` on korraga otsingu- ja kuvaväli). Teadlik valik: leidmine on tähtsam, originaali saab alati kontrollida — lugemis- ja toimetamisvaade EI muutu.

## Invariant

Loogika elab **ainult** `meili_doc.py`-s, kust impordivad mõlemad indekseerimisteed (live `meilisearch_ops.py` + seed `1-1_consolidate_data.py`). `test_meili_seed_live_parity` valvab, et need ei lahkneks.

## Testid

10 uut. pytest **1231** ✅ · vitest **730** ✅ · typecheck ✅ · lint 55 (muutumatu)

## Kasutuselevõtt

Jõustub täisreindeksi järel — `./scripts/server_seed_data.sh` kustutab ja loob `teosed` indeksi nullist, otsing on selle ajaks maas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)