### PR TITLE
OCR-i loopide tuvastus + klikitav HTML-raport (#227)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ loss/state/prosopography/
 
 # Suured skännid reference_data-s ei kuulu reposse (txt/csv kuuluvad)
 reference_data/*.jpg
+
+# Skriptide väljundid (consolidate jsonl, OCR-loopide raport) — tuletatavad
+output/

--- a/scripts/find_ocr_loops.py
+++ b/scripts/find_ocr_loops.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Leiab OCR-i lagunemised (loobid) ja teeb klikitava HTML-raporti (#227).
+
+EI muuda ühtegi faili — ainult loeb korpuse läbi ja kirjutab raporti.
+
+Kasutus serveris (andmed elavad seal):
+  cd ~/VUTT && .venv/bin/python3 scripts/find_ocr_loops.py
+  cd ~/VUTT && .venv/bin/python3 scripts/find_ocr_loops.py --min-reps 20
+
+Raport avaneb brauseris: iga rida on link lehele, mille saab ükshaaval üle
+käia. Linnukesed püsivad `localStorage`-is, nii et poolelijäänud läbivaatust
+saab hiljem jätkata.
+
+NB: re-OCR ei ole siin üldiselt lahendus — sama viga kordub, sest materjal
+(vilets käekiri, halb skann) on mudelile raskesti loetav. Raport on triaaži-
+nimekiri käsitsi läbivaatuseks.
+
+Andmejuur tuleb ``VUTT_DATA_DIR`` muutujast (Dockeris ``/data``).
+"""
+import argparse
+import html
+import json
+import os
+import sys
+import types
+from collections import defaultdict
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if "server" not in sys.modules:
+    _server_pkg = types.ModuleType("server")
+    _server_pkg.__path__ = [os.path.join(_PROJECT_ROOT, "server")]
+    _server_pkg.__package__ = "server"
+    sys.modules.setdefault("server", _server_pkg)
+sys.path.insert(0, _PROJECT_ROOT)
+
+from server.meili_doc import enumerate_page_images          # noqa: E402
+from server.ocr_loop_audit import find_repeat_loop          # noqa: E402
+
+DATA_ROOT = os.getenv("VUTT_DATA_DIR", os.path.join(_PROJECT_ROOT, "data"))
+DEFAULT_BASE_URL = "https://vutt.utlib.ut.ee"
+
+# Pikkuse-vihje: loopinud lehe mediaan on 1364 tokenit, puhta oma 281.
+# Laeni jookseb ainult pool loopidest, seega see on KINDLUSE VIHJE, mitte kriteerium.
+CAP_HINT_TOKENS = 1300
+
+
+def scan(data_root, min_reps, max_period):
+    """Käib korpuse läbi. Tagastab {work_key: (meta, [leiud])}."""
+    works = {}
+    for entry in sorted(os.listdir(data_root)):
+        work_dir = os.path.join(data_root, entry)
+        if not os.path.isdir(work_dir) or entry in (".git", "config"):
+            continue
+        meta_path = os.path.join(work_dir, "_metadata.json")
+        if not os.path.exists(meta_path):
+            continue
+        try:
+            with open(meta_path, encoding="utf-8") as fh:
+                meta = json.load(fh)
+        except Exception:
+            continue
+        work_id = meta.get("id")
+        if not work_id:
+            continue
+
+        hits = []
+        # Sama numeratsioon, mida kasutavad indekseerija ja bot-prerender —
+        # nii ei saa raporti lingid lehenumbritest lahku minna.
+        for page_index, img_name in enumerate(enumerate_page_images(work_dir)):
+            txt_path = os.path.join(work_dir, os.path.splitext(img_name)[0] + ".txt")
+            if not os.path.exists(txt_path):
+                continue
+            try:
+                with open(txt_path, encoding="utf-8") as fh:
+                    text = fh.read()
+            except Exception:
+                continue
+            loop = find_repeat_loop(text, min_reps=min_reps, max_period=max_period)
+            if loop:
+                loop["page"] = page_index + 1
+                hits.append(loop)
+
+        if hits:
+            works[entry] = ({
+                "work_id": work_id,
+                "title": meta.get("title") or entry,
+                "year": meta.get("year") or "",
+            }, hits)
+    return works
+
+
+def render_html(works, base_url, min_reps, total_pages_scanned):
+    e = html.escape
+    total_hits = sum(len(h) for _, h in works.values())
+    ordered = sorted(works.items(), key=lambda kv: -len(kv[1][1]))
+
+    rows = []
+    for _, (meta, hits) in ordered:
+        rows.append(
+            f'<section><h2>{e(str(meta["title"]))}'
+            f'<span class="meta">{e(str(meta["year"]))} · {e(meta["work_id"])} · '
+            f'{len(hits)} lehte</span></h2><table>'
+        )
+        for h in sorted(hits, key=lambda x: x["page"]):
+            url = f'{base_url}/work/{meta["work_id"]}/{h["page"]}'
+            cap = ' <span class="cap">laeni</span>' if h["tokens"] >= CAP_HINT_TOKENS else ""
+            pattern = h["pattern"]
+            if len(pattern) > 60:
+                pattern = pattern[:60] + "…"
+            rows.append(
+                f'<tr data-key="{e(url)}">'
+                f'<td class="c"><input type="checkbox"></td>'
+                f'<td><a href="{e(url)}" target="_blank" rel="noopener">lk {h["page"]}</a></td>'
+                f'<td class="n">{h["reps"]}×</td>'
+                f'<td class="n">per {h["period"]}</td>'
+                f'<td class="n">{h["tokens"]} tok{cap}</td>'
+                f'<td class="n">{round(h["cover"] * 100)}%</td>'
+                f'<td class="p">{e(pattern)}</td>'
+                f'</tr>'
+            )
+        rows.append("</table></section>")
+
+    return f"""<!doctype html>
+<html lang="et"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OCR-i loobid — {total_hits} lehte</title>
+<style>
+ :root {{ color-scheme: light dark; }}
+ body {{ font: 15px/1.5 system-ui, sans-serif; margin: 0 auto; padding: 1.5rem;
+        max-width: 60rem; background: #fbfbfa; color: #1a1a1a; }}
+ h1 {{ font-size: 1.4rem; margin: 0 0 .3rem; }}
+ .lead {{ color: #666; margin: 0 0 1.5rem; }}
+ .bar {{ position: sticky; top: 0; background: #fbfbfa; padding: .6rem 0;
+        border-bottom: 1px solid #ddd; margin-bottom: 1rem; font-weight: 600; }}
+ h2 {{ font-size: 1rem; margin: 1.6rem 0 .4rem; }}
+ .meta {{ font-weight: 400; color: #777; margin-left: .6rem; font-size: .85rem; }}
+ table {{ border-collapse: collapse; width: 100%; }}
+ td {{ padding: .25rem .5rem; border-bottom: 1px solid #eee; vertical-align: top; }}
+ .c {{ width: 1.6rem; }}
+ .n {{ color: #555; font-variant-numeric: tabular-nums; white-space: nowrap;
+       font-size: .85rem; }}
+ .p {{ font-family: ui-monospace, monospace; font-size: .8rem; color: #444;
+       word-break: break-all; }}
+ .cap {{ background: #fde68a; padding: 0 .3rem; border-radius: 3px; font-size: .75rem; }}
+ tr.done {{ opacity: .38; }}
+ tr.done a {{ text-decoration: line-through; }}
+ a {{ color: #1d4ed8; }}
+ @media (prefers-color-scheme: dark) {{
+   body {{ background: #16161a; color: #e8e8ea; }}
+   .bar {{ background: #16161a; border-color: #333; }}
+   td {{ border-color: #2a2a30; }}
+   .lead, .meta, .n, .p {{ color: #9a9aa2; }}
+   .cap {{ background: #78350f; color: #fde68a; }}
+   a {{ color: #93b4ff; }}
+ }}
+</style></head><body>
+<h1>OCR-i loobid</h1>
+<p class="lead">{total_hits} lehte {len(works)} teoses · läbi vaadatud {total_pages_scanned} lehekülge ·
+lävi: sama muster kordub järjest ≥{min_reps} korda.
+„laeni" = leht on ≥{CAP_HINT_TOKENS} tokenit, mis viitab sellele, et mudel kordas kuni väljundilaeni.</p>
+<div class="bar"><span id="progress"></span></div>
+{"".join(rows)}
+<script>
+ const KEY = 'vutt_ocr_loops_done';
+ const done = new Set(JSON.parse(localStorage.getItem(KEY) || '[]'));
+ const rows = [...document.querySelectorAll('tr[data-key]')];
+ const save = () => localStorage.setItem(KEY, JSON.stringify([...done]));
+ const paint = () => {{
+   document.getElementById('progress').textContent =
+     `${{done.size}} / ${{rows.length}} üle vaadatud`;
+ }};
+ for (const tr of rows) {{
+   const box = tr.querySelector('input');
+   const k = tr.dataset.key;
+   if (done.has(k)) {{ box.checked = true; tr.classList.add('done'); }}
+   box.addEventListener('change', () => {{
+     box.checked ? done.add(k) : done.delete(k);
+     tr.classList.toggle('done', box.checked);
+     save(); paint();
+   }});
+ }}
+ paint();
+</script>
+</body></html>"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--min-reps", type=int, default=10,
+                    help="mitu korda peab muster järjest korduma (vaikimisi 10)")
+    ap.add_argument("--max-period", type=int, default=5,
+                    help="pikim otsitav mustri periood tokenites (vaikimisi 5)")
+    ap.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    ap.add_argument("--out", default=os.path.join(_PROJECT_ROOT, "output", "ocr_loops.html"))
+    args = ap.parse_args()
+
+    print(f"Loen korpust: {DATA_ROOT}")
+    works = scan(DATA_ROOT, args.min_reps, args.max_period)
+    total_hits = sum(len(h) for _, h in works.values())
+
+    scanned = 0
+    for entry in os.listdir(DATA_ROOT):
+        d = os.path.join(DATA_ROOT, entry)
+        if os.path.isdir(d) and entry not in (".git", "config"):
+            scanned += len(enumerate_page_images(d))
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write(render_html(works, args.base_url.rstrip("/"), args.min_reps, scanned))
+
+    print(f"\nLeitud {total_hits} lehte {len(works)} teoses (vaadatud {scanned} lehekülge).")
+    for _, (meta, hits) in sorted(works.items(), key=lambda kv: -len(kv[1][1]))[:10]:
+        print(f"  {len(hits):4} lk  {meta['work_id']}  {str(meta['title'])[:60]}")
+    print(f"\nRaport: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/ocr_loop_audit.py
+++ b/server/ocr_loop_audit.py
@@ -1,0 +1,81 @@
+"""OCR-i lagunemise (loop) tuvastus — puhas, side-effect-vaba loogika (#227).
+
+Mudel satub mõnikord kordusesse ja täidab lehekülje sama mustriga
+(„. S. S. S. …" või „Propoſit. XII. Propoſit. XII. …"). Selline tekst läheb
+`lehekylje_tekst`-ina Meilisse ja bot-prerenderis Google'ile, kes loeb korduva
+tokeni müüri gibberish'iks.
+
+MÕÕDIKU VALIK (mõõdetud tootmiskorpusel 2026-08-09, 21 747 lehte >=50 tokenit):
+
+  pikim järjestikune sama token   p95 = 2      p99,5 = 959
+  korduva mustri kate leheküljest p95 = 0,015  p99,5 = 0,95
+
+Kaks selgelt eraldi populatsiooni — läviväärtuse täpne koht on peaaegu
+tähtsusetu (`reps >= 10` annab 273 lehte, `>= 50` annab 264).
+
+Detektor on ABSOLUUTNE korduste arv, MITTE katte-osakaal:
+- katte-reegel andis alla 50 tokeni lehtedel 240 valepositiivi (4-tokeniline
+  lehekülg on „100% kate"), korduste-reegel ainult ühe;
+- korduste-reegel on katte-reegli range ülemhulk (263 ühist, 10 ainult
+  korduste omaga, 0 ainult kattega) — ei vaja minimaalse pikkuse piirangut.
+
+Periood 2–5 on kohustuslik: 94 juhtu 250-st on „A B A B" tüüpi, mida ühe
+tokeni loendur ei näeks.
+
+Lehekülje PIKKUS on kinnitav signaal, mitte kriteerium: loopinud lehe mediaan
+on 1364 tokenit, puhta oma 281 — aga laeni jookseb ainult pool loopidest
+(139/273) ja 55 puhast lehte on üle 1300 tokeni. Raport kuvab pikkuse
+kindluse-vihjena, detektor seda ei kasuta.
+"""
+from .meili_doc import clean_text_for_search
+
+
+def _longest_cycle(toks, max_period):
+    """Pikim JÄRJESTIKUNE korduv n-gramm. Tagastab (periood, korduste arv, algus)."""
+    best = (0, 0, 0)
+    n = len(toks)
+    for period in range(1, max_period + 1):
+        i = 0
+        while i + period <= n:
+            reps = 1
+            j = i + period
+            while j + period <= n and toks[j:j + period] == toks[i:i + period]:
+                reps += 1
+                j += period
+            if reps > best[1]:
+                best = (period, reps, i)
+            # Kordunud plokist saab otse üle hüpata; muidu edasi ühe võrra.
+            i = j - period if reps > 1 else i + 1
+    return best
+
+
+def find_repeat_loop(text, min_reps=10, max_period=5):
+    """Otsib lehekülje tekstist korduse-loopi.
+
+    Tagastab ``None``, kui loopi ei ole, muidu::
+
+        {'period': 2, 'reps': 25, 'tokens': 50, 'cover': 1.0,
+         'pattern': 'Propoſit. XII.'}
+
+    ``cover`` on korduse osakaal leheküljest (raportis kuvamiseks, mitte
+    kriteeriumiks). Tekst puhastatakse ``clean_text_for_search``-iga, nii et
+    VUTT-i märgendus ja reavahetuse poolitused ei tekitaks võltskordusi —
+    sama teisendus, mis läheb otsinguindeksisse.
+    """
+    if not text:
+        return None
+    toks = clean_text_for_search(text).split()
+    if not toks:
+        return None
+
+    period, reps, start = _longest_cycle(toks, max_period)
+    if reps < min_reps:
+        return None
+
+    return {
+        "period": period,
+        "reps": reps,
+        "tokens": len(toks),
+        "cover": period * reps / len(toks),
+        "pattern": " ".join(toks[start:start + period]),
+    }

--- a/tests/test_ocr_loop_audit.py
+++ b/tests/test_ocr_loop_audit.py
@@ -1,0 +1,98 @@
+# tests/test_ocr_loop_audit.py
+"""OCR-i lagunemise (loop) tuvastus — #227.
+
+Mõõdetud korpusel 2026-08-09 (21 747 lehte >=50 tokenit):
+  pikim järjestikune sama token: p95 = 2, p99,5 = 959
+  → kaks selgelt eraldi populatsiooni, vahepealset ala peaaegu ei ole.
+
+Detektor on ABSOLUUTNE korduste arv, mitte katte-osakaal: katte-reegel andis
+lühikestel lehtedel 240 valepositiivi (4-tokeniline lehekülg = "100% kate"),
+korduste-reegel ainult ühe. Periood 2–5 on kohustuslik — 94 juhtu 250-st on
+'A B A B' tüüpi, mida ühe tokeni loendur ei näeks.
+"""
+import pytest
+
+from server.ocr_loop_audit import find_repeat_loop
+
+
+class TestPuhasTekst:
+    def test_tavaline_ladina_tekst_ei_ole_loop(self):
+        text = ("De philosophia Romanorum commentatus est Carolus Kühlstaedt. "
+                "Populus Romanus inde a prima origine bellis cum exteris gentibus "
+                "gerundis unice fere deditus regnique sui latius extendendi cupiditate")
+        assert find_repeat_loop(text) is None
+
+    def test_tyhi_tekst(self):
+        assert find_repeat_loop("") is None
+        assert find_repeat_loop(None) is None
+
+    def test_luhike_leht_ei_ole_loop(self):
+        """4-tokeniline lehekülg annab 100% katte, aga kordusi on kaks — mitte loop."""
+        assert find_repeat_loop("Ad lectorem Ad lectorem") is None
+
+    def test_paar_kordust_alla_lave(self):
+        assert find_repeat_loop("S. " * 9) is None
+
+
+class TestLoop:
+    def test_yhe_tokeni_kordus(self):
+        loop = find_repeat_loop("Praefatio " + "S. " * 40)
+        assert loop is not None
+        assert loop["period"] == 1
+        assert loop["reps"] == 40
+        assert loop["pattern"] == "S."
+
+    def test_kahe_tokeni_vaheldumine(self):
+        """'A B A B …' — ühe tokeni loendur ei näeks siin midagi."""
+        loop = find_repeat_loop("Propoſit. XII. " * 25)
+        assert loop is not None
+        assert loop["period"] == 2
+        assert loop["reps"] == 25
+        assert loop["pattern"] == "Propoſit. XII."
+
+    def test_nelja_tokeni_muster(self):
+        loop = find_repeat_loop("a b c d " * 15)
+        assert loop is not None
+        assert loop["period"] == 4
+        assert loop["reps"] == 15
+
+    def test_osaline_loop_pika_lehe_lopus(self):
+        """Mudel kordas alles lehe lõpus — kate on väike, aga kordusi palju."""
+        text = " ".join(f"sona{i}" for i in range(400)) + " " + "S. " * 30
+        loop = find_repeat_loop(text)
+        assert loop is not None
+        assert loop["reps"] == 30
+        assert loop["cover"] < 0.2      # kate madal — katte-reegel jätaks vahele
+
+    def test_tokenite_arv_ja_kate(self):
+        loop = find_repeat_loop("S. " * 50)
+        assert loop["tokens"] == 50
+        assert loop["cover"] == pytest.approx(1.0)
+
+
+class TestMargendus:
+    def test_vutt_tagid_ei_loe_kordusteks(self):
+        """<i>…</i> paarid ei tohi ise korduseks muutuda."""
+        text = " ".join(f"<i>sona{i}</i>" for i in range(60))
+        assert find_repeat_loop(text) is None
+
+    def test_marginaalia_sees_olev_loop_leitakse(self):
+        assert find_repeat_loop("tekst <m>" + "S. " * 30 + "</m>") is not None
+
+    def test_reavahetuse_poolitus_liidetakse_enne_lugemist(self):
+        """gro⸗\\nße → grosse; poolitus ei tohi tekitada võltskordust."""
+        text = "gro⸗\nsse " * 20
+        loop = find_repeat_loop(text)
+        assert loop is not None
+        assert loop["pattern"] == "grosse"
+
+
+class TestLavi:
+    def test_min_reps_on_seadistatav(self):
+        assert find_repeat_loop("S. " * 5, min_reps=3) is not None
+        assert find_repeat_loop("S. " * 5, min_reps=20) is None
+
+    def test_maksimaalne_periood_piirab(self):
+        text = "a b c d e f g " * 12          # periood 7
+        assert find_repeat_loop(text, max_period=5) is None
+        assert find_repeat_loop(text, max_period=7) is not None


### PR DESCRIPTION
Sulgeb #227 esimese osa (partiiskript). Jooksev automaatika jäeti teadlikult välja.

## Mõõtmine enne disaini

Tootmiskorpusel (21 747 lehte ≥50 tokenit) on kaks selgelt eraldi populatsiooni:

| mõõdik | p95 (normaalne) | p99,5 (loopinud) |
|---|---|---|
| pikim järjestikune sama token | 2 | **959** |
| korduva mustri kate leheküljest | 0,015 | **0,95** |

Läviväärtuse täpne koht on peaaegu tähtsusetu: `reps ≥ 10` → 273 lehte, `≥ 50` → 264. Issue's kirjeldatud kalibreerimise mure osutus alusetuks.

## Detektor: absoluutne korduste arv, mitte kate

- katte-reegel andis alla 50 tokeni lehtedel **240 valepositiivi** (4-tokeniline lehekülg on „100% kate"), korduste-reegel ainult ühe
- korduste-reegel on katte-reegli **range ülemhulk** (263 ühist, 10 ainult korduste omaga, **0** ainult kattega) → pikkuse-alampiiri pole vaja
- **periood 2–5 on kohustuslik**: 94 juhtu 250-st on `A B A B` tüüpi, mida ühe tokeni loendur ei näeks

Üks parameeter (`--min-reps`), mitte kaks.

## Pikkus on vihje, mitte kriteerium

Loopinud lehe mediaan on **1364** tokenit, puhta oma **281**. Aga laeni jookseb ainult pool loopidest (139/273), ja 55 puhast lehte on üle 1300 tokeni (pikim puhas 2615, pikim loopinud 3952). Raport kuvab „laeni" märke kindluse vihjena; detektor pikkust ei kasuta.

## Tulemus

**274 lehte 76 teoses**, 22 877 vaadatud leheküljest. Tugevalt koondunud — 10 teost katavad üle 160 lehe.

12 juhuslikku raporti linki kontrollitud Meili `text_content` vastu: kõik osutasid päris lagunenud lehele (nt `jri38n/141` → `Tentori.` × 750 / 750 tokenit), valepositiive valimis ei olnud.

## Struktuur

Järgib `marginalia_audit` mustrit — puhas loogika `server/ocr_loop_audit.py`, õhuke skript `scripts/find_ocr_loops.py`. Lehenumeratsioon tuleb `enumerate_page_images`-ist, sama funktsioon mida kasutavad indekseerija ja bot-prerender, nii ei saa raporti lingid lehenumbritest lahku minna.

## Raport

Klikitav HTML: teoste kaupa, enim mõjutatud eespool, iga rida link lehele + `reps×` + periood + tokenid + kordunud muster. Linnukesed püsivad `localStorage`-is, et poolelijäänud läbivaatust saaks jätkata.

**See on triaaži-nimekiri käsitsi läbivaatuseks, mitte re-OCR-i töönimekiri** — sama viga kordub, sest materjal (vilets käekiri, halb skann) on mudelile raskesti loetav.

Skript ei muuda ühtegi faili. `output/` lisatud `.gitignore`-i.

## Testid

14 uut (`tests/test_ocr_loop_audit.py`). pytest **1245** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)