### PR TITLE
Otsing: tõsta annotatsiooni vaste esile, nagu lehekommentaaridel

### DIFF
--- a/src/pages/search/SearchResults.tsx
+++ b/src/pages/search/SearchResults.tsx
@@ -185,9 +185,14 @@ const SearchResults: React.FC<SearchResultsProps> = ({
         const rawTags: string[] = isAnnotationBrowse ? ((hit as any)[tagsField] || hit.page_tags || []) : [];
         const showRawTags = isAnnotationBrowse && !hasHighlightedTags && rawTags.length > 0;
         const showRawComments = isAnnotationBrowse && (!highlightedComments || highlightedComments.length === 0);
-        // Annotatsiooniplokk ka vaikeulatuses, kui vaste TULI annotatsioonist — muidu
-        // näitab kaart lehekülje põhiteksti katkendit, kus vastet ei olegi.
-        const hasHighlightedAnnotations = ((hit._formatted as any)?.text_annotations_text || '').includes('<em');
+        // Annotatsioonid käituvad nagu kommentaarid: Meili tõstab `text_annotations[].comment`
+        // esile ka ilma seda otsitavaks tegemata, nii et iga plokk saab oma märgistuse.
+        // Annotatsiooni-ulatuses näidatakse kõiki lehe annotatsioone (nagu varem);
+        // mujal ainult siis, kui vaste TULI annotatsioonist — muidu näitaks kaart
+        // lehekülje põhiteksti katkendit, kus vastet ei olegi.
+        const highlightedAnnotations = (hit._formatted as any)?.text_annotations
+            ?.filter((ann: any) => (ann.comment || '').includes('<em'));
+        const hasHighlightedAnnotations = (highlightedAnnotations?.length ?? 0) > 0;
         const showTextAnnotations = (scopeParam === 'annotation' || hasHighlightedAnnotations)
             && (hit.text_annotations?.length ?? 0) > 0;
 
@@ -260,13 +265,16 @@ const SearchResults: React.FC<SearchResultsProps> = ({
                         )}
                         {showTextAnnotations && (
                             <div className="space-y-2 mt-2">
-                                {hit.text_annotations!.map((ann, idx) => (
+                                {(hasHighlightedAnnotations ? highlightedAnnotations : hit.text_annotations!).map((ann: any, idx: number) => (
                                     <div key={idx} className="bg-amber-50 border border-amber-200 rounded p-2 text-xs text-gray-800">
                                         <div className="flex items-center gap-1 mb-1 font-bold text-amber-800">
                                             <SquarePen size={12} />
                                             <span>{t('results.textAnnotation', { author: ann.author })}</span>
                                         </div>
-                                        <div>{ann.comment}</div>
+                                        {hasHighlightedAnnotations
+                                            ? <SafeHtml kind="highlight" html={ann.comment} />
+                                            : <div>{ann.comment}</div>
+                                        }
                                     </div>
                                 ))}
                             </div>

--- a/src/services/__tests__/searchScope.test.ts
+++ b/src/services/__tests__/searchScope.test.ts
@@ -70,6 +70,14 @@ describe('annotatsiooni-vaste on kaardi jaoks tuvastatav', () => {
     expect(highlightedFields()).toContain('text_annotations_text');
   });
 
+  it('annotatsioonid on esiletõstetavad plokikaupa, nagu kommentaarid', async () => {
+    // Meili tõstab `text_annotations[].comment` esile ka ilma seda otsitavaks
+    // tegemata — nii saab kaart iga annotatsiooni eraldi märgistada
+    // (`comments.text` mustriga ühtlane), ilma indeksi seadeid muutmata.
+    await searchContent(mockIndex, 'käsu');
+    expect(highlightedFields()).toContain('text_annotations');
+  });
+
   it('iga otsitav tekstiväli on ka esiletõstetav', async () => {
     await searchContent(mockIndex, 'käsu');
     const searched = mockSearch.mock.calls[0][1].attributesToSearchOn;

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -636,7 +636,7 @@ export const searchContent = async (index: Index, rawQuery: string, page: number
         facets: ['originaal_kataloog', 'work_id'],
         attributesToRetrieve: ['id', 'work_id', 'lehekylje_number', 'lehekylje_tekst', 'marginaalia_tekst', 'text_content', 'title', 'year', 'year_display', 'originaal_kataloog', 'lehekylje_pilt', 'tags', 'page_tags', 'page_tags_object', tagsField, 'comments', 'text_annotations', 'genre', 'genre_object', 'type', 'type_object', 'creators', 'collections', 'collections_hierarchy'],
         // Ei kasuta croppi - näitame kogu teksti
-        attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'],
+        attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text', 'text_annotations'],
         highlightPreTag: HIGHLIGHT_PRE_TAG,
         highlightPostTag: HIGHLIGHT_POST_TAG,
         attributesToSearchOn: attributesToSearchOn,
@@ -742,7 +742,7 @@ export const searchContent = async (index: Index, rawQuery: string, page: number
           attributesToRetrieve: ['id', 'work_id', 'lehekylje_number', 'lehekylje_tekst', 'marginaalia_tekst', 'text_content', 'title', 'year', 'year_display', 'originaal_kataloog', 'lehekylje_pilt', 'tags', 'tags_object', 'page_tags', 'page_tags_object', tagsField, 'comments', 'text_annotations', 'genre', 'genre_object', 'type', 'type_object', 'creators', 'collections', 'collections_hierarchy'],
           attributesToCrop: ['lehekylje_tekst', 'comments.text'],
           cropLength: 35,
-          attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'],
+          attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text', 'text_annotations'],
           highlightPreTag: HIGHLIGHT_PRE_TAG,
           highlightPostTag: HIGHLIGHT_POST_TAG,
           attributesToSearchOn: attributesToSearchOn
@@ -834,7 +834,7 @@ export const searchWorkHits = async (index: Index, rawQuery: string, workId: str
       attributesToRetrieve: ['id', 'work_id', 'lehekylje_number', 'lehekylje_tekst', 'marginaalia_tekst', 'text_content', 'title', 'year', 'year_display', 'originaal_kataloog', 'lehekylje_pilt', 'tags', 'page_tags', 'page_tags_object', tagsField, 'comments', 'text_annotations', 'genre', 'genre_object', 'type', 'type_object', 'creators'],
       attributesToCrop: ['lehekylje_tekst', 'comments.text'],
       cropLength: 35,
-      attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text'],
+      attributesToHighlight: ['lehekylje_tekst', 'marginaalia_tekst', tagsField, 'comments.text', 'text_annotations_text', 'text_annotations'],
       highlightPreTag: HIGHLIGHT_PRE_TAG,
       highlightPostTag: HIGHLIGHT_POST_TAG,
       sort: ['lehekylje_number:asc'],


### PR DESCRIPTION
Järg #231-le. Annotatsiooniplokk kuvati märgistamata toortekstina, kommentaarid aga kandsid `<em>`-esiletõstu. Nüüd sama muster mõlemal.

## Ilma indeksi muutmiseta

Meilisearch tõstab `text_annotations[].comment` esile ka siis, kui see väli ise **ei ole** otsitav — piisab selle lisamisest `attributesToHighlight`-i. Kontrollitud tootmisindeksil (`q=käsu`, lk `q0298s/77`, rakenduse päris highlight-tägidega):

```
_formatted.text_annotations[0]
  author  : Administraator
  comment : <em class="bg-yellow-200 font-bold not-italic">käsu</em> hans?
```

Seega **ei ole vaja** `searchableAttributes`-i muuta ega reindeksit teha.

## Muster on kommentaaridega ühtlane

- kaart filtreerib `<em`-i järgi täpselt nagu `highlightedComments`, ja näitab siis ainult tegelikult vastanud annotatsioone
- kui esiletõstu ei ole (annotatsiooni-ulatus tühja päringuga), langeb tagasi toortekstile — sama `showRawComments` loogika
- `SafeHtml kind="highlight"` allowlist katab need tägid juba (escape kõik, taasta ainult `HIGHLIGHT_PRE_TAG`/`POST_TAG`), nii et uut renderdusteed ei lisata

## Testid

1 uus. vitest **739** ✅ · typecheck ✅ · lint 55 (muutumatu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)