### PR TITLE
Otsing: „Terve dokument" otsib ka tekstiannotatsioonidest

### DIFF
--- a/src/services/__tests__/searchScope.test.ts
+++ b/src/services/__tests__/searchScope.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+vi.mock('../meiliService', () => ({
+  checkMixedContent: vi.fn(),
+  normalizeWork: vi.fn((hit) => hit),
+  normalizeContentSearchHit: vi.fn((hit) => hit),
+}));
+
+vi.mock('../../config', () => ({
+  MEILI_HOST: 'http://localhost:7700',
+  MEILI_INDEX: 'teosed',
+  IMAGE_BASE_URL: '/api/images',
+  FILE_API_URL: '/api/files',
+}));
+
+import { searchContent, searchWorkHits } from '../searchService';
+
+const mockIndex = { search: mockSearch } as any;
+
+beforeEach(() => {
+  mockSearch.mockReset();
+  mockSearch.mockResolvedValue({ hits: [], facetDistribution: {}, totalHits: 0, estimatedTotalHits: 0 });
+});
+
+const searchedFields = (): string[] => mockSearch.mock.calls[0][1].attributesToSearchOn;
+
+// „Terve dokument" PEAB katma kõik tekstiväljad — sh tekstiannotatsioonid.
+// Varem puudus text_annotations_text vaikeloendist, mistõttu vaikeulatus oli
+// kitsam kui tema enda alamvalik „Ainult annotatsioonid" ja annotatsiooni-vasted
+// olid vaikevaates nähtamatud.
+describe('otsinguulatus „Terve dokument" (vaikimisi)', () => {
+  it('searchContent otsib ka tekstiannotatsioonidest', async () => {
+    await searchContent(mockIndex, 'käsu');
+    expect(searchedFields()).toEqual(
+      expect.arrayContaining(['lehekylje_tekst', 'marginaalia_tekst', 'page_tags_et', 'comments.text', 'text_annotations_text'])
+    );
+  });
+
+  it('searchWorkHits otsib ka tekstiannotatsioonidest', async () => {
+    await searchWorkHits(mockIndex, 'käsu', 'work1');
+    expect(searchedFields()).toEqual(
+      expect.arrayContaining(['lehekylje_tekst', 'marginaalia_tekst', 'page_tags_et', 'comments.text', 'text_annotations_text'])
+    );
+  });
+
+  it('on vähemalt sama lai kui „Ainult annotatsioonid"', async () => {
+    await searchContent(mockIndex, 'käsu', 1, { scope: 'annotation' });
+    const annotationFields = searchedFields();
+    mockSearch.mockClear();
+    await searchContent(mockIndex, 'käsu', 1, { scope: 'all' });
+    expect(searchedFields()).toEqual(expect.arrayContaining(annotationFields));
+  });
+});
+
+describe('kitsamad ulatused jäävad kitsaks', () => {
+  it('„Ainult originaaltekst" ei otsi annotatsioonidest ega kommentaaridest', async () => {
+    await searchContent(mockIndex, 'käsu', 1, { scope: 'original' });
+    expect(searchedFields()).toEqual(['lehekylje_tekst', 'marginaalia_tekst']);
+  });
+
+  it('„Ainult annotatsioonid" ei otsi lehekülje põhitekstist', async () => {
+    await searchContent(mockIndex, 'käsu', 1, { scope: 'annotation' });
+    expect(searchedFields()).not.toContain('lehekylje_tekst');
+    expect(searchedFields()).toContain('text_annotations_text');
+  });
+});

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -613,7 +613,10 @@ export const searchContent = async (index: Index, rawQuery: string, page: number
   const typeFacetField = 'type_ids';
   const tagsFacetField = 'tags_ids';
 
-  let attributesToSearchOn: string[] = ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text'];
+  // „Terve dokument" katab KÕIK tekstiväljad — sh text_annotations_text.
+  // Selle puudumine tegi vaikeulatuse kitsamaks kui tema enda alamvalik
+  // „Ainult annotatsioonid", nii et annotatsiooni-vasted olid vaikevaates nähtamatud.
+  let attributesToSearchOn: string[] = ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'];
   if (options.scope === 'original') attributesToSearchOn = ['lehekylje_tekst', 'marginaalia_tekst'];
   else if (options.scope === 'annotation') {
     attributesToSearchOn = [tagsField, 'comments.text', 'text_annotations_text'];
@@ -814,7 +817,10 @@ export const searchWorkHits = async (index: Index, rawQuery: string, workId: str
   if (options.catalog && options.catalog !== 'all') filter.push(`originaal_kataloog = "${options.catalog}"`);
 
   const tagsField = options.lang ? `page_tags_${options.lang}` : 'page_tags_et';
-  let attributesToSearchOn: string[] = ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text'];
+  // „Terve dokument" katab KÕIK tekstiväljad — sh text_annotations_text.
+  // Selle puudumine tegi vaikeulatuse kitsamaks kui tema enda alamvalik
+  // „Ainult annotatsioonid", nii et annotatsiooni-vasted olid vaikevaates nähtamatud.
+  let attributesToSearchOn: string[] = ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'];
   if (options.scope === 'original') attributesToSearchOn = ['lehekylje_tekst', 'marginaalia_tekst'];
   else if (options.scope === 'annotation') {
     attributesToSearchOn = [tagsField, 'comments.text', 'text_annotations_text'];


### PR DESCRIPTION
Kasutaja tegi tekstiannotatsiooni lehele `/work/q0298s/77` („käsu hans?"), aga `/search?q=käsu` ei leidnud seda.

Annotatsioon **oli** indeksis korrektselt:

```
q0298s-77 → text_annotations_text: "käsu hans?"
            has_annotations: true
```

## Juurpõhjus

Vaikimisi otsinguulatus („Terve dokument") jättis `text_annotations_text` `attributesToSearchOn`-ist välja. Väli lisati ainult siis, kui kasutaja valis käsitsi ulatuseks „Ainult annotatsioonid" — nii et **vaikeulatus oli kitsam kui tema enda alamvalik** ja annotatsiooni-vasted olid vaikevaates nähtamatud.

Reprodutseeritud tootmisindeksil (`q=käsu`):

| ulatus | q0298s/77 leitud? | vasteid |
|---|---|---|
| Terve dokument (enne) | **EI** | 19 |
| Ainult annotatsioonid | JAH | 19 |
| Terve dokument (nüüd) | **JAH** | 20 |

## Muudatus

`text_annotations_text` lisatud mõlemasse vaikeloendisse — `searchContent` ja `searchWorkHits`. Kitsamad ulatused jäävad kitsaks: „Ainult originaaltekst" = `lehekylje_tekst` + `marginaalia_tekst`.

## Kasutuselevõtt

**Reindeksit ei ole vaja** — väli on indeksis juba olemas, muutub ainult see, millistelt väljadelt päring otsib. Piisab frontendi buildist ja rsync'ist.

## Testid

5 uut (`searchScope.test.ts`), sh invariant „vaikeulatus on vähemalt sama lai kui iga kitsam ulatus" — see püüaks sama vea kinni ka mõne muu välja puhul.

vitest **735** ✅ · typecheck ✅ · lint 55 (muutumatu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)