### PR TITLE
Otsing: vaikeulatus näitab annotatsiooni-vastet, mitte vale katkendit

### DIFF
--- a/src/pages/search/SearchResults.tsx
+++ b/src/pages/search/SearchResults.tsx
@@ -185,7 +185,11 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         const rawTags: string[] = isAnnotationBrowse ? ((hit as any)[tagsField] || hit.page_tags || []) : [];
         const showRawTags = isAnnotationBrowse && !hasHighlightedTags && rawTags.length > 0;
         const showRawComments = isAnnotationBrowse && (!highlightedComments || highlightedComments.length === 0);
-        const showTextAnnotations = (scopeParam === 'annotation') && (hit.text_annotations?.length ?? 0) > 0;
+        // Annotatsiooniplokk ka vaikeulatuses, kui vaste TULI annotatsioonist — muidu
+        // näitab kaart lehekülje põhiteksti katkendit, kus vastet ei olegi.
+        const hasHighlightedAnnotations = ((hit._formatted as any)?.text_annotations_text || '').includes('<em');
+        const showTextAnnotations = (scopeParam === 'annotation' || hasHighlightedAnnotations)
+            && (hit.text_annotations?.length ?? 0) > 0;
 
         return (
             <div key={hit.id} className={`p-3 ${isAdditional ? 'bg-gray-50 border-t border-gray-100' : ''}`}>

--- a/src/services/__tests__/searchScope.test.ts
+++ b/src/services/__tests__/searchScope.test.ts
@@ -54,6 +54,29 @@ describe('otsinguulatus „Terve dokument" (vaikimisi)', () => {
   });
 });
 
+// Ilma text_annotations_text-ita `attributesToHighlight`-is ei saa tulemuskaart aru,
+// kas vaste tuli annotatsioonist — ja langeb tagasi lehekülje põhiteksti katkendile,
+// kus vastet ei olegi. Meili tõstab sellel väljal esile: '<em>käsu</em> hans?'.
+describe('annotatsiooni-vaste on kaardi jaoks tuvastatav', () => {
+  const highlightedFields = (): string[] => mockSearch.mock.calls[0][1].attributesToHighlight;
+
+  it('searchContent tõstab esile ka tekstiannotatsioonid', async () => {
+    await searchContent(mockIndex, 'käsu');
+    expect(highlightedFields()).toContain('text_annotations_text');
+  });
+
+  it('searchWorkHits tõstab esile ka tekstiannotatsioonid', async () => {
+    await searchWorkHits(mockIndex, 'käsu', 'work1');
+    expect(highlightedFields()).toContain('text_annotations_text');
+  });
+
+  it('iga otsitav tekstiväli on ka esiletõstetav', async () => {
+    await searchContent(mockIndex, 'käsu');
+    const searched = mockSearch.mock.calls[0][1].attributesToSearchOn;
+    expect(highlightedFields()).toEqual(expect.arrayContaining(searched));
+  });
+});
+
 describe('kitsamad ulatused jäävad kitsaks', () => {
   it('„Ainult originaaltekst" ei otsi annotatsioonidest ega kommentaaridest', async () => {
     await searchContent(mockIndex, 'käsu', 1, { scope: 'original' });

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -636,7 +636,7 @@ export const searchContent = async (index: Index, rawQuery: string, page: number
         facets: ['originaal_kataloog', 'work_id'],
         attributesToRetrieve: ['id', 'work_id', 'lehekylje_number', 'lehekylje_tekst', 'marginaalia_tekst', 'text_content', 'title', 'year', 'year_display', 'originaal_kataloog', 'lehekylje_pilt', 'tags', 'page_tags', 'page_tags_object', tagsField, 'comments', 'text_annotations', 'genre', 'genre_object', 'type', 'type_object', 'creators', 'collections', 'collections_hierarchy'],
         // Ei kasuta croppi - näitame kogu teksti
-        attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text'],
+        attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'],
         highlightPreTag: HIGHLIGHT_PRE_TAG,
         highlightPostTag: HIGHLIGHT_POST_TAG,
         attributesToSearchOn: attributesToSearchOn,
@@ -742,7 +742,7 @@ export const searchContent = async (index: Index, rawQuery: string, page: number
           attributesToRetrieve: ['id', 'work_id', 'lehekylje_number', 'lehekylje_tekst', 'marginaalia_tekst', 'text_content', 'title', 'year', 'year_display', 'originaal_kataloog', 'lehekylje_pilt', 'tags', 'tags_object', 'page_tags', 'page_tags_object', tagsField, 'comments', 'text_annotations', 'genre', 'genre_object', 'type', 'type_object', 'creators', 'collections', 'collections_hierarchy'],
           attributesToCrop: ['lehekylje_tekst', 'comments.text'],
           cropLength: 35,
-          attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text'],
+          attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'],
           highlightPreTag: HIGHLIGHT_PRE_TAG,
           highlightPostTag: HIGHLIGHT_POST_TAG,
           attributesToSearchOn: attributesToSearchOn
@@ -834,7 +834,7 @@ export const searchWorkHits = async (index: Index, rawQuery: string, workId: str
       attributesToRetrieve: ['id', 'work_id', 'lehekylje_number', 'lehekylje_tekst', 'marginaalia_tekst', 'text_content', 'title', 'year', 'year_display', 'originaal_kataloog', 'lehekylje_pilt', 'tags', 'page_tags', 'page_tags_object', tagsField, 'comments', 'text_annotations', 'genre', 'genre_object', 'type', 'type_object', 'creators'],
       attributesToCrop: ['lehekylje_tekst', 'comments.text'],
       cropLength: 35,
-      attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text'],
+      attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'],
       highlightPreTag: HIGHLIGHT_PRE_TAG,
       highlightPostTag: HIGHLIGHT_POST_TAG,
       sort: ['lehekylje_number:asc'],


### PR DESCRIPTION
Järg #230-le. Pärast seda leiab „Terve dokument" annotatsiooni sisu, aga kaart näitas endiselt lehekülje põhiteksti katkendit — sealt, kus vastet ei olegi:

**Enne** (Terve dokument, `q=käsu`):
> Lk 77 | fol: 102 a 103. Arf Lof: vid ordr: dhl Rp. M.n H. Bruun. för de Kostad…

**Ainult annotatsioonid** (juba varem õige):
> Lk 77 | Tekst-annotatsioon (Administraator) — käsu hans?

## Kaks põhjust

1. `text_annotations_text` puudus `attributesToHighlight`-ist → kaart ei saanud aru, kas vaste tuli annotatsioonist
2. `SearchResults.tsx:188` renderdas annotatsiooniploki ainult siis, kui `scope === 'annotation'`

## Parandus

Kasutab **sama ploki**, mis annotatsiooni-ulatuses juba töötab — uut renderdusteed ei lisata. Päästik laieneb: plokk kuvatakse ka vaikeulatuses, kui `_formatted.text_annotations_text` sisaldab `<em>`.

Kontrollitud tootmisindeksil (`q=käsu`, lk `q0298s/77`):

```
_formatted.text_annotations_text : '<em>käsu</em> hans?'
_formatted.lehekylje_tekst       : ühtki <em> ei sisalda
```

**Reindeksit ei ole vaja** — esiletõst on päringuaegne.

## Testid

3 uut, sh invariant „iga otsitav tekstiväli on ka esiletõstetav" — see püüaks sama lahknevuse kinni ka mõne muu välja puhul.

Komponenditeste selles projektis ei ole (vitest jookseb `node`-keskkonnas, jsdom/RTL puudub), seega on kaetud teenusekihi muutus; komponendis on kahe rea muudatus, mis hoiab ümbritsevat inline-stiili.

vitest **738** ✅ · typecheck ✅ · lint 55 (muutumatu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)